### PR TITLE
Do not deploy docs on doc CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,11 +29,3 @@ jobs:
           name: Documentation
           path: doc/_build/html
           retention-days: 7
-
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@3.7.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: doc/_build/html
-          CLEAN: true


### PR DESCRIPTION
Currently running into merge issues with our documentation CI due to pushing the docs on commit.  This PR removes that step of the CI.