### PR TITLE
Use virtual env

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,8 @@
 trigger:
   branches:
     include:
-    - '*'
+    - releases/*
+    - master
     exclude:
     - 'gh-pages'
   tags:


### PR DESCRIPTION
Abandoning #166.  Note for @maxcapodi78:
- Getting this running on public CI turned out to be a two week nightmare.  AEDT can be "minimized" to be installed on public CI, but stability is an issue as there were a handful of tests that failed.  Had the same issue on a different Windows 10 machine.
- Ran into a variety of issues running on a self-hosted machine on Azure.  Strangely enough, builds failed when cloning the machine using a snapshot and VM creation.

This PR activates the virtual environment using powershell steps in the CI.  For whatever reason, it refuses to activate when using command prompt.
