### PR TITLE
Fix Jupyter Notebook toolkit launcher on Linux; Allow for strange characters in paths for toolkits on Linux

### DIFF
--- a/pyaedt/misc/Console.py_build
+++ b/pyaedt/misc/Console.py_build
@@ -51,12 +51,13 @@ def main():
         command = [
             term,
             "-e",
-            "{}".format(python_exe),
+            python_exe,
             "-i",
-            "{}".format(pyaedt_script),
+            pyaedt_script,
             str(oDesktop.GetProcessID()),
             str(oDesktop.GetVersion()[:6]),
         ]
+        subprocess.Popen(command)
     else:
         command = [
             '"{}"'.format(python_exe),
@@ -65,7 +66,7 @@ def main():
             str(oDesktop.GetProcessID()),
             str(oDesktop.GetVersion()[:6]),
         ]
-    subprocess.Popen(" ".join(command))
+        subprocess.Popen(" ".join(command))
 
 
 def get_linux_terminal():

--- a/pyaedt/misc/Jupyter.py_build
+++ b/pyaedt/misc/Jupyter.py_build
@@ -45,11 +45,22 @@ def main():
                 )
                 t.write(line)
     if is_linux:
-        command = ["{}".format(jupyter_exe), "lab", "{}".format(target)]
+        edt_root = os.path.normpath(oDesktop.GetExeDir())
+        os.environ["ANSYSEM_ROOT{}".format(version)] = edt_root
+        ld_library_path_dirs_to_add = [
+            "{}/commonfiles/CPython/3_7/linx64/Release/python/lib".format(edt_root),
+            "{}/commonfiles/CPython/3_10/linx64/Release/python/lib".format(edt_root),
+            "{}/common/mono/Linux64/lib64".format(edt_root),
+            "{}/Delcross".format(edt_root),
+            "{}".format(edt_root),
+        ]
+        os.environ["LD_LIBRARY_PATH"] = ":".join(ld_library_path_dirs_to_add) + ":" + os.getenv("LD_LIBRARY_PATH", "")
+
+        command = [jupyter_exe, "lab", target]
+        subprocess.Popen(command)
     else:
         command = ['"{}"'.format(jupyter_exe), "lab", '"{}"'.format(target)]
-
-    subprocess.Popen(" ".join(command))
+        subprocess.Popen(" ".join(command))
 
 
 def generate_unique_name(rootname, suffix="", n=6):


### PR DESCRIPTION
Fix Jupyter Notebook toolkit launcher on Linux; Allow for strange characters in paths for toolkits on Linux