### PR TITLE
fixed existing points not enumerating

### DIFF
--- a/pyaedt/modeler/cad/Primitives.py
+++ b/pyaedt/modeler/cad/Primitives.py
@@ -1461,7 +1461,7 @@ class Primitives(object):
         for obj_name in self.point_names:
             if obj_name not in self.points.keys():
                 self._create_object(obj_name)
-                added_objects.append(obj_name)                
+                added_objects.append(obj_name)
         return added_objects
 
     @pyaedt_function_handler()


### PR DESCRIPTION
It looks like app.modeler.planes will also not enumerate to a native object. It appears to return a dict of {name:comobject} and should really create a pyaedt Plane object also.