### PR TITLE
Add a new method install_with_pip in generic.general_methods

### DIFF
--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -1583,7 +1583,7 @@ def install_with_pip(package_name, package_path=None, upgrade=False, uninstall=F
     package_name : str
         Name of the package to install.
     package_path : str, optional
-        Package path for GitHub download. Example ``git+https://......``.
+        Path for the GitHub package to download and install. For example, ``git+https://.....``.
     upgrade : bool, optional
         Whether to upgrade the package. The default is ``False``.
     uninstall : bool, optional


### PR DESCRIPTION
The methods is useful when pyaedt is used from AEDT console