### PR TITLE
fix issue 3007 (get_messages failing with 3dcomp)

### DIFF
--- a/_unittest/test_06_MessageManager.py
+++ b/_unittest/test_06_MessageManager.py
@@ -4,6 +4,7 @@ import logging
 from _unittest.conftest import BasisTest
 from _unittest.conftest import config
 
+from pyaedt import Icepak
 from pyaedt import settings
 from pyaedt.aedt_logger import AedtLogger
 
@@ -49,6 +50,17 @@ class TestClass(BasisTest, object):
         assert len(msg.messages.global_level) >= 1
         assert len(msg.messages.project_level) >= 1
         assert len(msg.messages.design_level) >= 1
+        ipk_app = BasisTest.add_app(self, application=Icepak)
+        box = ipk_app.modeler.create_box([0, 0, 0], [1, 1, 1])
+        ipk_app.modeler.create_3dcomponent("test.a3dcomp")
+        box.delete()
+        cmp = ipk_app.modeler.insert_3d_component("test.a3dcomp")
+        ipk_app_comp = cmp.edit_definition()
+        msg_comp = ipk_app_comp.logger
+        msg_comp.add_info_message("3dcomp, Test Info design level")
+        msg_comp.add_info_message("3dcomp, Test Info project level", "Project")
+        assert len(msg_comp.messages.project_level) >= 1
+        assert len(msg_comp.messages.design_level) >= 1
         settings.enable_desktop_logs = False
 
     @pytest.mark.skipif(config["NonGraphical"], reason="Messages not functional in non-graphical mode")

--- a/pyaedt/aedt_logger.py
+++ b/pyaedt/aedt_logger.py
@@ -317,6 +317,10 @@ class AedtLogger(object):
         design_name = design_name or self._design_name
         if self._log_on_desktop or aedt_messages:
             global_message_data = self._desktop.GetMessages("", "", level)
+            # if a 3d component is open, GetMessages without the project name argument returns messages with
+            # "(3D Component)" appended to project name
+            if not any(msg in global_message_data for msg in self._desktop.GetMessages(project_name, "", 0)):
+                project_name = project_name + " (3D Component)"
             return MessageList(global_message_data, project_name, design_name)
         return MessageList([], project_name, design_name)
 


### PR DESCRIPTION
Fix get_messages failing to get messages from projects stemming from the editing of 3d components. This happens because if a 3d component is open, oDesktop.GetMessages without the project name argument returns messages with "(3D Component)" appended to the project name.
