### PR TITLE
Improved docstring for block bc assignment functions

### DIFF
--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -768,7 +768,7 @@ class Icepak(FieldAnalysis3D):
         >>> block.props["Nodes"]["Internal"][0]
         '2W'
         """
-        warnings.warn("This method is deprecated in 0.6.27. Use create_two_resistor_network_block", DeprecationWarning)
+        warnings.warn("This method is deprecated in 0.6.27. Use the create_two_resistor_network_block() method.", DeprecationWarning)
         if object_name in self.modeler.object_names:
             if gravity_dir > 2:
                 gravity_dir = gravity_dir - 3

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -3848,7 +3848,7 @@ class Icepak(FieldAnalysis3D):
             )
             return None
         if ext_temperature != "AmbientTemp" and ext_temperature is not None and not htc:
-            self.logger.add_error_message("Set an argument for ``htc`` or remove ``ext_temperature`` argument.")
+            self.logger.add_error_message("Set an argument for ``htc`` or remove the ``ext_temperature`` argument.")
             return None
         if isinstance(ext_temperature, dict) and ext_temperature["Type"] == "Temp Dep":
             self.logger.add_error_message(

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -684,7 +684,7 @@ class Icepak(FieldAnalysis3D):
         if input_power == 0:
             input_power = "0W"
         if not bool(input_power) ^ bool(thermal_dependent_dataset):
-            self.logger.error("Please assigned one input between ``thermal_dependent_dataset`` and  ``input_power``")
+            self.logger.error("Assign one input between ``thermal_dependent_dataset`` and  ``input_power``")
         if not source_name:
             source_name = generate_unique_name("Source")
         props = {}
@@ -768,9 +768,7 @@ class Icepak(FieldAnalysis3D):
         >>> block.props["Nodes"]["Internal"][0]
         '2W'
         """
-        warnings.warn(
-            "This method is deprecated in 0.6.27. Please use create_two_resistor_network_block", DeprecationWarning
-        )
+        warnings.warn("This method is deprecated in 0.6.27. Use create_two_resistor_network_block", DeprecationWarning)
         if object_name in self.modeler.object_names:
             if gravity_dir > 2:
                 gravity_dir = gravity_dir - 3
@@ -3789,28 +3787,40 @@ class Icepak(FieldAnalysis3D):
         object_name : str
             Name of the object.
         power_assignment : str or dict
-            String with value and units of the power assignment or with ``"Joule Heating"``.
-            Also, a dictionary can be used for temperature dependent or transient assignment.
-            The dictionary should contain three keys: ``"Type"``, ``"Function"`` and
-            ``"Values"``. Accepted ``"Type"`` values are: ``"Temp Dep"`` and ``"Transient"``.
-            Accepted ``"Function"`` are: ``"Linear"``, ``"Power Law"``, ``"Exponential"``,
-            ``"Sinusoidal"``, ``"Square Wave"`` and ``"Piecewise Linear"``. ``"Temp Dep"`` only
-            support the latter. ``"Values"`` contains a list of strings containing the parameters
-            required by the ``"Function"`` selection (e.g. ``"Linear"`` requires two parameters:
-            the value of the variable at t=0 and the slope of the line). The parameters required by
-            each ``Function`` option is in Icepak documentation. The parameters must contain the
-            units where needed.
+            String with the value and units of the power assignment or with
+            ``"Joule Heating"``. For a temperature-dependent or transient
+            assignment, a dictionary can be used. The dictionary should contain three keys:
+            ``"Type"``, ``"Function"``, and ``"Values"``.
+            - For the ``"Type"`` key, accepted values are ``"Temp Dep"`` and ``"Transient"``.
+            - For the ``"Function"`` key, acceptable values depend on the ``"Type"`` key
+              selection. When the ``"Type"`` key is set to ``"Temp Dep"``, the only
+              accepted value is ````"Piecewise Linear"`` . When the ``"Type"`` key is
+              set to ``"Transient"``, acceptable values are `"Exponential"``, `"Linear"``,
+              ```"Piecewise Linear"``, ``"Power Law"``, ``"Sinusoidal"``, and ``"Square
+               Wave"``.
+            - For the ``"Values"`` key, a list of strings contain the parameters required by
+              the ``"Function"`` key selection. For example, whn``"Linear"`` is set as the
+              ``"Function"`` key, two parameters are required: the value of the variable
+              at t=0 and the slope of the line. For the parameters required by each
+              ``"Function"`` key selection, see the Icepack documentation (). The parameters
+              must contain the units where needed.
         boundary_name : str, optional
-            Name of the source boundary. The default is ``None`` and the boundary name will be
-            generated automatically.
-        htc : float, str or dict, optional
-            String with value and units of heat transfer coefficient for the external conditions.
-            Also, a dictionary can be used for temperature dependent or transient assignment as
-            described in ``power_assignment``. The default is ``None``
+            Name of the source boundary. The default is ``None``, in which case the
+            boundary name is automatically generated.
+        htc : float, str, or dict, optional
+            String with the value and units of the heat transfer coefficient for the
+            external conditions. If a float is provided, ``"w_per_m2kel"`` unit will be used.
+            For a temperature-dependent or transient
+            assignment, a dictionary can be used. For more information, see the
+            description for the preceding ``power_assignment`` parameter. The
+            default is ``None``, in which case no external condition will be applied.
         ext_temperature : float, str or dict, optional
-            String with value and units of temperature for the external conditions.
-            Also, a dictionary can be used for transient assignment as described in ``power_assignment``.
-            The default is ``"AmbientTemp"`` and will have effect if ``htc`` is not ``None``
+            String with the value and units of temperature for the external conditions.
+            If a float is provided, ``"cel"`` unit will be used.
+            For a transient assignment, a dictionary can be used. For more information,
+            see the description for the preceding ``power_assignment`` parameter. The
+            default is ``"AmbientTemp"``, which is used if the ``htc`` parameter is not
+            set to ``None``.
 
 
         Returns
@@ -3834,11 +3844,11 @@ class Icepak(FieldAnalysis3D):
         """
         if not self.modeler.get_object_from_name(object_name).solve_inside:
             self.logger.add_error_message(
-                "Please use ``assign_hollow_block`` function with this object as" "``solve_inside`` is ``False``."
+                "Use ``assign_hollow_block`` function with this object as" "``solve_inside`` is ``False``."
             )
             return None
         if ext_temperature != "AmbientTemp" and ext_temperature is not None and not htc:
-            self.logger.add_error_message("Please set an argument for ``htc`` or remove ``ext_temperature`` argument.")
+            self.logger.add_error_message("Set an argument for ``htc`` or remove ``ext_temperature`` argument.")
             return None
         if isinstance(ext_temperature, dict) and ext_temperature["Type"] == "Temp Dep":
             self.logger.add_error_message(
@@ -3902,27 +3912,37 @@ class Icepak(FieldAnalysis3D):
         object_name : str
             Name of the object.
         assignment_type : str
-            Type of the boundary assignment. The accepted types are: "Total Power", "Heat Flux",
-            "Temperature" or "Heat Transfer Coefficient".
+            Type of the boundary assignment. Options are ``"Heat Transfer Coefficient"``,
+            ``"Heat Flux"``, ``"Temperature"``, and ``"Total Power"``.
         assignment_value : str or dict
-            String with value and units of the assignment. If ``"Total Power"`` is assignment_type,
-            ``"Joule Heating"`` can be used.
-            Also, a dictionary can be used for temperature dependent or transient assignment.
-            The dictionary should contain three keys: ``"Type"``, ``"Function"`` and
-            ``"Values"``. Accepted ``"Type"`` values are: ``"Temp Dep"`` and ``"Transient"``.
-            Accepted ``"Function"`` are: ``"Linear"``, ``"Power Law"``, ``"Exponential"``,
-            ``"Sinusoidal"``, ``"Square Wave"`` and ``"Piecewise Linear"``. ``"Temp Dep"`` only
-            support the latter. ``"Values"`` contains a list of strings containing the parameters
-            required by the ``"Function"`` selection (e.g. ``"Linear"`` requires two parameters:
-            the value of the variable at t=0 and the slope of the line). The parameters required by
-            each ``Function`` option is in Icepak documentation. The parameters must contain the
-            units where needed.
+            String with value and units of the assignment. If ``"Total Power"`` is
+            assignment_type, ``"Joule Heating"`` can be used.
+            For a temperature-dependent or transient assignment, a dictionary can be used.
+            The dictionary should contain three keys:
+            ``"Type"``, ``"Function"``, and ``"Values"``.
+            - For the ``"Type"`` key, accepted values are ``"Temp Dep"`` and ``"Transient"``.
+            - For the ``"Function"`` key, acceptable values depend on the ``"Type"`` key
+              selection. When the ``"Type"`` key is set to ``"Temp Dep"``, the only
+              accepted value is ````"Piecewise Linear"`` . When the ``"Type"`` key is
+              set to ``"Transient"``, acceptable values are `"Exponential"``, `"Linear"``,
+              ```"Piecewise Linear"``, ``"Power Law"``, ``"Sinusoidal"``, and ``"Square
+               Wave"``.
+            - For the ``"Values"`` key, a list of strings contain the parameters required by
+              the ``"Function"`` key selection. For example, whn``"Linear"`` is set as the
+              ``"Function"`` key, two parameters are required: the value of the variable
+              at t=0 and the slope of the line. For the parameters required by each
+              ``"Function"`` key selection, see the Icepack documentation (). The parameters
+              must contain the units where needed.
         boundary_name : str, optional
-            Name of the source boundary. The default is ``None`` and the boundary name will be
-            generated automatically.
+            Name of the source boundary. The default is ``None``, in which case the
+            boundary is automatically generated.
         external_temperature : str, dict or float, optional
-            String with value and unit of temperature for the Heat Transfer Coefficient. If float,
-            ``"cel"`` unit will be added automatically. The default is ``"AmbientTemp"``.
+            String with the value and unit of the temperature for the heat transfer
+            coefficient. If a float value is specified, the ``"cel"`` unit is automatically
+            added.
+            For a transient assignment, a dictionary can be used as described for the
+            assignment_value argument. Temperature dependent assignment is not supported.
+            The default is ``"AmbientTemp"``.
 
 
         Returns
@@ -3947,7 +3967,7 @@ class Icepak(FieldAnalysis3D):
         """
         if self.modeler.get_object_from_name(object_name).solve_inside:
             self.logger.add_error_message(
-                "Please use ``assign_solid_block`` function with this object as" "``solve_inside`` is ``True``."
+                "Use ``assign_solid_block`` function with this object as" "``solve_inside`` is ``True``."
             )
             return None
         if assignment_value == "Joule Heating" and assignment_type != "Total Power":
@@ -3993,7 +4013,7 @@ class Icepak(FieldAnalysis3D):
             if isinstance(external_temperature, dict):
                 if external_temperature["Type"] == "Temp Dep":
                     self.logger.add_error_message(
-                        'It is not possible to use a "Temp Dep" assignment for a' "temperature assignment."
+                        'It is not possible to use a "Temp Dep" assignment for a temperature assignment.'
                     )
                     return None
                 assignment_value_dict = self._parse_variation_data(

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -768,7 +768,10 @@ class Icepak(FieldAnalysis3D):
         >>> block.props["Nodes"]["Internal"][0]
         '2W'
         """
-        warnings.warn("This method is deprecated in 0.6.27. Use the create_two_resistor_network_block() method.", DeprecationWarning)
+        warnings.warn(
+            "This method is deprecated in 0.6.27. Use the create_two_resistor_network_block() method.",
+            DeprecationWarning,
+        )
         if object_name in self.modeler.object_names:
             if gravity_dir > 2:
                 gravity_dir = gravity_dir - 3
@@ -3846,7 +3849,7 @@ class Icepak(FieldAnalysis3D):
         """
         if not self.modeler.get_object_from_name(object_name).solve_inside:
             self.logger.add_error_message(
-                "Use the ``assign_hollow_block()`` method with this object as ``"solve_inside`` is ``False``."
+                "Use the ``assign_hollow_block()`` method with this object as ``solve_inside`` is ``False``."
             )
             return None
         if ext_temperature != "AmbientTemp" and ext_temperature is not None and not htc:

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -684,7 +684,7 @@ class Icepak(FieldAnalysis3D):
         if input_power == 0:
             input_power = "0W"
         if not bool(input_power) ^ bool(thermal_dependent_dataset):
-            self.logger.error("Assign one input between ``thermal_dependent_dataset`` and  ``input_power``")
+            self.logger.error("Assign one input between ``thermal_dependent_dataset`` and  ``input_power``.")
         if not source_name:
             source_name = generate_unique_name("Source")
         props = {}

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -3791,6 +3791,7 @@ class Icepak(FieldAnalysis3D):
             ``"Joule Heating"``. For a temperature-dependent or transient
             assignment, a dictionary can be used. The dictionary should contain three keys:
             ``"Type"``, ``"Function"``, and ``"Values"``.
+            
             - For the ``"Type"`` key, accepted values are ``"Temp Dep"`` and ``"Transient"``.
             - For the ``"Function"`` key, acceptable values depend on the ``"Type"`` key
               selection. When the ``"Type"`` key is set to ``"Temp Dep"``, the only
@@ -3804,6 +3805,7 @@ class Icepak(FieldAnalysis3D):
               at t=0 and the slope of the line. For the parameters required by each
               ``"Function"`` key selection, see the Icepack documentation (). The parameters
               must contain the units where needed.
+              
         boundary_name : str, optional
             Name of the source boundary. The default is ``None``, in which case the
             boundary name is automatically generated.
@@ -3920,6 +3922,7 @@ class Icepak(FieldAnalysis3D):
             For a temperature-dependent or transient assignment, a dictionary can be used.
             The dictionary should contain three keys:
             ``"Type"``, ``"Function"``, and ``"Values"``.
+            
             - For the ``"Type"`` key, accepted values are ``"Temp Dep"`` and ``"Transient"``.
             - For the ``"Function"`` key, acceptable values depend on the ``"Type"`` key
               selection. When the ``"Type"`` key is set to ``"Temp Dep"``, the only
@@ -3933,6 +3936,7 @@ class Icepak(FieldAnalysis3D):
               at t=0 and the slope of the line. For the parameters required by each
               ``"Function"`` key selection, see the Icepack documentation (). The parameters
               must contain the units where needed.
+              
         boundary_name : str, optional
             Name of the source boundary. The default is ``None``, in which case the
             boundary is automatically generated.

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -3791,7 +3791,7 @@ class Icepak(FieldAnalysis3D):
             ``"Joule Heating"``. For a temperature-dependent or transient
             assignment, a dictionary can be used. The dictionary should contain three keys:
             ``"Type"``, ``"Function"``, and ``"Values"``.
-            
+
             - For the ``"Type"`` key, accepted values are ``"Temp Dep"`` and ``"Transient"``.
             - For the ``"Function"`` key, acceptable values depend on the ``"Type"`` key
               selection. When the ``"Type"`` key is set to ``"Temp Dep"``, the only
@@ -3805,7 +3805,7 @@ class Icepak(FieldAnalysis3D):
               at t=0 and the slope of the line. For the parameters required by each
               ``"Function"`` key selection, see the Icepack documentation (). The parameters
               must contain the units where needed.
-              
+
         boundary_name : str, optional
             Name of the source boundary. The default is ``None``, in which case the
             boundary name is automatically generated.
@@ -3922,7 +3922,7 @@ class Icepak(FieldAnalysis3D):
             For a temperature-dependent or transient assignment, a dictionary can be used.
             The dictionary should contain three keys:
             ``"Type"``, ``"Function"``, and ``"Values"``.
-            
+
             - For the ``"Type"`` key, accepted values are ``"Temp Dep"`` and ``"Transient"``.
             - For the ``"Function"`` key, acceptable values depend on the ``"Type"`` key
               selection. When the ``"Type"`` key is set to ``"Temp Dep"``, the only
@@ -3936,7 +3936,7 @@ class Icepak(FieldAnalysis3D):
               at t=0 and the slope of the line. For the parameters required by each
               ``"Function"`` key selection, see the Icepack documentation (). The parameters
               must contain the units where needed.
-              
+
         boundary_name : str, optional
             Name of the source boundary. The default is ``None``, in which case the
             boundary is automatically generated.

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -3844,7 +3844,7 @@ class Icepak(FieldAnalysis3D):
         """
         if not self.modeler.get_object_from_name(object_name).solve_inside:
             self.logger.add_error_message(
-                "Use ``assign_hollow_block`` function with this object as" "``solve_inside`` is ``False``."
+                "Use the ``assign_hollow_block()`` method with this object as ``"solve_inside`` is ``False``."
             )
             return None
         if ext_temperature != "AmbientTemp" and ext_temperature is not None and not htc:


### PR DESCRIPTION
@PipKat I applied your suggestions from https://github.com/ansys/pyaedt/pull/3018

The only one I did not applied was the one regarding the introduction of a link to the Icepak documentation. I'm currently thinking of introducing one or more function that may help an unfamiliar user to build those dictionaries. In this way we can also shorten those explanations which are repeated on several functions (and will be repeated on others) and can potentially become annoying to maintain.