### PR TITLE
Fixed some handles left open in desktop.py

### DIFF
--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -64,6 +64,8 @@ else:
     _com = "gprc_v3"
     settings.use_grpc_api = True
 
+devnull = subprocess.DEVNULL
+
 
 @pyaedt_function_handler()
 def launch_aedt(full_path, non_graphical, port, first_run=True):
@@ -77,9 +79,11 @@ def launch_aedt(full_path, non_graphical, port, first_run=True):
         for env, val in settings.aedt_environment_variables.items():
             my_env[env] = val
         if is_linux:  # pragma: no cover
-            subprocess.Popen(command, env=my_env, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+            with subprocess.Popen(command, env=my_env, stdout=devnull, stderr=devnull) as p:
+                p.wait()
         else:
-            subprocess.Popen(" ".join(command), env=my_env, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+            with subprocess.Popen(" ".join(command), env=my_env, stdout=devnull, stderr=devnull) as p:
+                p.wait()
 
     _aedt_process_thread = threading.Thread(target=launch_desktop_on_port)
     _aedt_process_thread.daemon = True
@@ -127,7 +131,7 @@ def launch_aedt_in_lsf(non_graphical, port):  # pragma: no cover
     if non_graphical:
         command.append("-ng")
     print(command)
-    p = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    p = subprocess.Popen(command, stdout=devnull, stderr=devnull)
     timeout = settings.lsf_timeout
     i = 0
     while i < timeout:
@@ -154,10 +158,12 @@ def _check_grpc_port(port, machine_name=""):
             machine_name = "127.0.0.1"
         s.connect((machine_name, port))
     except socket.error:
-        return False
+        success = False
     else:
+        success = True
+    finally:
         s.close()
-        return True
+    return success
 
 
 def _find_free_port():


### PR DESCRIPTION
When opening AEDT under certain environments (like through a WSGI server), these warnings appear:

![Screenshot 2023-05-25 121017](https://github.com/ansys/pyaedt/assets/84965833/2e2bdfbf-c207-4416-97ac-d136577ed2b9)

![Screenshot 2023-05-25 152714](https://github.com/ansys/pyaedt/assets/84965833/091cf5cd-7de1-42c9-8442-498737ad1e77)

![Screenshot 2023-05-25 153113](https://github.com/ansys/pyaedt/assets/84965833/7d30e7bc-b126-48ad-bb78-05121af752c1)

The first one is due to an unclosed socket in the `_check_grpc_port` function.
The second one is due to the fact that the `subprocess` returncode attribute is not set and returned. `subprocess.wait()` does that for us.
The last one is because we are not closing the streams associated with the `Popen()` object we opened. The stream was opened on stderr, but it is not necessary.

This PR addresses each one of them.