### PR TITLE
Simulation configuration flexibility added

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -1790,7 +1790,11 @@ class TestClass(BasisTest, object):
         edbapp.close_edb()
 
     def test_129_hfss_simulation_setup(self):
-        setup1 = self.edbapp.create_hfss_setup("setup1")
+        source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
+        target_path = os.path.join(self.local_scratch.path, "test_0129.aedb")
+        self.local_scratch.copyfolder(source_path, target_path)
+        edbapp = Edb(target_path, edbversion=desktop_version)
+        setup1 = edbapp.create_hfss_setup("setup1")
         assert setup1.set_solution_single_frequency()
         assert setup1.set_solution_multi_frequencies()
         assert setup1.set_solution_broadband()
@@ -1800,7 +1804,7 @@ class TestClass(BasisTest, object):
         setup1.hfss_solver_settings.relative_residual = 0.0002
         setup1.hfss_solver_settings.use_shell_elements = True
 
-        hfss_solver_settings = self.edbapp.setups["setup1"].hfss_solver_settings
+        hfss_solver_settings = edbapp.setups["setup1"].hfss_solver_settings
         assert hfss_solver_settings.order_basis == "first"
         assert hfss_solver_settings.relative_residual == 0.0002
         assert hfss_solver_settings.solver_type
@@ -1819,15 +1823,15 @@ class TestClass(BasisTest, object):
         setup1.adaptive_settings.use_convergence_matrix = True
         setup1.adaptive_settings.use_max_refinement = True
 
-        assert self.edbapp.setups["setup1"].adaptive_settings.adapt_type == "kBroadband"
-        assert not self.edbapp.setups["setup1"].adaptive_settings.basic
-        assert self.edbapp.setups["setup1"].adaptive_settings.max_refinement == 1000001
-        assert self.edbapp.setups["setup1"].adaptive_settings.max_refine_per_pass == 20
-        assert self.edbapp.setups["setup1"].adaptive_settings.min_passes == 2
-        assert self.edbapp.setups["setup1"].adaptive_settings.save_fields
-        assert self.edbapp.setups["setup1"].adaptive_settings.save_rad_field_only
+        assert edbapp.setups["setup1"].adaptive_settings.adapt_type == "kBroadband"
+        assert not edbapp.setups["setup1"].adaptive_settings.basic
+        assert edbapp.setups["setup1"].adaptive_settings.max_refinement == 1000001
+        assert edbapp.setups["setup1"].adaptive_settings.max_refine_per_pass == 20
+        assert edbapp.setups["setup1"].adaptive_settings.min_passes == 2
+        assert edbapp.setups["setup1"].adaptive_settings.save_fields
+        assert edbapp.setups["setup1"].adaptive_settings.save_rad_field_only
         # assert adaptive_settings.use_convergence_matrix
-        assert self.edbapp.setups["setup1"].adaptive_settings.use_max_refinement
+        assert edbapp.setups["setup1"].adaptive_settings.use_max_refinement
 
         setup1.defeature_settings.defeature_abs_length = "1um"
         setup1.defeature_settings.defeature_ratio = 1e-5
@@ -1839,7 +1843,7 @@ class TestClass(BasisTest, object):
         setup1.defeature_settings.use_defeature = False
         setup1.defeature_settings.use_defeature_abs_length = True
 
-        defeature_settings = self.edbapp.setups["setup1"].defeature_settings
+        defeature_settings = edbapp.setups["setup1"].defeature_settings
         assert defeature_settings.defeature_abs_length == "1um"
         assert defeature_settings.defeature_ratio == 1e-5
         # assert defeature_settings.healing_option == 0
@@ -1856,7 +1860,7 @@ class TestClass(BasisTest, object):
         via_settings.via_num_sides = 8
         via_settings.via_style = "kNum25DViaStyle"
 
-        via_settings = self.edbapp.setups["setup1"].via_settings
+        via_settings = edbapp.setups["setup1"].via_settings
         assert via_settings.via_density == 1
         assert via_settings.via_material == "pec"
         assert via_settings.via_num_sides == 8
@@ -1867,7 +1871,7 @@ class TestClass(BasisTest, object):
         advanced_mesh_settings.mesh_display_attributes = "#0000001"
         advanced_mesh_settings.replace_3d_triangles = False
 
-        advanced_mesh_settings = self.edbapp.setups["setup1"].advanced_mesh_settings
+        advanced_mesh_settings = edbapp.setups["setup1"].advanced_mesh_settings
         assert advanced_mesh_settings.layer_snap_tol == "1e-6"
         assert advanced_mesh_settings.mesh_display_attributes == "#0000001"
         assert not advanced_mesh_settings.replace_3d_triangles
@@ -1879,7 +1883,7 @@ class TestClass(BasisTest, object):
         curve_approx_settings.start_azimuth = "1"
         curve_approx_settings.use_arc_to_chord_error = True
 
-        curve_approx_settings = self.edbapp.setups["setup1"].curve_approx_settings
+        curve_approx_settings = edbapp.setups["setup1"].curve_approx_settings
         assert curve_approx_settings.arc_to_chord_error == "0.1"
         assert curve_approx_settings.max_arc_points == 12
         assert curve_approx_settings.start_azimuth == "1"
@@ -1892,7 +1896,7 @@ class TestClass(BasisTest, object):
         dcr_settings.conduction_per_error = 2.0
         dcr_settings.conduction_per_refine = 33.0
 
-        dcr_settings = self.edbapp.setups["setup1"].dcr_settings
+        dcr_settings = edbapp.setups["setup1"].dcr_settings
         assert dcr_settings.conduction_max_passes == 11
         assert dcr_settings.conduction_min_converged_passes == 2
         assert dcr_settings.conduction_min_passes == 2
@@ -1925,11 +1929,11 @@ class TestClass(BasisTest, object):
         sweep1.adaptive_sampling = True
         assert sweep1.adaptive_sampling
 
-        self.edbapp.setups["setup1"].name = "setup1a"
-        assert "setup1" not in self.edbapp.setups
-        assert "setup1a" in self.edbapp.setups
+        edbapp.setups["setup1"].name = "setup1a"
+        assert "setup1" not in edbapp.setups
+        assert "setup1a" in edbapp.setups
 
-        mop = self.edbapp.setups["setup1a"].add_length_mesh_operation({"GND": ["TOP", "BOTTOM"]}, "m1")
+        mop = edbapp.setups["setup1a"].add_length_mesh_operation({"GND": ["TOP", "BOTTOM"]}, "m1")
         assert mop.name == "m1"
         assert mop.max_elements == "1000"
         assert mop.restrict_max_elements
@@ -1948,7 +1952,7 @@ class TestClass(BasisTest, object):
         assert not mop.restrict_length
         assert mop.max_length == "2mm"
 
-        mop = self.edbapp.setups["setup1a"].add_skin_depth_mesh_operation({"GND": ["TOP", "BOTTOM"]})
+        mop = edbapp.setups["setup1a"].add_skin_depth_mesh_operation({"GND": ["TOP", "BOTTOM"]})
         assert mop.max_elements == "1000"
         assert mop.restrict_max_elements
         assert mop.skin_depth == "1um"
@@ -2330,7 +2334,7 @@ class TestClass(BasisTest, object):
         edb.stackup.add_layer(layer_name="FR4", base_layer="gnd", thickness="250um")
         edb.stackup.add_layer(layer_name="SIGNAL", base_layer="FR4", thickness="30um")
         edb.modeler.create_trace(layer_name="SIGNAL", width=0.02, net_name="net1", path_list=[[-1e3, 0, 1e-3, 0]])
-        edb.mo.create_rectangle(
+        edb.modeler.create_rectangle(
             layer_name="GND",
             representation_type="CenterWidthHeight",
             center_point=["0mm", "0mm"],

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -2286,10 +2286,8 @@ class TestClass(BasisTest, object):
         edb.stackup.add_layer(layer_name="GND", fillMaterial="AIR", thickness="30um")
         edb.stackup.add_layer(layer_name="FR4", base_layer="gnd", thickness="250um")
         edb.stackup.add_layer(layer_name="SIGNAL", base_layer="FR4", thickness="30um")
-        edb.core_primitives.create_trace(
-            layer_name="SIGNAL", width=0.02, net_name="net1", path_list=[[-1e3, 0, 1e-3, 0]]
-        )
-        edb.core_primitives.create_rectangle(
+        edb.modeler.create_trace(layer_name="SIGNAL", width=0.02, net_name="net1", path_list=[[-1e3, 0, 1e-3, 0]])
+        edb.modeler.create_rectangle(
             layer_name="GND",
             representation_type="CenterWidthHeight",
             center_point=["0mm", "0mm"],
@@ -2299,7 +2297,7 @@ class TestClass(BasisTest, object):
         )
         sim_setup = edb.new_simulation_configuration()
         sim_setup.signal_nets = ["net1"]
-        sim_setup.power_nets = ["GND"]
+        # sim_setup.power_nets = ["GND"]
         sim_setup.use_dielectric_extent_multiple = False
         sim_setup.use_airbox_horizontal_extent_multiple = False
         sim_setup.use_airbox_negative_vertical_extent_multiple = False
@@ -2308,8 +2306,14 @@ class TestClass(BasisTest, object):
         sim_setup.airbox_horizontal_extent = 0.001
         sim_setup.airbox_negative_vertical_extent = 0.05
         sim_setup.airbox_positive_vertical_extent = 0.04
+        sim_setup.add_frequency_sweep = False
+        sim_setup.include_only_selected_nets = True
+        sim_setup.do_cutout_subdesign = False
+        sim_setup.generate_excitations = False
         edb.build_simulation_project(sim_setup)
         hfss_ext_info = edb.active_cell.GetHFSSExtentInfo()
+        assert list(edb.nets.nets.values())[0].name == "net1"
+        assert not edb.setups["Pyaedt_setup"].frequency_sweeps
         assert hfss_ext_info
         assert hfss_ext_info.AirBoxHorizontalExtent.Item1 == 0.001
         assert not hfss_ext_info.AirBoxHorizontalExtent.Item2

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -2329,10 +2329,8 @@ class TestClass(BasisTest, object):
         edb.stackup.add_layer(layer_name="GND", fillMaterial="AIR", thickness="30um")
         edb.stackup.add_layer(layer_name="FR4", base_layer="gnd", thickness="250um")
         edb.stackup.add_layer(layer_name="SIGNAL", base_layer="FR4", thickness="30um")
-        edb.core_primitives.create_trace(
-            layer_name="SIGNAL", width=0.02, net_name="net1", path_list=[[-1e3, 0, 1e-3, 0]]
-        )
-        edb.core_primitives.create_rectangle(
+        edb.modeler.create_trace(layer_name="SIGNAL", width=0.02, net_name="net1", path_list=[[-1e3, 0, 1e-3, 0]])
+        edb.mo.create_rectangle(
             layer_name="GND",
             representation_type="CenterWidthHeight",
             center_point=["0mm", "0mm"],

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -3036,6 +3036,11 @@ class Edb(object):
                         remove_single_pin_components=True,
                     )
                     self.logger.info("Cutout processed.")
+            else:
+                if simulation_setup.include_only_selected_nets:
+                    included_nets = simulation_setup.signal_nets + simulation_setup.power_nets
+                    nets_to_remove = [net for net in list(self.nets.nets.values()) if not net.name in included_nets]
+                    self.nets.delete(nets_to_remove)
             self.logger.info("Deleting existing ports.")
             map(lambda port: port.Delete(), list(self.active_layout.Terminals))
             map(lambda pg: pg.Delete(), list(self.active_layout.PinGroups))

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -3040,44 +3040,47 @@ class Edb(object):
             map(lambda port: port.Delete(), list(self.active_layout.Terminals))
             map(lambda pg: pg.Delete(), list(self.active_layout.PinGroups))
             if simulation_setup.solver_type == SolverType.Hfss3dLayout:
-                self.logger.info("Creating HFSS ports for signal nets.")
-                for cmp in simulation_setup.components:
-                    self.components.create_port_on_component(
-                        cmp,
-                        net_list=simulation_setup.signal_nets,
-                        do_pingroup=False,
-                        reference_net=simulation_setup.power_nets,
-                        port_type=SourceType.CoaxPort,
-                    )
-                if not self.hfss.set_coax_port_attributes(simulation_setup):  # pragma: no cover
-                    self.logger.error("Failed to configure coaxial port attributes.")
-                self.logger.info("Number of ports: {}".format(self.hfss.get_ports_number()))
-                self.logger.info("Configure HFSS extents.")
-                if simulation_setup.trim_reference_size:  # pragma: no cover
-                    self.logger.info(
-                        "Trimming the reference plane for coaxial ports: {0}".format(
-                            bool(simulation_setup.trim_reference_size)
+                if simulation_setup.generate_excitations:
+                    self.logger.info("Creating HFSS ports for signal nets.")
+                    for cmp in simulation_setup.components:
+                        self.components.create_port_on_component(
+                            cmp,
+                            net_list=simulation_setup.signal_nets,
+                            do_pingroup=False,
+                            reference_net=simulation_setup.power_nets,
+                            port_type=SourceType.CoaxPort,
                         )
-                    )
-                    self.hfss.trim_component_reference_size(simulation_setup)  # pragma: no cover
+                    if not self.hfss.set_coax_port_attributes(simulation_setup):  # pragma: no cover
+                        self.logger.error("Failed to configure coaxial port attributes.")
+                    self.logger.info("Number of ports: {}".format(self.hfss.get_ports_number()))
+                    self.logger.info("Configure HFSS extents.")
+                    if simulation_setup.trim_reference_size:  # pragma: no cover
+                        self.logger.info(
+                            "Trimming the reference plane for coaxial ports: {0}".format(
+                                bool(simulation_setup.trim_reference_size)
+                            )
+                        )
+                        self.hfss.trim_component_reference_size(simulation_setup)  # pragma: no cover
                 self.hfss.configure_hfss_extents(simulation_setup)
                 if not self.hfss.configure_hfss_analysis_setup(simulation_setup):
                     self.logger.error("Failed to configure HFSS simulation setup.")
             if simulation_setup.solver_type == SolverType.SiwaveSYZ:
-                for cmp in simulation_setup.components:
-                    self.components.create_port_on_component(
-                        cmp,
-                        net_list=simulation_setup.signal_nets,
-                        do_pingroup=simulation_setup.do_pingroup,
-                        reference_net=simulation_setup.power_nets,
-                        port_type=SourceType.CircPort,
-                    )
+                if simulation_setup.generate_excitations:
+                    for cmp in simulation_setup.components:
+                        self.components.create_port_on_component(
+                            cmp,
+                            net_list=simulation_setup.signal_nets,
+                            do_pingroup=simulation_setup.do_pingroup,
+                            reference_net=simulation_setup.power_nets,
+                            port_type=SourceType.CircPort,
+                        )
                 self.logger.info("Configuring analysis setup.")
                 if not self.siwave.configure_siw_analysis_setup(simulation_setup):  # pragma: no cover
                     self.logger.error("Failed to configure Siwave simulation setup.")
 
             if simulation_setup.solver_type == SolverType.SiwaveDC:
-                self.components.create_source_on_component(simulation_setup.sources)
+                if simulation_setup.generate_excitations:
+                    self.components.create_source_on_component(simulation_setup.sources)
                 if not self.siwave.configure_siw_analysis_setup(simulation_setup):  # pragma: no cover
                     self.logger.error("Failed to configure Siwave simulation setup.")
             self.padstacks.check_and_fix_via_plating()

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -3039,7 +3039,9 @@ class Edb(object):
             else:
                 if simulation_setup.include_only_selected_nets:
                     included_nets = simulation_setup.signal_nets + simulation_setup.power_nets
-                    nets_to_remove = [net for net in list(self.nets.nets.values()) if not net.name in included_nets]
+                    nets_to_remove = [
+                        net.name for net in list(self.nets.nets.values()) if not net.name in included_nets
+                    ]
                     self.nets.delete(nets_to_remove)
             self.logger.info("Deleting existing ports.")
             map(lambda port: port.Delete(), list(self.active_layout.Terminals))

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -606,7 +606,7 @@ class SimulationConfigurationBatch(object):
         Returns
         -------
         bool
-            ``True`` or ``False. Default value is ``False``.
+            ``True`` or ``False``. Default value is ``False``.
 
         """
         return self._include_only_selected_nets

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -34,6 +34,7 @@ class SimulationConfigurationBatch(object):
         self._use_default_cutout = True
         self._generate_excitations = True
         self._add_frequency_sweep = True
+        self._include_only_selected_nets = True
         self._generate_solder_balls = True
         self._coax_solder_ball_diameter = []
         self._use_default_coax_port_radial_extension = True
@@ -587,7 +588,7 @@ class SimulationConfigurationBatch(object):
         Returns
         -------
         bool
-            ``True`` freuquency sweep is created, ``False`` skip sweep adding. Default value is ``True``.
+            ``True`` frequency sweep is created, ``False`` skip sweep adding. Default value is ``True``.
 
         """
         return self._add_frequency_sweep
@@ -596,6 +597,23 @@ class SimulationConfigurationBatch(object):
     def add_frequency_sweep(self, value):
         if isinstance(value, bool):
             self._add_frequency_sweep = value
+
+    @property
+    def include_only_selected_nets(self):
+        """Include only net selection in the project. Is only used when do_cutout is set to ``False``. Will also be
+        ignored if signal_nets and power_nets are ``None``, resulting project will have all nets included.
+
+        Returns
+        -------
+        bool
+            ``True`` or ``False. Default value is ``True``.
+
+        """
+
+    @include_only_selected_nets.setter
+    def include_only_selected_nets(self, value):
+        if isinstance(value, bool):
+            self._include_only_selected_nets = value
 
 
 class SimulationConfigurationDc(object):

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -34,7 +34,7 @@ class SimulationConfigurationBatch(object):
         self._use_default_cutout = True
         self._generate_excitations = True
         self._add_frequency_sweep = True
-        self._include_only_selected_nets = True
+        self._include_only_selected_nets = False
         self._generate_solder_balls = True
         self._coax_solder_ball_diameter = []
         self._use_default_coax_port_radial_extension = True
@@ -606,7 +606,7 @@ class SimulationConfigurationBatch(object):
         Returns
         -------
         bool
-            ``True`` or ``False. Default value is ``True``.
+            ``True`` or ``False. Default value is ``False``.
 
         """
         return self._include_only_selected_nets

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -600,8 +600,8 @@ class SimulationConfigurationBatch(object):
 
     @property
     def include_only_selected_nets(self):
-        """Include only net selection in the project. It is only used when ``do_cutout`` is set to ``False``. Will also be
-        ignored if signal_nets and power_nets are ``None``, resulting project will have all nets included.
+        """Include only net selection in the project. It is only used when ``do_cutout`` is set to ``False``.
+        Will also be ignored if signal_nets and power_nets are ``None``, resulting project will have all nets included.
 
         Returns
         -------

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -600,7 +600,7 @@ class SimulationConfigurationBatch(object):
 
     @property
     def include_only_selected_nets(self):
-        """Include only net selection in the project. Is only used when do_cutout is set to ``False``. Will also be
+        """Include only net selection in the project. It is only used when ``do_cutout`` is set to ``False``. Will also be
         ignored if signal_nets and power_nets are ``None``, resulting project will have all nets included.
 
         Returns

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -2319,6 +2319,9 @@ class SimulationConfiguration(object):
     def _read_cfg(self):  # pragma: no cover
         """Configuration file reader.
 
+        .. deprecated:: 0.6.78
+           Use :func:`import_json` instead.
+
         Examples
         --------
 

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -33,6 +33,7 @@ class SimulationConfigurationBatch(object):
         self._cutout_subdesign_round_corner = True
         self._use_default_cutout = True
         self._generate_excitations = True
+        self._add_frequency_sweep = True
         self._generate_solder_balls = True
         self._coax_solder_ball_diameter = []
         self._use_default_coax_port_radial_extension = True
@@ -578,6 +579,23 @@ class SimulationConfigurationBatch(object):
     def generate_excitations(self, value):
         if isinstance(value, bool):
             self._generate_excitations = value
+
+    @property
+    def add_frequency_sweep(self):
+        """Activate the frequency sweep creation when build project with the class.
+
+        Returns
+        -------
+        bool
+            ``True`` freuquency sweep is created, ``False`` skip sweep adding. Default value is ``True``.
+
+        """
+        return self._add_frequency_sweep
+
+    @add_frequency_sweep.setter
+    def add_frequency_sweep(self, value):
+        if isinstance(value, bool):
+            self._add_frequency_sweep = value
 
 
 class SimulationConfigurationDc(object):

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -32,6 +32,7 @@ class SimulationConfigurationBatch(object):
         self._cutout_subdesign_expansion = 0.001
         self._cutout_subdesign_round_corner = True
         self._use_default_cutout = True
+        self._generate_excitations = True
         self._generate_solder_balls = True
         self._coax_solder_ball_diameter = []
         self._use_default_coax_port_radial_extension = True
@@ -560,6 +561,23 @@ class SimulationConfigurationBatch(object):
     def signal_layers_properties(self, value):  # pragma: no cover
         if isinstance(value, dict):
             self._signal_layers_properties = value
+
+    @property
+    def generate_excitations(self):
+        """Activate ports and sources for DC generation when build project with the class.
+
+        Returns
+        -------
+        bool
+            ``True`` ports are created, ``False`` skip port generation. Default value is ``True``.
+
+        """
+        return self._generate_excitations
+
+    @generate_excitations.setter
+    def generate_excitations(self, value):
+        if isinstance(value, bool):
+            self._generate_excitations = value
 
 
 class SimulationConfigurationDc(object):

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -609,6 +609,7 @@ class SimulationConfigurationBatch(object):
             ``True`` or ``False. Default value is ``True``.
 
         """
+        return self._include_only_selected_nets
 
     @include_only_selected_nets.setter
     def include_only_selected_nets(self, value):

--- a/pyaedt/edb_core/hfss.py
+++ b/pyaedt/edb_core/hfss.py
@@ -1261,33 +1261,37 @@ class EdbHfss(object):
         simsetup_info.SimulationSettings.DefeatureSettings.DefeatureAbsLength = simulation_setup.defeature_abs_length
 
         try:
-            sweep = self._pedb.simsetupdata.SweepData(simulation_setup.sweep_name)
-            sweep.IsDiscrete = False
-            sweep.UseQ3DForDC = simulation_setup.use_q3d_for_dc
-            sweep.RelativeSError = simulation_setup.relative_error
-            sweep.InterpUsePortImpedance = False
-            sweep.EnforceCausality = simulation_setup.enforce_causality
-            # sweep.EnforceCausality = False
-            sweep.EnforcePassivity = simulation_setup.enforce_passivity
-            sweep.PassivityTolerance = simulation_setup.passivity_tolerance
-            sweep.Frequencies.Clear()
+            if simulation_setup.add_frequency_sweep:
+                self._logger.info("Adding frequency sweep")
+                sweep = self._pedb.simsetupdata.SweepData(simulation_setup.sweep_name)
+                sweep.IsDiscrete = False
+                sweep.UseQ3DForDC = simulation_setup.use_q3d_for_dc
+                sweep.RelativeSError = simulation_setup.relative_error
+                sweep.InterpUsePortImpedance = False
+                sweep.EnforceCausality = simulation_setup.enforce_causality
+                # sweep.EnforceCausality = False
+                sweep.EnforcePassivity = simulation_setup.enforce_passivity
+                sweep.PassivityTolerance = simulation_setup.passivity_tolerance
+                sweep.Frequencies.Clear()
 
-            if simulation_setup.sweep_type == SweepType.LogCount:  # setup_info.SweepType == 'DecadeCount'
-                self._setup_decade_count_sweep(
-                    sweep,
-                    str(simulation_setup.start_freq),
-                    str(simulation_setup.stop_freq),
-                    str(simulation_setup.decade_count),
-                )  # Added DecadeCount as a new attribute
+                if simulation_setup.sweep_type == SweepType.LogCount:  # setup_info.SweepType == 'DecadeCount'
+                    self._setup_decade_count_sweep(
+                        sweep,
+                        str(simulation_setup.start_freq),
+                        str(simulation_setup.stop_freq),
+                        str(simulation_setup.decade_count),
+                    )  # Added DecadeCount as a new attribute
 
+                else:
+                    sweep.Frequencies = self._pedb.simsetupdata.SweepData.SetFrequencies(
+                        simulation_setup.start_freq,
+                        simulation_setup.stop_freq,
+                        simulation_setup.step_freq,
+                    )
+
+                simsetup_info.SweepDataList.Add(sweep)
             else:
-                sweep.Frequencies = self._pedb.simsetupdata.SweepData.SetFrequencies(
-                    simulation_setup.start_freq,
-                    simulation_setup.stop_freq,
-                    simulation_setup.step_freq,
-                )
-
-            simsetup_info.SweepDataList.Add(sweep)
+                self._logger.info("Adding frequency sweep disabled")
 
         except Exception as err:
             self._logger.error("Exception in Sweep configuration: {0}".format(err))


### PR DESCRIPTION
adding more flexibility with SimulationConfiguration class
- add_frequency_sweep[bool] allowing custom frequency sweep assignement
- include_only_selected_nets only available when du_cutou_subdesign = False, to remove only nets which are not selected in signal and power nets 
- generate_excitations allowing custom port definition after build project