### PR TITLE
Remove redundant docstring in reset_timer

### DIFF
--- a/pyaedt/aedt_logger.py
+++ b/pyaedt/aedt_logger.py
@@ -285,7 +285,6 @@ class AedtLogger(object):
         -------
 
         """
-        """Reset actual timer from now."""
         if time_val:
             self._timer = time_val
         else:


### PR DESCRIPTION
This fix addresses a small mistake in the docstring of the reset_timer method. It looks like there was an extra docstring added that is redundant given the one above it.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!

