### PR TITLE
Preserve Spice Pins during cutout in EDB

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -649,6 +649,8 @@ class TestClass(BasisTest, object):
         target_path = os.path.join(self.local_scratch.path, "ANSYS-HSD_V1_cutou2.aedb")
         self.local_scratch.copyfolder(source_path, target_path)
         edbapp = Edb(target_path, edbversion=desktop_version)
+        spice_path = os.path.join(local_path, "example_models", test_subfolder, "GRM32_DC0V_25degC.mod")
+        edbapp.components.instances["R8"].assign_spice_model(spice_path)
         edbapp.nets.nets
         if is_ironpython:
             assert not edbapp.cutout(
@@ -664,6 +666,7 @@ class TestClass(BasisTest, object):
                 extent_type="Bounding",
                 number_of_threads=4,
                 extent_defeature=0.001,
+                preserve_components_with_model=True,
             )
             assert "A0_N" not in edbapp.nets.nets
             assert isinstance(edbapp.nets.find_and_fix_disjoint_nets("GND", order_by_area=True), list)

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1501,7 +1501,7 @@ class Edb(Database):
             Default is `10`.
         preserve_components_with_model : bool, optional
             Whether to preserve all pins of components that have associated models (Spice or NPort).
-            It works only in pyaedt cutout (except point list).
+            This parameter is applicable only for a PyAEDT cutout (except point list).
 
 
         Returns

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1437,7 +1437,7 @@ class Edb(Database):
         preserve_components_with_model=False,
     ):
         """Create a cutout using an approach entirely based on PyAEDT.
-        This new method replaces all legacy cutout methods in pyaedt.
+        This method replaces all legacy cutout methods in PyAEDT.
         It does in sequence:
         - delete all nets not in list,
         - create a extent of the nets,

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1950,16 +1950,6 @@ class Edb(Database):
                             for prim in list_prims:
                                 if not prim.IsNull():
                                     poly_to_create.append([prim, prim_1.layer_name, net, list_void])
-                            #
-                            # list_voids = intersect(p, voids_data)
-                            # for void_intersected in list_voids:
-                            #     if not void_intersected.IsNull():
-                            #         int_data_2 = p.GetIntersectionType(void_intersected)
-                            #         if int_data_2 == 2:
-                            #             list_void.append(void_intersected)
-                            #         elif int_data == 1 or int_data_2 > 2:
-                            #             p = subtract(p, void_intersected)[0]
-                            # poly_to_create.append([p, prim_1.layer_name, net, list_void])
                         else:
                             poly_to_create.append([p, prim_1.layer_name, net, list_void])
 

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1497,7 +1497,7 @@ class Edb(Database):
             The trace width search is limited to nets with ports attached. Works only if `use_pyaedt_cutout`.
             Default is `0` to disable the search.
         maximum_iterations : int, optional
-            Maximum number of iterations before stopping in searching for a cutout with an error.
+            Maximum number of iterations before stopping a search for a cutout with an error.
             Default is `10`.
         preserve_components_with_model : bool, optional
             Whether to preserve all pins of components that have associated models (Spice or NPort).

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1436,7 +1436,7 @@ class Edb(Database):
         maximum_iterations=10,
         preserve_components_with_model=False,
     ):
-        """Create a cutout using an approach entirely based on pyaedt.
+        """Create a cutout using an approach entirely based on PyAEDT.
         This new method replaces all legacy cutout methods in pyaedt.
         It does in sequence:
         - delete all nets not in list,

--- a/pyaedt/edb_core/components.py
+++ b/pyaedt/edb_core/components.py
@@ -1516,7 +1516,8 @@ class Components(object):
         Parameters
         ----------
         deactivate_only : bool, optional
-            Whether to delete the components or keep them and deactivate only. Default is ``False`` to delete them.
+            Whether to only deactivate RLC components with a single point rather than
+            delete them. The default is ``False``, in which case they are deleted.
 
         Returns
         -------

--- a/pyaedt/edb_core/components.py
+++ b/pyaedt/edb_core/components.py
@@ -1509,8 +1509,13 @@ class Components(object):
             return pingroup
 
     @pyaedt_function_handler()
-    def delete_single_pin_rlc(self):
+    def delete_single_pin_rlc(self, deactivate_only=False):
         """Delete all RLC components with a single pin.
+
+        Parameters
+        ----------
+        deactivate_only : bool, optional
+            Whether to delete the components or keep them and deactivate only. Default is ``False`` to delete them.
 
         Returns
         -------
@@ -1530,9 +1535,13 @@ class Components(object):
         deleted_comps = []
         for comp, val in self.instances.items():
             if val.numpins < 2 and val.type in ["Resistor", "Capacitor", "Inductor"]:
-                val.edbcomponent.Delete()
-                deleted_comps.append(comp)
-        self.refresh_components()
+                if deactivate_only:
+                    val.is_enabled = False
+                else:
+                    val.edbcomponent.Delete()
+                    deleted_comps.append(comp)
+        if not deactivate_only:
+            self.refresh_components()
         self._pedb._logger.info("Deleted {} components".format(len(deleted_comps)))
 
         return deleted_comps

--- a/pyaedt/edb_core/components.py
+++ b/pyaedt/edb_core/components.py
@@ -1510,6 +1510,7 @@ class Components(object):
 
     @pyaedt_function_handler()
     def delete_single_pin_rlc(self, deactivate_only=False):
+        # type: (bool) -> list
         """Delete all RLC components with a single pin.
 
         Parameters


### PR DESCRIPTION
Added new argument to cutout method working only on pyaedt cutout which actually checks all components and find pins on components with associated models (spice, sparam, netlist) and preserve them to avoid errors in siwave simulation.

Option is set by default to False to preserve actual behaviour.
Added an argument to delete_single_pin_rlc to preserve the component and deactivate it
#3165 & #3164
