### PR TITLE
two new functions to deal with diff pairs into 3DL

### DIFF
--- a/_unittest/test_41_3dlayout_modeler.py
+++ b/_unittest/test_41_3dlayout_modeler.py
@@ -719,6 +719,7 @@ class TestClass(BasisTest, object):
 
     @pytest.mark.skipif(is_linux, reason="Bug on linux")
     def test_90_set_differential_pairs(self):
+        assert not self.aedtapp.get_differential_pairs()
         assert self.hfss3dl.set_differential_pair(
             positive_terminal="Port3",
             negative_terminal="Port4",
@@ -730,6 +731,8 @@ class TestClass(BasisTest, object):
             matched=False,
         )
         assert self.hfss3dl.set_differential_pair(positive_terminal="Port3", negative_terminal="Port5")
+        assert self.hfss3dl.get_differential_pairs()
+        assert self.hfss3dl.get_traces_for_plot(differential_pairs=["Diff1"], category="dB(S")
 
     @pytest.mark.skipif(is_linux, reason="Bug on linux")
     def test_91_load_and_save_diff_pair_file(self):

--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -488,70 +488,70 @@ class Analysis(Design, object):
                             list_output.append(value)
         return list_output
         
-	@pyaedt_function_handler()
-	def get_diff_traces_for_plot(
-		self,
-		difflist=[],
-		get_self_terms=True,
-		get_mutual_terms=True,
-		first_element_filter=None,
-		second_element_filter=None,
-		category="dB(S",
-	):
-		"""Retrieve a list of traces of specified designs ready to use in plot reports.
+    @pyaedt_function_handler()
+    def get_diff_traces_for_plot(
+        self,
+        difflist=[],
+        get_self_terms=True,
+        get_mutual_terms=True,
+        first_element_filter=None,
+        second_element_filter=None,
+        category="dB(S",
+    ):
+        """Retrieve a list of traces of specified designs ready to use in plot reports.
 
-		Parameters
-		----------
-		difflist : list
-			List of differential pairs defined via the 3DL UI. The default is ``[]``. For example, ``["Diff_RX0"]``.
-		get_self_terms : bool, optional
-			Whether to return self terms. The default is ``True``.
-		get_mutual_terms : bool, optional
-			Whether to return mutual terms. The default is ``True``.
-		first_element_filter : str, optional
-			Filter to apply to the first element of the equation.
-			This parameter accepts ``*`` and ``?`` as special characters. The default is ``None``.
-		second_element_filter : str, optional
-			Filter to apply to the second element of the equation.
-			This parameter accepts ``*`` and ``?`` as special characters. The default is ``None``.
-		category : str
-			Plot category name as in the report (including operator).
-			The default is ``"dB(S"``,  which is the plot category name for capacitance.
+        Parameters
+        ----------
+        difflist : list
+            List of differential pairs defined via the 3DL UI. The default is ``[]``. For example, ``["Diff_RX0"]``.
+        get_self_terms : bool, optional
+            Whether to return self terms. The default is ``True``.
+        get_mutual_terms : bool, optional
+            Whether to return mutual terms. The default is ``True``.
+        first_element_filter : str, optional
+            Filter to apply to the first element of the equation.
+            This parameter accepts ``*`` and ``?`` as special characters. The default is ``None``.
+        second_element_filter : str, optional
+            Filter to apply to the second element of the equation.
+            This parameter accepts ``*`` and ``?`` as special characters. The default is ``None``.
+        category : str
+            Plot category name as in the report (including operator).
+            The default is ``"dB(S"``,  which is the plot category name for capacitance.
 
-		Returns
-		-------
-		list
-			List of traces of specified designs ready to use in plot reports.
+        Returns
+        -------
+        list
+            List of traces of specified designs ready to use in plot reports.
 
-		Examples
-		--------
-		>>> from pyaedt import Hfss3dLayout
-		>>> hfss = Hfss3dLayout(project_path)
-		>>> hfss.get_diff_traces_for_plot(difflist=['Diff_U0_data0','Diff_U0_data1','Diff_U1_data0','Diff_U1_data1'],first_element_filter="*_U1_data?",
-		...                           second_element_filter="*_U0_*", category="dB(S")
-		"""
-		if len(difflist) == 0:
-			self.logger.error("difflist argument cannot be empty.")
-			return False
-		if not first_element_filter:
-			first_element_filter = "*"
-		if not second_element_filter:
-			second_element_filter = "*"
-		list_output = []
-		end_str = ")" * (category.count("(") + 1)
-		if get_self_terms:
-			for el in difflist:
-				value = "{}({},{}{}".format(category, el, el, end_str)
-				if filter_tuple(value, first_element_filter, second_element_filter):
-					list_output.append(value)
-		if get_mutual_terms:
-			for el1 in difflist:
-				for el2 in difflist:
-					if el1 != el2:
-						value = "{}({},{}{}".format(category, el1, el2, end_str)
-						if filter_tuple(value, first_element_filter, second_element_filter):
-							list_output.append(value)
-		return list_output
+        Examples
+        --------
+        >>> from pyaedt import Hfss3dLayout
+        >>> hfss = Hfss3dLayout(project_path)
+        >>> hfss.get_diff_traces_for_plot(difflist=['Diff_U0_data0','Diff_U0_data1','Diff_U1_data0','Diff_U1_data1'],first_element_filter="*_U1_data?",
+        ...                           second_element_filter="*_U0_*", category="dB(S")
+        """
+        if len(difflist) == 0:
+            self.logger.error("difflist argument cannot be empty.")
+            return False
+        if not first_element_filter:
+            first_element_filter = "*"
+        if not second_element_filter:
+            second_element_filter = "*"
+        list_output = []
+        end_str = ")" * (category.count("(") + 1)
+        if get_self_terms:
+            for el in difflist:
+                value = "{}({},{}{}".format(category, el, el, end_str)
+                if filter_tuple(value, first_element_filter, second_element_filter):
+                    list_output.append(value)
+        if get_mutual_terms:
+            for el1 in difflist:
+                for el2 in difflist:
+                    if el1 != el2:
+                        value = "{}({},{}{}".format(category, el1, el2, end_str)
+                        if filter_tuple(value, first_element_filter, second_element_filter):
+                            list_output.append(value)
+        return list_output
         
     @pyaedt_function_handler()
     def list_of_variations(self, setup_name=None, sweep_name=None):

--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -487,7 +487,7 @@ class Analysis(Design, object):
                         if filter_tuple(value, first_element_filter, second_element_filter):
                             list_output.append(value)
         return list_output
-        
+
     @pyaedt_function_handler()
     def get_diff_traces_for_plot(
         self,
@@ -552,7 +552,7 @@ class Analysis(Design, object):
                         if filter_tuple(value, first_element_filter, second_element_filter):
                             list_output.append(value)
         return list_output
-        
+
     @pyaedt_function_handler()
     def list_of_variations(self, setup_name=None, sweep_name=None):
         """Retrieve a list of active variations for input setup.

--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -463,8 +463,8 @@ class Analysis(Design, object):
 
         Examples
         --------
-        >>> from pyaedt import Q3d
-        >>> hfss = hfss(project_path)
+        >>> from pyaedt import Hfss3dLayout
+        >>> hfss = Hfss3dLayout(project_path)
         >>> hfss.get_traces_for_plot(first_element_filter="Bo?1",
         ...                           second_element_filter="GND*", category="dB(S")
         """
@@ -487,7 +487,72 @@ class Analysis(Design, object):
                         if filter_tuple(value, first_element_filter, second_element_filter):
                             list_output.append(value)
         return list_output
+        
+	@pyaedt_function_handler()
+	def get_diff_traces_for_plot(
+		self,
+		difflist=[],
+		get_self_terms=True,
+		get_mutual_terms=True,
+		first_element_filter=None,
+		second_element_filter=None,
+		category="dB(S",
+	):
+		"""Retrieve a list of traces of specified designs ready to use in plot reports.
 
+		Parameters
+		----------
+		difflist : list
+			List of differential pairs defined via the 3DL UI. The default is ``[]``. For example, ``["Diff_RX0"]``.
+		get_self_terms : bool, optional
+			Whether to return self terms. The default is ``True``.
+		get_mutual_terms : bool, optional
+			Whether to return mutual terms. The default is ``True``.
+		first_element_filter : str, optional
+			Filter to apply to the first element of the equation.
+			This parameter accepts ``*`` and ``?`` as special characters. The default is ``None``.
+		second_element_filter : str, optional
+			Filter to apply to the second element of the equation.
+			This parameter accepts ``*`` and ``?`` as special characters. The default is ``None``.
+		category : str
+			Plot category name as in the report (including operator).
+			The default is ``"dB(S"``,  which is the plot category name for capacitance.
+
+		Returns
+		-------
+		list
+			List of traces of specified designs ready to use in plot reports.
+
+		Examples
+		--------
+		>>> from pyaedt import Hfss3dLayout
+		>>> hfss = Hfss3dLayout(project_path)
+		>>> hfss.get_diff_traces_for_plot(difflist=['Diff_U0_data0','Diff_U0_data1','Diff_U1_data0','Diff_U1_data1'],first_element_filter="*_U1_data?",
+		...                           second_element_filter="*_U0_*", category="dB(S")
+		"""
+		if len(difflist) == 0:
+			self.logger.error("difflist argument cannot be empty.")
+			return False
+		if not first_element_filter:
+			first_element_filter = "*"
+		if not second_element_filter:
+			second_element_filter = "*"
+		list_output = []
+		end_str = ")" * (category.count("(") + 1)
+		if get_self_terms:
+			for el in difflist:
+				value = "{}({},{}{}".format(category, el, el, end_str)
+				if filter_tuple(value, first_element_filter, second_element_filter):
+					list_output.append(value)
+		if get_mutual_terms:
+			for el1 in difflist:
+				for el2 in difflist:
+					if el1 != el2:
+						value = "{}({},{}{}".format(category, el1, el2, end_str)
+						if filter_tuple(value, first_element_filter, second_element_filter):
+							list_output.append(value)
+		return list_output
+        
     @pyaedt_function_handler()
     def list_of_variations(self, setup_name=None, sweep_name=None):
         """Retrieve a list of active variations for input setup.

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -1656,9 +1656,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         return True
 
     @pyaedt_function_handler()
-    def get_ui_defined_diff_pairs(
-        self
-    ):
+    def get_ui_defined_diff_pairs(self):
         """Retrieve a list of differential pairs using existing ports.
 
         Parameters
@@ -1675,12 +1673,12 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         >>> from pyaedt import Hfss3dLayout
         >>> hfss = Hfss3dLayout(project_path)
         >>> hfss.get_defined_diff_pairs()
-        
+
         References
         ----------
         Under 3D Layout UI, RMB click on Excitations > Differential Pairs... to obtain differential pairs
         """
-        
+
         list_output = []
         if len(self.excitations) != 0:
             tmpfile1 = os.path.join(self.working_directory, generate_unique_name("tmp"))
@@ -1688,17 +1686,17 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
             if os.stat(tmpfile1).st_size != 0:
                 with open_file(tmpfile1, "r") as fi:
                     fi_lst = fi.readlines()
-                list_output = [line.split(',')[4] for line in fi_lst]
+                list_output = [line.split(",")[4] for line in fi_lst]
             else:
                 self.logger.warning("ERROR: No differential pairs defined under Excitations > Differential Pairs...")
-            
+
             try:
                 os.remove(tmpfile1)
             except:  # pragma: no cover
                 self.logger.warning("ERROR: Cannot remove temp files.")
-        
+
         return list_output
-    
+
     @pyaedt_function_handler()
     def load_diff_pairs_from_file(self, filename):
         """Load differtential pairs definition from file.

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -1656,6 +1656,50 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         return True
 
     @pyaedt_function_handler()
+    def get_ui_defined_diff_pairs(
+        self
+    ):
+        """Retrieve a list of differential pairs using existing ports.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        list
+            List of differential pairs.
+
+        Examples
+        --------
+        >>> from pyaedt import Hfss3dLayout
+        >>> hfss = Hfss3dLayout(project_path)
+        >>> hfss.get_defined_diff_pairs()
+        
+        References
+        ----------
+        Under 3D Layout UI, RMB click on Excitations > Differential Pairs... to obtain differential pairs
+        """
+        
+        list_output = []
+        if len(self.excitations) != 0:
+            tmpfile1 = os.path.join(self.working_directory, generate_unique_name("tmp"))
+            self.oexcitation.SaveDiffPairsToFile(tmpfile1)
+            if os.stat(tmpfile1).st_size != 0:
+                with open_file(tmpfile1, "r") as fi:
+                    fi_lst = fi.readlines()
+                list_output = [line.split(',')[4] for line in fi_lst]
+            else:
+                self.logger.warning("ERROR: No differential pairs defined under Excitations > Differential Pairs...")
+            
+            try:
+                os.remove(tmpfile1)
+            except:  # pragma: no cover
+                self.logger.warning("ERROR: Cannot remove temp files.")
+        
+        return list_output
+    
+    @pyaedt_function_handler()
     def load_diff_pairs_from_file(self, filename):
         """Load differtential pairs definition from file.
 

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -1656,8 +1656,9 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         return True
 
     @pyaedt_function_handler()
-    def get_ui_defined_diff_pairs(self):
-        """Retrieve a list of differential pairs using existing ports.
+    def get_differential_pairs(self):
+        # type: () -> list
+        """Get the list defined differential pairs.
 
         Parameters
         ----------
@@ -1671,19 +1672,15 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         Examples
         --------
         >>> from pyaedt import Hfss3dLayout
-        >>> hfss = Hfss3dLayout(project_path)
+        >>> hfss = Hfss3dLayout()
         >>> hfss.get_defined_diff_pairs()
-
-        References
-        ----------
-        Under 3D Layout UI, RMB click on Excitations > Differential Pairs... to obtain differential pairs
         """
 
         list_output = []
         if len(self.excitations) != 0:
             tmpfile1 = os.path.join(self.working_directory, generate_unique_name("tmp"))
-            self.oexcitation.SaveDiffPairsToFile(tmpfile1)
-            if os.stat(tmpfile1).st_size != 0:
+            file_flag = self.save_diff_pairs_to_file(tmpfile1)
+            if file_flag and os.stat(tmpfile1).st_size != 0:
                 with open_file(tmpfile1, "r") as fi:
                     fi_lst = fi.readlines()
                 list_output = [line.split(",")[4] for line in fi_lst]
@@ -1699,6 +1696,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
 
     @pyaedt_function_handler()
     def load_diff_pairs_from_file(self, filename):
+        # type: (str) -> bool
         """Load differtential pairs definition from file.
 
         You can use the ``save_diff_pairs_to_file`` method to obtain the file format.
@@ -1738,9 +1736,10 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
 
     @pyaedt_function_handler()
     def save_diff_pairs_to_file(self, filename):
+        # type: (str) -> bool
         """Save differtential pairs definition to a file.
 
-        If a filee with the specified name already exists, it is overwritten.
+        If a file with the specified name already exists, it is overwritten.
 
         Parameters
         ----------


### PR DESCRIPTION
Hi guys,
A customer was trying to use the function aedtapp.get_traces_for_plot() but this function only checks single-ended ports available on 3DL. Since he needed to check for differential pairs that were created via the UI, under Excitations > Differential Pairs..., I added two new functions that get the list of diff pairs defined and that uses this list as input to create traces for plot. 
Please consider.
Kind regards,
Felipe