### PR TITLE
Nnetake make flexible unit of ambient temp

### DIFF
--- a/_unittest/test_98_Icepak.py
+++ b/_unittest/test_98_Icepak.py
@@ -258,6 +258,8 @@ class TestClass(BasisTest, object):
 
     def test_14_edit_design_settings(self):
         assert self.aedtapp.edit_design_settings(gravityDir=1)
+        assert self.aedtapp.edit_design_settings(ambtemp=20)
+        assert self.aedtapp.edit_design_settings(ambtemp="325kel")
 
     def test_15_insert_new_icepak(self):
         self.aedtapp.insert_design("Solve")

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -1420,8 +1420,10 @@ class Icepak(FieldAnalysis3D):
 
         >>> oDesign.SetDesignSettings
         """
-        if ambtemp and isinstance(ambtemp, str):
+        if ambtemp and not isinstance(ambtemp, str):
             AmbientTemp = str(ambtemp) + "cel"
+        else:
+            AmbientTemp = ambtemp
         #
         # Configure design settings for gravity etc
         IceGravity = ["X", "Y", "Z"]

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -1394,7 +1394,7 @@ class Icepak(FieldAnalysis3D):
             The default is ``0``.
         ambtemp : float, str, optional
             Ambient temperature. The default is ``20``.
-            The default unit is celcius for float or string including unit definition is accepted, e.g. ``325kel``.
+            The default unit is celsius for float or string including unit definition is accepted, e.g. ``325kel``.
         performvalidation : bool, optional
             Whether to perform validation. The default is ``False``.
         CheckLevel : str, optional

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -1392,8 +1392,9 @@ class Icepak(FieldAnalysis3D):
         gravityDir : int, optional
             Gravity direction from -X to +Z. Options are ``0`` to ``5``.
             The default is ``0``.
-        ambtemp : optional
-            Ambient temperature. The default is ``22``.
+        ambtemp : float, str, optional
+            Ambient temperature. The default is ``20``.
+            The default unit is celcius for float or string including unit definition is accepted, e.g. ``325kel``.
         performvalidation : bool, optional
             Whether to perform validation. The default is ``False``.
         CheckLevel : str, optional
@@ -1419,7 +1420,8 @@ class Icepak(FieldAnalysis3D):
 
         >>> oDesign.SetDesignSettings
         """
-        AmbientTemp = str(ambtemp) + "cel"
+        if ambtemp and isinstance(ambtemp, str):
+            AmbientTemp = str(ambtemp) + "cel"
         #
         # Configure design settings for gravity etc
         IceGravity = ["X", "Y", "Z"]


### PR DESCRIPTION
In this PR I have refactored a method edit_design_settings of Icepak to accept ambient temperature with different units maintaining the reverse compatibility.