### PR TITLE
HFSS seems to use "farad", not "F" for capacitance units on lumped RLC boundary

### DIFF
--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -2880,7 +2880,7 @@ class Hfss(FieldAnalysis3D, object):
                 props["Inductance"] = str(Lvalue) + "H"
             if Cvalue:
                 props["UseCap"] = True
-                props["Capacitance"] = str(Cvalue) + "F"
+                props["Capacitance"] = str(Cvalue) + "farad"
 
             return self._create_boundary(sourcename, props, "Lumped RLC")
         return False


### PR DESCRIPTION
Lumped RLC boundaries were previously showing up without a unit for capacitance inside HFSS. This PR fixes that issue by correcting the units.