### PR TITLE
rename impedance multiplier parameter for clear usage

### DIFF
--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -5792,14 +5792,14 @@ class Hfss(FieldAnalysis3D, object):
             return False
 
     @pyaedt_function_handler()
-    def set_impedance_multiplier(self, impedance):
+    def set_impedance_multiplier(self, multiplier):
         # type: (float) -> bool
         """Set impedance multiplier.
 
         Parameters
         ----------
-        impedance : float
-            Impedance.
+        multiplier : float
+            Impedance Multiplier.
 
         Returns
         -------
@@ -5827,7 +5827,7 @@ class Hfss(FieldAnalysis3D, object):
             if self.solution_type not in ["Modal"]:
                 self.logger.error("Symmetry is only available with 'Modal' solution type.")
                 return False
-            self.oboundary.ChangeImpedanceMult(impedance)
+            self.oboundary.ChangeImpedanceMult(multiplier)
             return True
         except:
             return False


### PR DESCRIPTION
Fix #3326 