### PR TITLE
added comparison of versions to choose the python version

### DIFF
--- a/pyaedt_with_IDE.bat
+++ b/pyaedt_with_IDE.bat
@@ -77,13 +77,18 @@ set aedt_path=potato
 if [%specified_python%]==[y] (
 	aedt_path=!argVec[%python_path_index%]!
 ) else (
-	set aedt_path=!%chosen_root%!\commonfiles\CPython\3_7\winx64\Release\python
+	set python_ver=3_10
+	if %version% leq 231 (
+		set python_ver=3_7
+	)
+	echo using python version !python_ver!.
+	set aedt_path=!%chosen_root%!\commonfiles\CPython\!python_ver!\winx64\Release\python
 	echo Built-in Python is !aedt_path!.
 )
+
 set aedt_path=!aedt_path:"=!
 
 echo %aedt_path%
-
 
 
 set pyaedt_install_dir=%APPDATA%\pyaedt_env_ide\v%version%


### PR DESCRIPTION
For version 2023 R2 
The installation buttons in AEDT are still `Beta` hence it is necessary to provide the batch file for the customers.

Added just comparison of Ansys versions to choose from either `3_7` or  `3_10`   