### PR TITLE
Automatically detect obj type for mesh priority 

### DIFF
--- a/pyaedt/modules/MeshIcepak.py
+++ b/pyaedt/modules/MeshIcepak.py
@@ -604,7 +604,7 @@ class IcepakMesh(object):
                 "PriorityNumber:=",
                 i,
                 "PriorityListType:=",
-                "3D",
+                ["2D", "3D"][int(self._app.modeler[new_obj_list[0]].is3d)],
             ]
             self._priorities_args.append(prio)
             args += self._priorities_args


### PR DESCRIPTION
Mixed (2d and 3d) priority assignment is not supported, that's why checking the first element of the list should be enough.