### PR TITLE
fix: typo in the ci-cd dev docs indexing

### DIFF
--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -58,7 +58,6 @@ jobs:
 
   doc-index-dev:
     name: "Deploy dev docs index"
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs: docs_upload
     steps:
@@ -73,7 +72,7 @@ jobs:
         uses: ansys/actions/doc-deploy-index@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev
-          index-name: pyaedt-v${{ env.VERSION_MEILI }}
+          index-name: pyaedt-vdev
           host-url: ${{ vars.MEILISEARCH_HOST_URL }}
           api-key: ${{ env.MEILISEARCH_API_KEY }}
           pymeilisearchopts: --stop_urls \"EDBAPI\" # Add EDB API as another index to show it in dropdown button
@@ -82,7 +81,7 @@ jobs:
         uses: ansys/actions/doc-deploy-index@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev/EDBAPI/
-          index-name: pyedb-v${{ env.VERSION_MEILI }}
+          index-name: pyedb-vdev
           host-url: ${{ vars.MEILISEARCH_HOST_URL }}
           api-key: ${{ env.MEILISEARCH_API_KEY }}
           doc-artifact-name: documentation-html/EDBAPI # Add only EDB API to index


### PR DESCRIPTION
- remove the conditional workflow and fix the typo in naming of nightly dev docs indexing