### PR TITLE
add support to choose the notebook dir using env variable

### DIFF
--- a/pyaedt/misc/Jupyter.py_build
+++ b/pyaedt/misc/Jupyter.py_build
@@ -36,6 +36,7 @@ def main():
     target = os.path.join(proj_dir, generate_unique_name("pyaedt", ".ipynb", n=3))
     check_file(jupyter_exe)
     check_file(template)
+    notebook_dir = os.environ.get("AEDT_NOTEBOOK_DIR",None)
 
     with open(template, "r") as source:
         with open(target, "w") as t:
@@ -55,11 +56,16 @@ def main():
             "{}".format(edt_root),
         ]
         os.environ["LD_LIBRARY_PATH"] = ":".join(ld_library_path_dirs_to_add) + ":" + os.getenv("LD_LIBRARY_PATH", "")
-
-        command = [jupyter_exe, "lab", target]
+        if notebook_dir:
+            command = [jupyter_exe, "lab", target,"--notebook-dir",notebook_dir]
+        else:
+            command = [jupyter_exe, "lab", target]
         subprocess.Popen(command)
     else:
-        command = ['"{}"'.format(jupyter_exe), "lab", '"{}"'.format(target)]
+        if notebook_dir:
+            command = ['"{}"'.format(jupyter_exe), "lab", '"{}"'.format(target),"--notebook-dir",'"{0}"'.format(notebook_dir)] 
+        else:
+            command = ['"{}"'.format(jupyter_exe), "lab", '"{}"'.format(target)]
         subprocess.Popen(" ".join(command))
 
 


### PR DESCRIPTION
- if user want to open the jupyter lab in any other directory using just button that are available, it is not possible
- added support for settings a environment variable with which user can set one directory for all notebooks and still use the buttons in AEDT Desktop
- `AEDT_NOTEBOOK_DIR` is the name of the variable