### PR TITLE
Create port on path

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -1344,8 +1344,9 @@ class TestClass:
         assert edb.hfss.create_edge_port_on_polygon(
             polygon=port_poly, terminal_point=port_location, reference_layer="gnd"
         )
-        edb.layout.primitives[1].create_edge_port("new_wave_port")
-        edb.layout.primitives[1].create_edge_port("new_gap_port", "start", "gap")
+        sig = edb.modeler.create_trace([[0, 0], ["9mm", 0]], "TOP", "1mm", "SIG", "Flat", "Flat")
+        assert sig.create_edge_port("pcb_port", "end", "Wave", None, 8, 8)
+        assert sig.create_edge_port("pcb_port", "start", "gap")
         edb.close()
 
     def test_108_create_dc_simulation(self):

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -1344,6 +1344,8 @@ class TestClass:
         assert edb.hfss.create_edge_port_on_polygon(
             polygon=port_poly, terminal_point=port_location, reference_layer="gnd"
         )
+        edb.layout.primitives[1].create_edge_port("new_wave_port")
+        edb.layout.primitives[1].create_edge_port("new_gap_port", "start", "gap")
         edb.close()
 
     def test_108_create_dc_simulation(self):

--- a/pyaedt/edb_core/edb_data/primitives_data.py
+++ b/pyaedt/edb_core/edb_data/primitives_data.py
@@ -753,6 +753,55 @@ class EdbPath(EDBPrimitives, PathDotNet):
         if cloned_path:
             return cloned_path
 
+    #@pyaedt_function_handler
+    @pyaedt_function_handler
+    def create_edge_port(self, name, position="End", port_type="Wave",
+                         reference_layer=None,
+                         horizontal_extent_factor=5,
+                         vertical_extent_factor=3,
+                         pec_launch_width="0.01mm"):
+        """
+
+        Parameters
+        ----------
+        name : str
+            Name of the port.
+        position : str, optional
+            Position of the port. The default is ``"End"``, in which case the port is created at the end of the trace.
+            Options are ``"Start"`` and ``"End"``.
+        port_type : str, optional
+            Type of the port. The default is ``"Wave"``, in which case a wave port is created. Options are ``"Wave"``
+             and ``"Gap"``.
+        reference_layer : str, optional
+            Name of the references layer. The default is ``None``. Only available for gap port.
+        horizontal_extent_factor: int, optional
+            Horizontal extent factor of the wave port. The default is ``5``.
+        vertical_extent_factor : int, optional
+            Vertical extent factor of the wave port. The default is ``3``.
+        pec_launch_width : float, str, optional
+            Perfect electrical conductor width of the wave port. The default is ``"0.01mm"``.
+
+        Returns
+        -------
+            :class:`pyaedt.edb_core.edb_data.sources.ExcitationPorts`
+
+        Examples
+        --------
+        >>> edbapp = pyaedt.Edb("myproject.aedb")
+        >>> sig = appedb.modeler.create_trace([[0, 0], ["9mm", 0]], "TOP", "1mm", "SIG", "Flat", "Flat")
+        >>> sig..create_edge_port("pcb_port", "end", "Wave", None, 8, 8)
+
+        """
+        center_line = self.get_center_line()
+        pos = center_line[-1] if position.lower()=="end" else center_line[0]
+
+        if port_type.lower() == "wave":
+            return self._app.hfss.create_wave_port(self.id, pos, name, 50, horizontal_extent_factor,
+            vertical_extent_factor,
+            pec_launch_width)
+        else:
+            return self._app.hfss.create_edge_port_vertical(self.id, pos, name, 50, reference_layer)
+
 
 class EdbRectangle(EDBPrimitives, RectangleDotNet):
     def __init__(self, raw_primitive, core_app):

--- a/pyaedt/edb_core/edb_data/primitives_data.py
+++ b/pyaedt/edb_core/edb_data/primitives_data.py
@@ -753,13 +753,18 @@ class EdbPath(EDBPrimitives, PathDotNet):
         if cloned_path:
             return cloned_path
 
-    #@pyaedt_function_handler
+    # @pyaedt_function_handler
     @pyaedt_function_handler
-    def create_edge_port(self, name, position="End", port_type="Wave",
-                         reference_layer=None,
-                         horizontal_extent_factor=5,
-                         vertical_extent_factor=3,
-                         pec_launch_width="0.01mm"):
+    def create_edge_port(
+        self,
+        name,
+        position="End",
+        port_type="Wave",
+        reference_layer=None,
+        horizontal_extent_factor=5,
+        vertical_extent_factor=3,
+        pec_launch_width="0.01mm",
+    ):
         """
 
         Parameters
@@ -793,12 +798,12 @@ class EdbPath(EDBPrimitives, PathDotNet):
 
         """
         center_line = self.get_center_line()
-        pos = center_line[-1] if position.lower()=="end" else center_line[0]
+        pos = center_line[-1] if position.lower() == "end" else center_line[0]
 
         if port_type.lower() == "wave":
-            return self._app.hfss.create_wave_port(self.id, pos, name, 50, horizontal_extent_factor,
-            vertical_extent_factor,
-            pec_launch_width)
+            return self._app.hfss.create_wave_port(
+                self.id, pos, name, 50, horizontal_extent_factor, vertical_extent_factor, pec_launch_width
+            )
         else:
             return self._app.hfss.create_edge_port_vertical(self.id, pos, name, 50, reference_layer)
 

--- a/pyaedt/edb_core/edb_data/primitives_data.py
+++ b/pyaedt/edb_core/edb_data/primitives_data.py
@@ -779,7 +779,7 @@ class EdbPath(EDBPrimitives, PathDotNet):
              and ``"Gap"``.
         reference_layer : str, optional
             Name of the references layer. The default is ``None``. Only available for gap port.
-        horizontal_extent_factor: int, optional
+        horizontal_extent_factor : int, optional
             Horizontal extent factor of the wave port. The default is ``5``.
         vertical_extent_factor : int, optional
             Vertical extent factor of the wave port. The default is ``3``.


### PR DESCRIPTION
Improve usability. Now user can create port from trace object.
```
sig = appedb.modeler.create_trace([[0, 0], ["9mm", 0]], "TOP", "1mm", "SIG", "Flat", "Flat")
sig.create_edge_port("pcb_port", "end", "Wave", None, 8, 8)
```
