### PR TITLE
Fix issue with setting Object Priorities on 2D objects in Icepak

### DIFF
--- a/pyaedt/modules/MeshIcepak.py
+++ b/pyaedt/modules/MeshIcepak.py
@@ -589,7 +589,7 @@ class IcepakMesh(object):
             non_user_defined_component_parts = self._app.modeler.oeditor.GetChildNames()
             new_obj_list = []
             for comp in obj_list:
-                if comp != "Region" and comp in non_user_defined_component_parts and self._app.modeler[comp].is3d:
+                if comp != "Region" and comp in non_user_defined_component_parts:
                     new_obj_list.append(comp)
 
             objects = ", ".join(new_obj_list)


### PR DESCRIPTION
This PR was completed a while back to support setting priorities on 2D objects:

https://github.com/ansys/pyaedt/pull/3435/

However it still does not work, likely because *new_obj_list* will be empty if we send in a list of all 2D objects, due to the check further up: 

<pre>
            for comp in obj_list:
                if comp != "Region" and comp in non_user_defined_component_parts and <b>self._app.modeler[comp].is3d</b>:
                    new_obj_list.append(comp)
</pre>

This PR removes the is3D check. 