### PR TITLE
Improved documentation and support for number as AEDT version

### DIFF
--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -38,7 +38,7 @@ class FieldAnalysis3D(Analysis, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT  to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     non_graphical : bool, optional

--- a/pyaedt/application/Analysis3DLayout.py
+++ b/pyaedt/application/Analysis3DLayout.py
@@ -33,7 +33,7 @@ class FieldAnalysis3DLayout(Analysis):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT  to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional

--- a/pyaedt/application/AnalysisMaxwellCircuit.py
+++ b/pyaedt/application/AnalysisMaxwellCircuit.py
@@ -18,7 +18,7 @@ class AnalysisMaxwellCircuit(Analysis):
         Name of the design to select. The default is ``None``, in
         which case an attempt is made to get an active design. If no
         designs are present, an empty design is created.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``. If ``None``,
         the active setup is used or the latest installed version is
         used.

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -82,7 +82,7 @@ class Design(AedtObjects):
     solution_type : str, optional
         Solution type to apply to the design. The default is
         ``None``, in which case the default type is applied.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     non_graphical : bool, optional

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -48,10 +48,11 @@ class Circuit(FieldAnalysisCircuit, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is  used.
         This parameter is ignored when Script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to run AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.
@@ -104,15 +105,15 @@ class Circuit(FieldAnalysisCircuit, object):
 
     >>> aedtapp = Circuit("myfile.aedt")
 
-    Create an instance of Circuit using the 2021 R1 version and
+    Create an instance of Circuit using the 2023 R2 version and
     open the specified project, which is ``"myfile.aedt"``.
 
-    >>> aedtapp = Circuit(specified_version="2021.2", projectname="myfile.aedt")
+    >>> aedtapp = Circuit(specified_version=2023.2, projectname="myfile.aedt")
 
-    Create an instance of Circuit using the 2021 R2 student version and open
+    Create an instance of Circuit using the 2023 R2 student version and open
     the specified project, which is named ``"myfile.aedt"``.
 
-    >>> hfss = Circuit(specified_version="2021.2", projectname="myfile.aedt", student_version=True)
+    >>> hfss = Circuit(specified_version="2023.2", projectname="myfile.aedt", student_version=True)
 
     """
 

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -42,6 +42,7 @@ from pyaedt import settings
 from pyaedt.generic.desktop_sessions import _desktop_sessions
 from pyaedt.generic.general_methods import active_sessions
 from pyaedt.generic.general_methods import com_active_sessions
+from pyaedt.generic.general_methods import get_string_version
 from pyaedt.generic.general_methods import grpc_active_sessions
 from pyaedt.generic.general_methods import inside_desktop
 from pyaedt.generic.general_methods import is_ironpython
@@ -383,9 +384,10 @@ class Desktop(object):
 
     Parameters
     ----------
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case the
         active setup or latest installed version is used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.
@@ -416,19 +418,19 @@ class Desktop(object):
 
     Examples
     --------
-    Launch AEDT 2021 R1 in non-graphical mode and initialize HFSS.
+    Launch AEDT 2023 R1 in non-graphical mode and initialize HFSS.
 
     >>> import pyaedt
-    >>> desktop = pyaedt.Desktop(specified_version="2021.2", non_graphical=True)
+    >>> desktop = pyaedt.Desktop(specified_version="2023.2", non_graphical=True)
     PyAEDT INFO: pyaedt v...
     PyAEDT INFO: Python version ...
     >>> hfss = pyaedt.Hfss(designname="HFSSDesign1")
     PyAEDT INFO: Project...
     PyAEDT INFO: Added design 'HFSSDesign1' of type HFSS.
 
-    Launch AEDT 2021 R1 in graphical mode and initialize HFSS.
+    Launch AEDT 2023 R2 in graphical mode and initialize HFSS.
 
-    >>> desktop = Desktop("2021.2")
+    >>> desktop = Desktop(232)
     PyAEDT INFO: pyaedt v...
     PyAEDT INFO: Python version ...
     >>> hfss = pyaedt.Hfss(designname="HFSSDesign1")
@@ -478,7 +480,6 @@ class Desktop(object):
             return
         else:
             self._initialized = True
-
         self._initialized_from_design = True if Desktop._invoked_from_design else False
         Desktop._invoked_from_design = False
 
@@ -749,6 +750,7 @@ class Desktop(object):
                     self.logger.warning("Only AEDT Student Version found on the system. Using Student Version.")
         elif student_version:
             specified_version += "SV"
+        specified_version = get_string_version(specified_version)
 
         if float(specified_version[0:6]) < 2019:
             raise ValueError("PyAEDT supports AEDT version 2021 R1 and later. Recommended version is 2022 R2 or later.")

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -47,6 +47,7 @@ from pyaedt.edb_core.stackup import Stackup
 from pyaedt.generic.constants import AEDT_UNITS
 from pyaedt.generic.constants import SolverType
 from pyaedt.generic.general_methods import generate_unique_name
+from pyaedt.generic.general_methods import get_string_version
 from pyaedt.generic.general_methods import inside_desktop
 from pyaedt.generic.general_methods import is_ironpython
 from pyaedt.generic.general_methods import is_linux
@@ -79,8 +80,9 @@ class Edb(Database):
     isreadonly : bool, optional
         Whether to open EBD in read-only mode when it is
         owned by HFSS 3D Layout. The default is ``False``.
-    edbversion : str, optional
-        Version of EDB to use. The default is ``"2021.2"``.
+    edbversion : str, int, float, optional
+        Version of EDB to use. The default is ``None``.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     isaedtowned : bool, optional
         Whether to launch EDB from HFSS 3D Layout. The
         default is ``False``.
@@ -138,6 +140,8 @@ class Edb(Database):
         use_ppe=False,
         technology_file=None,
     ):
+        edbversion = get_string_version(edbversion)
+
         self._clean_variables()
         Database.__init__(self, edbversion=edbversion, student_version=student_version)
         self.standalone = True

--- a/pyaedt/emit.py
+++ b/pyaedt/emit.py
@@ -34,10 +34,11 @@ class Emit(Design, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active setup is used or the latest installed version is
         used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.
@@ -73,7 +74,7 @@ class Emit(Design, object):
 
     Typically, it is desirable to specify a project name, design name, and other parameters.
 
-    >>> aedtapp = Emit(projectname, designame)
+    >>> aedtapp = Emit(projectname, designame, specified_version=232)
 
     Once an ``Emit`` instance is initialized, you can edit the schematic:
 

--- a/pyaedt/generic/design_types.py
+++ b/pyaedt/generic/design_types.py
@@ -19,9 +19,95 @@ def Circuit(
 ):
     """Circuit Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open.  The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is  used.
+        This parameter is ignored when Script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to run AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine.  The default is ``True``. This parameter is ignored when
+        a script is launched within AEDT.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+        This parameter is ignored when Script is launched within AEDT.
+    machine : str, optional
+        Machine name to which connect the oDesktop Session. Works only in 2022 R2
+        or later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If a machine is `"localhost"`, the
+        server also starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or
+        later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
     :class:`pyaedt.circuit.Circuit`
+
+    Examples
+    --------
+    Create an instance of Circuit and connect to an existing HFSS
+    design or create a new HFSS design if one does not exist.
+
+    >>> from pyaedt import Circuit
+    >>> aedtapp = Circuit()
+
+    Create an instance of Circuit and link to a project named
+    ``"projectname"``. If this project does not exist, create one with
+    this name.
+
+    >>> aedtapp = Circuit(projectname)
+
+    Create an instance of Circuit and link to a design named
+    ``"designname"`` in a project named ``"projectname"``.
+
+    >>> aedtapp = Circuit(projectname,designame)
+
+    Create an instance of Circuit and open the specified project,
+    which is ``"myfie.aedt"``.
+
+    >>> aedtapp = Circuit("myfile.aedt")
+
+    Create an instance of Circuit using the 2023 R2 version and
+    open the specified project, which is ``"myfile.aedt"``.
+
+    >>> aedtapp = Circuit(specified_version=2023.2, projectname="myfile.aedt")
+
+    Create an instance of Circuit using the 2023 R2 student version and open
+    the specified project, which is named ``"myfile.aedt"``.
+
+    >>> hfss = Circuit(specified_version="2023.2", projectname="myfile.aedt", student_version=True)
+
     """
     from pyaedt.circuit import Circuit as app
 
@@ -57,9 +143,115 @@ def Hfss(
 ):
     """Return an instance of the Hfss Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open. The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is used.
+        This parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to run AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine. The default is ``False``. This parameter is ignored when
+        a script is launched within AEDT.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is
+        ``False``. This parameter is ignored when a script is launched
+        within AEDT.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This parameter works only on
+        2022 R2 or later. The remote Server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`, the server
+        starts if it is not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or later.
+        The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
     :class:`pyaedt.hfss.Hfss`
+
+    Examples
+    --------
+    Create an instance of HFSS and connect to an existing HFSS
+    design or create a new HFSS design if one does not exist.
+
+    >>> from pyaedt import Hfss
+    >>> hfss = Hfss()
+    PyAEDT INFO: No project is defined...
+    PyAEDT INFO: Active design is set to...
+
+
+    Create an instance of HFSS and link to a project named
+    ``HfssProject``. If this project does not exist, create one with
+    this name.
+
+    >>> hfss = Hfss("HfssProject")
+    PyAEDT INFO: Project HfssProject has been created.
+    PyAEDT INFO: No design is present. Inserting a new design.
+    PyAEDT INFO: Added design ...
+
+
+    Create an instance of HFSS and link to a design named
+    ``HfssDesign1`` in a project named ``HfssProject``.
+
+    >>> hfss = Hfss("HfssProject","HfssDesign1")
+    PyAEDT INFO: Added design 'HfssDesign1' of type HFSS.
+
+
+    Create an instance of HFSS and open the specified project,
+    which is named ``"myfile.aedt"``.
+
+    >>> hfss = Hfss("myfile.aedt")
+    PyAEDT INFO: Project myfile has been created.
+    PyAEDT INFO: No design is present. Inserting a new design.
+    PyAEDT INFO: Added design...
+
+
+    Create an instance of HFSS using the 2023 R2 release and open
+    the specified project, which is named ``"myfile2.aedt"``.
+
+    >>> hfss = Hfss(specified_version=232, projectname="myfile2.aedt")
+    PyAEDT INFO: Project myfile2 has been created.
+    PyAEDT INFO: No design is present. Inserting a new design.
+    PyAEDT INFO: Added design...
+
+
+    Create an instance of HFSS using the 2023 R2 student version and open
+    the specified project, which is named ``"myfile3.aedt"``.
+
+    >>> hfss = Hfss(specified_version="2023.2", projectname="myfile3.aedt", student_version=True)
+    PyAEDT INFO: Project myfile3 has been created.
+    PyAEDT INFO: No design is present. Inserting a new design.
+    PyAEDT INFO: Added design...
+
     """
     from pyaedt.hfss import Hfss as app
 
@@ -95,9 +287,99 @@ def Icepak(
 ):
     """Icepak Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open.  The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is  used.
+        This parameter is ignored when Script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non-graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine.  The default is ``True``.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+        This parameter is ignored when a script is launched within AEDT.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in 2022 R2 or later.
+        The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+        If the machine is `"localhost"`, the server also starts if not present.
+    port : int, optional
+        Port number of which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or later.
+        The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
-    :class:`pyaedt.icepak.Icepak`"""
+    :class:`pyaedt.icepak.Icepak`
+
+    Examples
+    --------
+
+    Create an instance of Icepak and connect to an existing Icepak
+    design or create a new Icepak design if one does not exist.
+
+    >>> from pyaedt import Icepak
+    >>> icepak = Icepak()
+    PyAEDT INFO: No project is defined. Project ...
+    PyAEDT INFO: Active design is set to ...
+
+    Create an instance of Icepak and link to a project named
+    ``IcepakProject``. If this project does not exist, create one with
+    this name.
+
+    >>> icepak = Icepak("IcepakProject")
+    PyAEDT INFO: Project ...
+    PyAEDT INFO: Added design ...
+
+    Create an instance of Icepak and link to a design named
+    ``IcepakDesign1`` in a project named ``IcepakProject``.
+
+    >>> icepak = Icepak("IcepakProject", "IcepakDesign1")
+    PyAEDT INFO: Added design 'IcepakDesign1' of type Icepak.
+
+    Create an instance of Icepak and open the specified project,
+    which is ``myipk.aedt``.
+
+    >>> icepak = Icepak("myipk.aedt")
+    PyAEDT INFO: Project myipk has been created.
+    PyAEDT INFO: No design is present. Inserting a new design.
+    PyAEDT INFO: Added design ...
+
+    Create an instance of Icepak using the 2023 R2 release and
+    open the specified project, which is ``myipk2.aedt``.
+
+    >>> icepak = Icepak(specified_version=2023.2, projectname="myipk2.aedt")
+    PyAEDT INFO: Project...
+    PyAEDT INFO: No design is present. Inserting a new design.
+    PyAEDT INFO: Added design...
+    """
     from pyaedt.icepak import Icepak as app
 
     return app(
@@ -132,9 +414,97 @@ def Emit(
 ):
     """Emit Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open.  The default is ``None``, in which case
+        an attempt is made to get an active project. If no projects are
+        present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in which case
+        an attempt is made to get an active design. If no designs are
+        present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is ``None``, in which
+        case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active setup is used or the latest installed version is
+        used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine.  The default is ``True``.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to start the AEDT student version. The default is ``False``.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a server. This parameter works only in 2022 R2 or later.
+        The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+        The default is ``0``.
+    machine : str, optional
+        Machine name that the Desktop session is to connect to. This
+        parameter works only in 2022 R2 and later. The remote server must be
+        up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+        If the machine is `"localhost"`, the server starts if it is not present.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
-    :class:`pyaedt.emit.Emit`"""
+    :class:`pyaedt.emit.Emit`
+
+    Examples
+    --------
+    Create an ``Emit`` instance. You can also choose to define parameters for this instance here.
+
+    >>> from pyaedt import Emit
+    >>> aedtapp = Emit()
+
+    Typically, it is desirable to specify a project name, design name, and other parameters.
+
+    >>> aedtapp = Emit(projectname, designame, specified_version=232)
+
+    Once an ``Emit`` instance is initialized, you can edit the schematic:
+
+    >>> rad1 = aedtapp.modeler.components.create_component("Bluetooth")
+    >>> ant1 = aedtapp.modeler.components.create_component("Antenna")
+    >>> if rad1 and ant1:
+    >>>     ant1.move_and_connect_to(rad1)
+
+    Once the schematic is generated, the ``Emit`` object can be analyzed to generate
+    a revision. Each revision is added as an element of the ``Emit`` object member's
+    revisions_list.
+
+    >>> aedtapp.analyze()
+
+    A revision within PyAEDT is analogous to a revision in AEDT. An interaction domain must
+    be defined and then used as the input to the run command used on that revision.
+
+    >>> domain = aedtapp.interaction_domain()
+    >>> domain.rx_radio_name = "UE - HandHeld"
+    >>> interaction = aedtapp.revisions_list[0].run(domain)
+
+    The output of the run command is an ``interaction`` object. This object summarizes the interaction data
+    that is defined in the interaction domain.
+
+    >>> instance = interaction.worst_instance(ResultType.SENSITIVITY)
+    >>> val = instance.value(ResultType.SENSITIVITY)
+    >>> print("Worst-case sensitivity for Rx '{}' is {}dB.".format(domain.rx_radio_name, val))
+    """
     from pyaedt.emit import Emit as app
 
     return app(
@@ -169,9 +539,95 @@ def Hfss3dLayout(
 ):
     """Hfss3dLayout Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open or the path to the ``aedb`` folder or
+        ``edb.def`` file. The default is ``None``, in which case an
+        attempt is made to get an active project. If no projects are present,
+        an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False```, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine. The default is ``True``.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in 2022 R2 or later.
+        The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+        If the machine is `"localhost"`. the server also starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or later.
+        The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
-    :class:`pyaedt.hfss3dlayout.Hfss3dLayout`"""
+    :class:`pyaedt.hfss3dlayout.Hfss3dLayout`
+
+    Examples
+    --------
+    Create an ``Hfss3dLayout`` object and connect to an existing HFSS
+    design or create a new HFSS design if one does not exist.
+
+    >>> from pyaedt import Hfss3dLayout
+    >>> aedtapp = Hfss3dLayout()
+
+    Create an ``Hfss3dLayout`` object and link to a project named
+    ``projectname``. If this project does not exist, create one with
+    this name.
+
+    >>> aedtapp = Hfss3dLayout(projectname)
+
+    Create an ``Hfss3dLayout`` object and link to a design named
+    ``designname`` in a project named ``projectname``.
+
+    >>> aedtapp = Hfss3dLayout(projectname,designame)
+
+    Create an ``Hfss3dLayout`` object and open the specified project.
+
+    >>> aedtapp = Hfss3dLayout("myfile.aedt")
+
+    Create an AEDT 2023 R1 object and then create a
+    ``Hfss3dLayout`` object and open the specified project.
+
+    >>> aedtapp = Hfss3dLayout(specified_version="2023.1", projectname="myfile.aedt")
+
+    Create an instance of ``Hfss3dLayout`` from an ``Edb``
+
+    >>> import pyaedt
+    >>> edb_path = "/path/to/edbfile.aedb"
+    >>> edb = pyaedt.Edb(edb_path, edbversion=231)
+    >>> edb.import_stackup("stackup.xml")  # Import stackup. Manipulate edb, ...
+    >>> edb.save_edb()
+    >>> edb.close_edb()
+    >>> aedtapp = pyaedt.Hfss3dLayout(specified_version=231, projectname=edb_path)
+    """
     from pyaedt.hfss3dlayout import Hfss3dLayout as app
 
     return app(
@@ -205,6 +661,56 @@ def Maxwell2d(
     aedt_process_id=None,
 ):
     """Maxwell2d Class.
+
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open. The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is used.
+        This parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine. The default is ``True``. This parameter is ignored when
+        a script is launched within AEDT.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+        This parameter is ignored when a script is launched within AEDT.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in 2022 R2
+        or later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`,
+        the server also starts if not present.
+    port : int, optional
+        Port number of which to start the oDesktop communication on an already existing
+        server. This parameter is ignored when creating a new server. It works only in 2022
+        R2 or later. The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
 
     Returns
     -------
@@ -243,9 +749,77 @@ def Maxwell3d(
 ):
     """Maxwell3d Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open. The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is used. This
+        parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical
+        mode. This parameter is ignored when a script is launched within
+        AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine. The default is ``True``. This parameter is ignored
+        when a script is launched within AEDT.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is
+        ``False``. This parameter is ignored when a script is launched
+        within AEDT.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in 2022 R2
+        or later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`, the
+        server also starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when a new server is created. It works only in 2022 R2 or later.
+        The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
-    :class:`pyaedt.maxwell.Maxwell3d`"""
+    :class:`pyaedt.maxwell.Maxwell3d`
+
+    Examples
+    --------
+    Create an instance of Maxwell 3D and open the specified
+    project, which is named ``mymaxwell.aedt``.
+
+    >>> from pyaedt import Maxwell3d
+    >>> aedtapp = Maxwell3d("mymaxwell.aedt")
+    PyAEDT INFO: Added design ...
+
+    Create an instance of Maxwell 3D using the 2023 R2 release and open
+    the specified project, which is named ``mymaxwell2.aedt``.
+
+    >>> aedtapp = Maxwell3d(specified_version="2023.2", projectname="mymaxwell2.aedt")
+    PyAEDT INFO: Added design ...
+    """
     from pyaedt.maxwell import Maxwell3d as app
 
     return app(
@@ -278,6 +852,47 @@ def MaxwellCircuit(
     aedt_process_id=None,
 ):
     """MaxwellCircuit Class.
+
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open. The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``. If ``None``,
+        the active setup is used or the latest installed version is
+        used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non-graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine. The default is ``True``.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in 2022 R2
+        and later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`, the server
+        is also started if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or
+        later. The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
 
     Returns
     -------
@@ -315,9 +930,90 @@ def Mechanical(
 ):
     """Mechanical Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open.  The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is used.
+        This parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in the non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in the graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine. The default is ``True``. This parameter is ignored when
+        a script is launched within AEDT.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+        This parameter is ignored when a script is launched within AEDT.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. Works only in 2022R2 and
+        later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`,
+        the server also starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or
+        later. The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
-    :class:`pyaedt.mechanical.Mechanical`"""
+    :class:`pyaedt.mechanical.Mechanical`
+
+    Examples
+    --------
+    Create an instance of Mechanical and connect to an existing
+    HFSS design or create a new HFSS design if one does not exist.
+
+    >>> from pyaedt import Mechanical
+    >>> aedtapp = Mechanical()
+
+    Create an instance of Mechanical and link to a project named
+    ``"projectname"``. If this project does not exist, create one with
+    this name.
+
+    >>> aedtapp = Mechanical(projectname)
+
+    Create an instance of Mechanical and link to a design named
+    ``"designname"`` in a project named ``"projectname"``.
+
+    >>> aedtapp = Mechanical(projectname,designame)
+
+    Create an instance of Mechanical and open the specified
+    project, which is named ``"myfile.aedt"``.
+
+    >>> aedtapp = Mechanical("myfile.aedt")
+
+    Create a ``Desktop on 2023 R2`` object and then create an
+    ``Mechanical`` object and open the specified project, which is
+    named ``"myfile.aedt"``.
+
+    >>> aedtapp = Mechanical(specified_version=23.2, projectname="myfile.aedt")
+    """
     from pyaedt.mechanical import Mechanical as app
 
     return app(
@@ -351,6 +1047,56 @@ def Q2d(
     aedt_process_id=None,
 ):
     """Q2D Class.
+
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open. The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is used.  This
+        parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine. The default is ``True``. This parameter is ignored
+        when a script is launched within AEDT.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. This parameter is
+        ignored when a script is launched within AEDT.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in 2022 R2
+        and later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`,
+        the server also starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or later.
+        The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
 
     Returns
     -------
@@ -389,6 +1135,57 @@ def Q3d(
 ):
     """Q3D Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open. The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or nothing
+        is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is used.
+        This parameter is ignored when Script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine. The default is ``True``. This parameter is ignored when
+        a script is launched within AEDT.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+        This parameter is ignored when a script is launched within AEDT.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in
+        2022 R2 and later. The remote server must be up and running with the
+        command `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`,
+        the server also starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already
+        existing server. This parameter is ignored when a new server is created.
+        It works only in 2022 R2 and later. The remote server must be up and
+        running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
     :class:`pyaedt.q3d.Q3d`"""
@@ -425,6 +1222,56 @@ def Rmxprt(
     aedt_process_id=None,
 ):
     """Rmxprt Class.
+
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open. The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    model_units : str, optional
+        Model units.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case
+        the active setup is used or the latest installed version is
+        used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine.  The default is ``True``.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in 2022 R2 or
+        later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`, the
+        server also starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or later.
+        The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
 
     Returns
     -------
@@ -463,6 +1310,54 @@ def TwinBuilder(
 ):
     """TwinBuilder Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open.  The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which
+        case the active setup or latest installed version is
+        used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine.  The default is ``True``.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in 2022 R2
+        or later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`,
+        the server also starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or later.
+        The remote server must be up and running with command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
     :class:`pyaedt.twinbuilder.TwinBuilder`"""
@@ -500,6 +1395,54 @@ def Simplorer(
 ):
     """Simplorer Class.
 
+    Parameters
+    ----------
+    projectname : str, optional
+        Name of the project to select or the full path to the project
+        or AEDTZ archive to open.  The default is ``None``, in which
+        case an attempt is made to get an active project. If no
+        projects are present, an empty project is created.
+    designname : str, optional
+        Name of the design to select. The default is ``None``, in
+        which case an attempt is made to get an active design. If no
+        designs are present, an empty design is created.
+    solution_type : str, optional
+        Solution type to apply to the design. The default is
+        ``None``, in which case the default type is applied.
+    setup_name : str, optional
+        Name of the setup to use as the nominal. The default is
+        ``None``, in which case the active setup is used or
+        nothing is used.
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which
+        case the active setup or latest installed version is
+        used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the
+        machine.  The default is ``True``.
+    close_on_exit : bool, optional
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False``.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This works only in 2022 R2
+        or later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`,
+        the server also starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on an already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 or later.
+        The remote server must be up and running with command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
+
     Returns
     -------
     :class:`pyaedt.twinbuilder.TwinBuilder`"""
@@ -532,10 +1475,64 @@ def Desktop(
     aedt_process_id=None,
 ):
     """Desktop Class.
+    Parameters
+    ----------
+    specified_version : str, int, float, optional
+        Version of AEDT to use. The default is ``None``, in which case the
+        active setup or latest installed version is used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
+    non_graphical : bool, optional
+        Whether to launch AEDT in non-graphical mode. The default
+        is ``False``, in which case AEDT is launched in graphical mode.
+        This parameter is ignored when a script is launched within AEDT.
+    new_desktop_session : bool, optional
+        Whether to launch an instance of AEDT in a new thread, even if
+        another instance of the ``specified_version`` is active on the machine.
+        The default is ``True``.
+    close_on_exit : bool, optional
+        Whether to close AEDT on exit. The default is ``True``.
+        This option is used only when Desktop is used in a context manager (``with`` statement).
+        If Desktop is used outside a context manager, see the ``release_desktop`` arguments.
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is
+        ``False``.
+    machine : str, optional
+        Machine name to connect the oDesktop session to. This parameter works only in 2022 R2
+        and later. The remote server must be up and running with the command
+        `"ansysedt.exe -grpcsrv portnum"`. If the machine is `"localhost"`, the server also
+        starts if not present.
+    port : int, optional
+        Port number on which to start the oDesktop communication on the already existing server.
+        This parameter is ignored when creating a new server. It works only in 2022 R2 and
+        later. The remote server must be up and running with the command `"ansysedt.exe -grpcsrv portnum"`.
+    aedt_process_id : int, optional
+        Process ID for the instance of AEDT to point PyAEDT at. The default is
+        ``None``. This parameter is only used when ``new_desktop_session = False``.
 
     Returns
     -------
-    :class:`pyaedt.desktop.Desktop`"""
+    :class:`pyaedt.desktop.Desktop`
+
+    Examples
+    --------
+    Launch AEDT 2023 R1 in non-graphical mode and initialize HFSS.
+
+    >>> import pyaedt
+    >>> desktop = pyaedt.Desktop(specified_version="2023.2", non_graphical=True)
+    PyAEDT INFO: pyaedt v...
+    PyAEDT INFO: Python version ...
+    >>> hfss = pyaedt.Hfss(designname="HFSSDesign1")
+    PyAEDT INFO: Project...
+    PyAEDT INFO: Added design 'HFSSDesign1' of type HFSS.
+
+    Launch AEDT 2023 R2 in graphical mode and initialize HFSS.
+
+    >>> desktop = Desktop(232)
+    PyAEDT INFO: pyaedt v...
+    PyAEDT INFO: Python version ...
+    >>> hfss = pyaedt.Hfss(designname="HFSSDesign1")
+    PyAEDT INFO: No project is defined. Project...
+    """
     from pyaedt.desktop import Desktop as app
 
     return app(
@@ -564,7 +1561,7 @@ def launch_desktop(
 
     Parameters
     ----------
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case the
         active setup or latest installed version is used.
     non_graphical : bool, optional
@@ -648,7 +1645,7 @@ def Edb(
 
     Parameters
     ----------
-    edbpath : str, optional
+    edbpath : str, int, float optional
         Full path to the ``aedb`` folder. The variable can also contain
         the path to a layout to import. Allowed formats are BRD,
         XML (IPC2581), GDS, and DXF. The default is ``None``.

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -436,6 +436,24 @@ def get_version_and_release(input_version):
 
 
 @pyaedt_function_handler()
+def get_string_version(input_version):
+    output_version = input_version
+    if isinstance(input_version, float):
+        output_version = str(input_version)
+        if len(output_version) == 4:
+            output_version = "20" + output_version
+    elif isinstance(input_version, int):
+        output_version = str(input_version)
+        output_version = "20{}.{}".format(output_version[:2], output_version[-1])
+    elif isinstance(input_version, str):
+        if len(input_version) == 3:
+            output_version = "20{}.{}".format(input_version[:2], input_version[-1])
+        elif len(input_version) == 4:
+            output_version = "20" + input_version
+    return output_version
+
+
+@pyaedt_function_handler()
 def env_path(input_version):
     """Get the path of the version environment variable for an AEDT version.
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -52,10 +52,11 @@ class Hfss(FieldAnalysis3D, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
         This parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to run AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.
@@ -121,19 +122,19 @@ class Hfss(FieldAnalysis3D, object):
     PyAEDT INFO: Added design...
 
 
-    Create an instance of HFSS using the 2021 R1 release and open
+    Create an instance of HFSS using the 2023 R2 release and open
     the specified project, which is named ``"myfile2.aedt"``.
 
-    >>> hfss = Hfss(specified_version="2021.2", projectname="myfile2.aedt")
+    >>> hfss = Hfss(specified_version=232, projectname="myfile2.aedt")
     PyAEDT INFO: Project myfile2 has been created.
     PyAEDT INFO: No design is present. Inserting a new design.
     PyAEDT INFO: Added design...
 
 
-    Create an instance of HFSS using the 2021 R2 student version and open
+    Create an instance of HFSS using the 2023 R2 student version and open
     the specified project, which is named ``"myfile3.aedt"``.
 
-    >>> hfss = Hfss(specified_version="2021.2", projectname="myfile3.aedt", student_version=True)
+    >>> hfss = Hfss(specified_version="2023.2", projectname="myfile3.aedt", student_version=True)
     PyAEDT INFO: Project myfile3 has been created.
     PyAEDT INFO: No design is present. Inserting a new design.
     PyAEDT INFO: Added design...

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -45,9 +45,10 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False```, in which case AEDT is launched in graphical mode.
@@ -95,7 +96,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
 
     >>> aedtapp = Hfss3dLayout("myfile.aedt")
 
-    Create an AEDT 2021 R1 object and then create a
+    Create an AEDT 2023 R1 object and then create a
     ``Hfss3dLayout`` object and open the specified project.
 
     >>> aedtapp = Hfss3dLayout(specified_version="2023.1", projectname="myfile.aedt")
@@ -104,12 +105,11 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
 
     >>> import pyaedt
     >>> edb_path = "/path/to/edbfile.aedb"
-    >>> specified_version = "2023.1"
-    >>> edb = pyaedt.Edb(edb_path)
+    >>> edb = pyaedt.Edb(edb_path, edbversion=231)
     >>> edb.import_stackup("stackup.xml")  # Import stackup. Manipulate edb, ...
     >>> edb.save_edb()
     >>> edb.close_edb()
-    >>> aedtapp = pyaedt.Hfss3dLayout(specified_version="2021.2", projectname=edb_path)
+    >>> aedtapp = pyaedt.Hfss3dLayout(specified_version=231, projectname=edb_path)
 
     """
 

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -59,10 +59,11 @@ class Icepak(FieldAnalysis3D):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is  used.
         This parameter is ignored when Script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non-graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.
@@ -121,10 +122,10 @@ class Icepak(FieldAnalysis3D):
     PyAEDT INFO: No design is present. Inserting a new design.
     PyAEDT INFO: Added design ...
 
-    Create an instance of Icepak using the 2021 R1 release and
+    Create an instance of Icepak using the 2023 R2 release and
     open the specified project, which is ``myipk2.aedt``.
 
-    >>> icepak = Icepak(specified_version="2021.2", projectname="myipk2.aedt")
+    >>> icepak = Icepak(specified_version=2023.2, projectname="myipk2.aedt")
     PyAEDT INFO: Project...
     PyAEDT INFO: No design is present. Inserting a new design.
     PyAEDT INFO: Added design...

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -1857,10 +1857,11 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used. This
         parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical
@@ -1899,10 +1900,10 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
     >>> aedtapp = Maxwell3d("mymaxwell.aedt")
     PyAEDT INFO: Added design ...
 
-    Create an instance of Maxwell 3D using the 2021 R1 release and open
+    Create an instance of Maxwell 3D using the 2023 R2 release and open
     the specified project, which is named ``mymaxwell2.aedt``.
 
-    >>> aedtapp = Maxwell3d(specified_version="2021.2", projectname="mymaxwell2.aedt")
+    >>> aedtapp = Maxwell3d(specified_version="2023.2", projectname="mymaxwell2.aedt")
     PyAEDT INFO: Added design ...
 
     """
@@ -2595,10 +2596,11 @@ class Maxwell2d(Maxwell, FieldAnalysis3D, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
         This parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.

--- a/pyaedt/maxwellcircuit.py
+++ b/pyaedt/maxwellcircuit.py
@@ -23,10 +23,11 @@ class MaxwellCircuit(AnalysisMaxwellCircuit, object):
         Name of the design to select. The default is ``None``, in
         which case an attempt is made to get an active design. If no
         designs are present, an empty design is created.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``. If ``None``,
         the active setup is used or the latest installed version is
         used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non-graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.

--- a/pyaedt/mechanical.py
+++ b/pyaedt/mechanical.py
@@ -31,10 +31,11 @@ class Mechanical(FieldAnalysis3D, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
         This parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in the non-graphical mode. The default
         is ``False``, in which case AEDT is launched in the graphical mode.
@@ -86,11 +87,11 @@ class Mechanical(FieldAnalysis3D, object):
 
     >>> aedtapp = Mechanical("myfile.aedt")
 
-    Create a ``Desktop on 2021R2`` object and then create an
+    Create a ``Desktop on 2023 R2`` object and then create an
     ``Mechanical`` object and open the specified project, which is
     named ``"myfile.aedt"``.
 
-    >>> aedtapp = Mechanical(specified_version="2021.2", projectname="myfile.aedt")
+    >>> aedtapp = Mechanical(specified_version=23.2, projectname="myfile.aedt")
 
     """
 

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -1219,10 +1219,11 @@ class Q3d(QExtractor, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or nothing
         is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
         This parameter is ignored when Script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.
@@ -2025,10 +2026,11 @@ class Q2d(QExtractor, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.  This
         parameter is ignored when a script is launched within AEDT.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.

--- a/pyaedt/rmxprt.py
+++ b/pyaedt/rmxprt.py
@@ -141,10 +141,11 @@ class Rmxprt(FieldAnalysisRMxprt):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active setup is used or the latest installed version is
         used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.

--- a/pyaedt/rpc/rpyc_services.py
+++ b/pyaedt/rpc/rpyc_services.py
@@ -359,7 +359,7 @@ class PyaedtServiceWindows(rpyc.Service):
             Name of the setup to use as the nominal. The default is
             ``None``, in which case the active setup is used or
             nothing is used.
-        specified_version : str, optional
+        specified_version : str, int, float, optional
             Version of AEDT to use. The default is ``None``, in which case
             the active version or latest installed version is used.
         non_graphical : bool, optional
@@ -414,7 +414,7 @@ class PyaedtServiceWindows(rpyc.Service):
             Name of the setup to use as the nominal. The default is
             ``None``, in which case the active setup is used or
             nothing is used.
-        specified_version : str, optional
+        specified_version : str, int, float, optional
             Version of AEDT to use. The default is ``None``, in which case
             the active version or latest installed version is used.
         non_graphical : bool, optional
@@ -469,7 +469,7 @@ class PyaedtServiceWindows(rpyc.Service):
             Name of the setup to use as the nominal. The default is
             ``None``, in which case the active setup is used or
             nothing is used.
-        specified_version : str, optional
+        specified_version : str, int, float, optional
             Version of AEDT to use. The default is ``None``, in which case
             the active version or latest installed version is used.
         non_graphical : bool, optional
@@ -524,7 +524,7 @@ class PyaedtServiceWindows(rpyc.Service):
             Name of the setup to use as the nominal. The default is
             ``None``, in which case the active setup is used or
             nothing is used.
-        specified_version : str, optional
+        specified_version : str, int, float, optional
             Version of AEDT to use. The default is ``None``, in which case
             the active version or latest installed version is used.
         non_graphical : bool, optional
@@ -579,7 +579,7 @@ class PyaedtServiceWindows(rpyc.Service):
             Name of the setup to use as the nominal. The default is
             ``None``, in which case the active setup is used or
             nothing is used.
-        specified_version : str, optional
+        specified_version : str, int, float, optional
             Version of AEDT to use. The default is ``None``, in which case
             the active version or latest installed version is used.
         non_graphical : bool, optional
@@ -634,7 +634,7 @@ class PyaedtServiceWindows(rpyc.Service):
             Name of the setup to use as the nominal. The default is
             ``None``, in which case the active setup is used or
             nothing is used.
-        specified_version : str, optional
+        specified_version : str, int, float, optional
             Version of AEDT to use. The default is ``None``, in which case
             the active version or latest installed version is used.
         non_graphical : bool, optional
@@ -689,7 +689,7 @@ class PyaedtServiceWindows(rpyc.Service):
             Name of the setup to use as the nominal. The default is
             ``None``, in which case the active setup is used or
             nothing is used.
-        specified_version : str, optional
+        specified_version : str, int, float, optional
             Version of AEDT to use. The default is ``None``, in which case
             the active version or latest installed version is used.
         non_graphical : bool, optional
@@ -744,7 +744,7 @@ class PyaedtServiceWindows(rpyc.Service):
             Name of the setup to use as the nominal. The default is
             ``None``, in which case the active setup is used or
             nothing is used.
-        specified_version : str, optional
+        specified_version : str, int, float, optional
             Version of AEDT to use. The default is ``None``, in which case
             the active version or latest installed version is used.
         non_graphical : bool, optional
@@ -799,7 +799,7 @@ class PyaedtServiceWindows(rpyc.Service):
             Name of the setup to use as the nominal. The default is
             ``None``, in which case the active setup is used or
             nothing is used.
-        specified_version : str, optional
+        specified_version : str, int, float, optional
             Version of AEDT to use. The default is ``None``, in which case
             the active version or latest installed version is used.
         non_graphical : bool, optional

--- a/pyaedt/siwave.py
+++ b/pyaedt/siwave.py
@@ -25,7 +25,7 @@ class Siwave(object):
 
     Parameters
     ----------
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active setup is used or the latest installed version is used.
 

--- a/pyaedt/twinbuilder.py
+++ b/pyaedt/twinbuilder.py
@@ -30,10 +30,11 @@ class TwinBuilder(AnalysisTwinBuilder, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version : str, optional
+    specified_version : str, int, float, optional
         Version of AEDT to use. The default is ``None``, in which
         case the active setup or latest installed version is
         used.
+        Examples of input values are ``232``, ``23.2``,``2023.2``,``"2023.2"``.
     non_graphical : bool, optional
         Whether to launch AEDT in non-graphical mode. The default
         is ``False``, in which case AEDT is launched in graphical mode.


### PR DESCRIPTION
Now specified_version and edbversion supports strings, float or int as input.
Example:
- Hfss(specified_version="2023.2")
- Hfss(specified_version=2023.2)
- Hfss(specified_version=23.2)
- Hfss(specified_version=232)