### PR TITLE
Edb cutout improvements

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -742,6 +742,7 @@ class TestClass:
             number_of_threads=4,
             extent_type="ConvexHull",
             custom_extent=points,
+            simple_pad_check=False,
         )
         edbapp.close()
 

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1489,6 +1489,7 @@ class Edb(Database):
         expansion_factor=0,
         maximum_iterations=10,
         preserve_components_with_model=False,
+        simple_pad_check=True,
     ):
         """Create a cutout using an approach entirely based on PyAEDT.
         This method replaces all legacy cutout methods in PyAEDT.
@@ -1644,6 +1645,8 @@ class Edb(Database):
                         check_terminals=check_terminals,
                         include_pingroups=include_pingroups,
                         preserve_components_with_model=preserve_components_with_model,
+                        include_partial=include_partial_instances,
+                        simple_pad_check=simple_pad_ckeck,
                     )
                     if self.are_port_reference_terminals_connected():
                         if output_aedb_path:
@@ -1681,6 +1684,8 @@ class Edb(Database):
                     check_terminals=check_terminals,
                     include_pingroups=include_pingroups,
                     preserve_components_with_model=preserve_components_with_model,
+                    include_partial=include_partial_instances,
+                    simple_pad_check=simple_pad_ckeck,
                 )
             if result and not open_cutout_at_end and self.edbpath != legacy_path:
                 self.save_edb()
@@ -1884,6 +1889,8 @@ class Edb(Database):
         check_terminals=False,
         include_pingroups=True,
         preserve_components_with_model=False,
+        include_partial=False,
+        simple_pad_check=True,
     ):
         if is_ironpython:  # pragma: no cover
             self.logger.error("Method working only in Cpython")
@@ -2011,7 +2018,7 @@ class Edb(Database):
                 prims_to_delete.append(prim_1)
 
         def pins_clean(pinst):
-            if not pinst.in_polygon(_poly, simple_check=True):
+            if not pinst.in_polygon(_poly, include_partial=include_partial, simple_check=simple_pad_check):
                 pins_to_delete.append(pinst)
 
         with ThreadPoolExecutor(number_of_threads) as pool:

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -1039,15 +1039,23 @@ class EDBPadstackInstance(object):
         polygon_data : PolygonData Object
         include_partial : bool, optional
             Whether to include partial intersecting instances. The default is ``True``.
+        simple_check : bool, optional
+            Whether to perform a single check based on the padstack center or check the padstack bounding box.
 
         Returns
         -------
         bool
             ``True`` when successful, ``False`` when failed.
         """
+        pos = [i for i in self.position]
+        int_val = 1 if polygon_data.PointInPolygon(self._pedb.point_data(*pos)) else 0
+        if int_val == 0:
+            return False
+
         if simple_check:
-            pos = [i for i in self.position]
-            int_val = 1 if polygon_data.PointInPolygon(self._pedb.point_data(*pos)) else 0
+            # pos = [i for i in self.position]
+            # int_val = 1 if polygon_data.PointInPolygon(self._pedb.point_data(*pos)) else 0
+            return True
         else:
             plane = self._pedb.modeler.Shape("rectangle", pointA=self.bounding_box[0], pointB=self.bounding_box[1])
             rectangle_data = self._pedb.modeler.shape_to_polygon_data(plane)


### PR DESCRIPTION
New Edb cutout supports 2 options for padstack cutout:
- simple pad check based on padstack center (inside or outside extent)
- complete pad check (bounding box inside or outside extent or partially)
Complex pad check is much slower but provides a behaviour more similar to original edb api cutout method
Default is simple pad check to keep back compatibility.