### PR TITLE
bugfix: compatibility with pymechanical

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "cffi == 1.15.1;platform_system=='Linux' and python_version == '3.7'",
     "cffi == 1.16.0;platform_system=='Linux' and python_version > '3.7'",
     "pywin32 >= 303;platform_system=='Windows'",
-    "pythonnet == 3.0.2",
+    "ansys-pythonnet>=3.1.0rc2",
     "rpyc==5.3.1",
     "psutil",
     "dotnetcore2 ==3.1.23;platform_system=='Linux'",


### PR DESCRIPTION
Use ansys-pythonnet (ansys fork) rc 2 to provide consistant libraries as a bundle.

Closes ansys/pyansys#384