### PR TITLE
added waitforlicense options to settings

### DIFF
--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -66,6 +66,8 @@ def launch_aedt(full_path, non_graphical, port, student_version, first_run=True)
         command = [full_path, "-grpcsrv", str(port)]
         if non_graphical:
             command.append("-ng")
+        if settings.wait_for_license:
+            command.append("-waitforlicense")
         my_env = os.environ.copy()
         for env, val in settings.aedt_environment_variables.items():
             my_env[env] = val
@@ -131,6 +133,8 @@ def launch_aedt_in_lsf(non_graphical, port):  # pragma: no cover
         ]
     if non_graphical:
         command.append("-ng")
+    if settings.wait_for_license:
+        command.append("-waitforlicense")
     print(command)
     p = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     timeout = settings.lsf_timeout

--- a/pyaedt/generic/settings.py
+++ b/pyaedt/generic/settings.py
@@ -65,6 +65,22 @@ class Settings(object):
         self._desktop_launch_timeout = 90
         self._number_of_grpc_api_retries = 6
         self._retry_n_times_time_interval = 0.1
+        self._wait_for_license = False
+
+    @property
+    def wait_for_license(self):
+        """Whether if Electronics Desktop has to be launched with ``-waitforlicense`` flag enabled or not.
+        Default is ``False``.
+
+        Returns
+        -------
+        bool
+        """
+        return self._wait_for_license
+
+    @wait_for_license.setter
+    def wait_for_license(self, value):
+        self._wait_for_license = value
 
     @property
     def retry_n_times_time_interval(self):


### PR DESCRIPTION
#3730 
Implemented waitforlicense flag into settings

```
from pyaedt import settings, Desktop
settings.wait_for_license=True
d = Desktop()
```