### PR TITLE
CI: Add edb label to labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,3 +13,10 @@ testing:
 - _unittest/conftest.py
 - _unittest_ironpython/run_unittests.py
 - _unittest_ironpython/run_unittests_batchmode.cmd
+# TODO : Remove once EDB is extracted from PyAEDT
+edb:
+- examples/00-EDB/**
+- examples/01-HFSS3DLayout/EDB_in_3DLayout.py
+- examples/05-Q3D/Q3D_from_EDB.py
+- pyaedt/edb_core/**
+- pyaedt/edb.py


### PR DESCRIPTION
Update the Github workflow labeler to track changes related to `edb` (based on specific modified files).
This could me removed later on but would be of great help for the split between AEDT and EDB.