### PR TITLE
CI: Add edb label to labels.yml

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -29,3 +29,7 @@
 - name: testing
   description: Anything related to testing
   color: 5802B8
+
+- name: edb
+  description: Anything related to the EDB API
+  color: C4C25D


### PR DESCRIPTION
Previous PR (#3761) was missing an item in `.github/labels.yml` which resulted in:
- the deletion of the `edb` label on github (cf #3745) and the removal from each issue / PR
- no label added on PRs touching targeted files

This addition should patch it (tested on a fork cf https://github.com/SMoraisAnsys/pyaedt/pull/2)