### PR TITLE
Refact edb load amat

### DIFF
--- a/_unittest/example_models/syslib/Materials.amat
+++ b/_unittest/example_models/syslib/Materials.amat
@@ -1,0 +1,123 @@
+$begin '$base_index$'
+  $begin 'properties'
+    all_levels=000000000000
+    time(year=000000002021, month=000000000009, day=000000000001, hour=000000000015, min=000000000032, sec=000000000052)
+    version=000000000000
+  $end 'properties'
+  $begin '$base_index$'
+    $index$(pos=000000318773, lin=000000011311, lvl=000000000000)
+  $end '$base_index$'
+$end '$base_index$'
+$begin 'FC-78'
+  $begin 'MaterialDef'
+    $begin 'FC-78'
+      CoordinateSystemType='Cartesian'
+      BulkOrSurfaceType=1
+      $begin 'PhysicsTypes'
+        set('Thermal')
+      $end 'PhysicsTypes'
+      $begin 'AttachedData'
+        $begin 'MatAppearanceData'
+          property_data='appearance_data'
+          Red=0
+          Green=128
+          Blue=255
+          Transparency=0.8
+        $end 'MatAppearanceData'
+      $end 'AttachedData'
+      thermal_conductivity='0.062'
+      mass_density='1700'
+      specific_heat='1050'
+      thermal_expansion_coeffcient='0.0016'
+      $begin 'thermal_material_type'
+        property_type='ChoiceProperty'
+        Choice='Fluid'
+      $end 'thermal_material_type'
+      $begin 'clarity_type'
+        property_type='ChoiceProperty'
+        Choice='Transparent'
+      $end 'clarity_type'
+      molecular_mass='0.001'
+      viscosity='0.000462'
+      ModTime=1592011950
+    $end 'FC-78'
+  $end 'MaterialDef'
+$end 'FC-78'
+$begin 'Polyflon CuFlon (tm)'
+  $begin 'AttachedData'
+    $begin 'MatAppearanceData'
+      property_data='appearance_data'
+      Red=230
+      Green=225
+      Blue=220
+    $end 'MatAppearanceData'
+  $end 'AttachedData'
+  simple('permittivity', 2.1)
+  simple('dielectric_loss_tangent', 0.00045)
+  ModTime=1499970477
+$end 'Polyflon CuFlon (tm)'
+$begin 'Water(@360K)'
+  $begin 'MaterialDef'
+    $begin 'Water(@360K)'
+      CoordinateSystemType='Cartesian'
+      BulkOrSurfaceType=1
+      $begin 'PhysicsTypes'
+        set('Thermal')
+      $end 'PhysicsTypes'
+      $begin 'AttachedData'
+        $begin 'MatAppearanceData'
+          property_data='appearance_data'
+          Red=0
+          Green=128
+          Blue=255
+          Transparency=0.8
+        $end 'MatAppearanceData'
+      $end 'AttachedData'
+      thermal_conductivity='0.6743'
+      mass_density='967.4'
+      specific_heat='4206'
+      thermal_expansion_coeffcient='0.0006979'
+      $begin 'thermal_material_type'
+        property_type='ChoiceProperty'
+        Choice='Fluid'
+      $end 'thermal_material_type'
+      $begin 'clarity_type'
+        property_type='ChoiceProperty'
+        Choice='Transparent'
+      $end 'clarity_type'
+      material_refractive_index='1.333'
+      diffusivity='1.657e-007'
+      molecular_mass='0.018015'
+      viscosity='0.000324'
+      ModTime=1592011950
+    $end 'Water(@360K)'
+  $end 'MaterialDef'
+$end 'Water(@360K)'
+$begin 'steel_stainless'
+  $begin 'AttachedData'
+    $begin 'MatAppearanceData'
+      property_data='appearance_data'
+      Red=176
+      Green=154
+      Blue=176
+    $end 'MatAppearanceData'
+  $end 'AttachedData'
+  simple('conductivity', 1100000)
+  simple('thermal_conductivity', 13.8)
+  simple('mass_density', 8055)
+  simple('specific_heat', 480)
+  simple('youngs_modulus', 195000000000)
+  simple('poissons_ratio', 0.3)
+  simple('thermal_expansion_coeffcient', 1.08e-005)
+  ModTime=1499970477
+$end 'steel_stainless'
+$begin '$index$'
+	$begin '$index$'
+		steel_stainless(pos=1224, lin=48, lvl=0)
+		'Polyflon CuFlon (tm)'(pos=22164, lin=814, lvl=0)
+		'FC-78'(pos=126130, lin=4842, lvl=0)
+    'Water(@360K)'(pos=118115, lin=4556, lvl=0)
+		$base_index$(pos=0, lin=1, lvl=0)
+		$index$(pos=318773, lin=11311, lvl=0)
+	$end '$index$'
+$end '$index$'

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -1,10 +1,14 @@
+import builtins
 import json
 import os
 
 # Setup paths for module imports
 # Import required modules
 import sys
+from unittest.mock import mock_open
 
+from mock import MagicMock
+from mock import patch
 import pytest
 
 from pyaedt import Edb
@@ -12,6 +16,7 @@ from pyaedt.edb_core.components import resistor_value_parser
 from pyaedt.edb_core.edb_data.edbvalue import EdbValue
 from pyaedt.edb_core.edb_data.simulation_configuration import SimulationConfiguration
 from pyaedt.edb_core.edb_data.sources import Source
+from pyaedt.edb_core.materials import Materials
 from pyaedt.generic.constants import RadiationBoxType
 from pyaedt.generic.general_methods import check_numeric_equivalence
 
@@ -32,6 +37,59 @@ from pyaedt.generic.constants import SourceType
 #     import _unittest_ironpython.conf_unittest as pytest
 
 test_subfolder = "TEDB"
+
+MATERIALS = """
+$begin 'Polyflon CuFlon (tm)'
+  $begin 'AttachedData'
+    $begin 'MatAppearanceData'
+      property_data='appearance_data'
+      Red=230
+      Green=225
+      Blue=220
+    $end 'MatAppearanceData'
+  $end 'AttachedData'
+  simple('permittivity', 2.1)
+  simple('dielectric_loss_tangent', 0.00045)
+  ModTime=1499970477
+$end 'Polyflon CuFlon (tm)'
+$begin 'Water(@360K)'
+  $begin 'MaterialDef'
+    $begin 'Water(@360K)'
+      CoordinateSystemType='Cartesian'
+      BulkOrSurfaceType=1
+      $begin 'PhysicsTypes'
+        set('Thermal')
+      $end 'PhysicsTypes'
+      $begin 'AttachedData'
+        $begin 'MatAppearanceData'
+          property_data='appearance_data'
+          Red=0
+          Green=128
+          Blue=255
+          Transparency=0.8
+        $end 'MatAppearanceData'
+      $end 'AttachedData'
+      thermal_conductivity='0.6743'
+      mass_density='967.4'
+      specific_heat='4206'
+      thermal_expansion_coeffcient='0.0006979'
+      $begin 'thermal_material_type'
+        property_type='ChoiceProperty'
+        Choice='Fluid'
+      $end 'thermal_material_type'
+      $begin 'clarity_type'
+        property_type='ChoiceProperty'
+        Choice='Transparent'
+      $end 'clarity_type'
+      material_refractive_index='1.333'
+      diffusivity='1.657e-007'
+      molecular_mass='0.018015'
+      viscosity='0.000324'
+      ModTime=1592011950
+    $end 'Water(@360K)'
+  $end 'MaterialDef'
+$end 'Water(@360K)'
+"""
 
 
 @pytest.fixture(scope="class")
@@ -2954,12 +3012,23 @@ class TestClass:
         assert len(edbapp.nets["DDR4_DM3"].find_dc_short()) == 0
         edbapp.close()
 
-    def test_148_load_amat(self):
-        assert "Rogers RO3003 (tm)" in self.edbapp.materials.materials_in_aedt
-        material_file = os.path.join(self.edbapp.materials.syslib, "Materials.amat")
-        assert self.edbapp.materials.add_material_from_aedt("Arnold_Magnetics_N28AH_-40C")
-        assert "Arnold_Magnetics_N28AH_-40C" in self.edbapp.materials.materials.keys()
-        assert self.edbapp.materials.load_amat(material_file)
+    @patch.object(builtins, "open", new_callable=mock_open, read_data=MATERIALS)
+    def test_149_materials_read_materials(self, mock_file_open):
+        """Read materials from an amat file."""
+        materials = Materials(MagicMock(materials=["copper"]))
+        expected_res = {
+            "Polyflon CuFlon (tm)": {"permittivity": 2.1, "tangent_delta": 0.00045},
+            "Water(@360K)": {
+                "thermal_conductivity": 0.6743,
+                "mass_density": 967.4,
+                "specific_heat": 4206,
+                "thermal_expansion_coeffcient": 0.0006979,
+            },
+        }
+        mats = materials.read_materials("some path")
+        assert mats == expected_res
+
+    def test_150_material_load_syslib_amat(self):
         material_list = list(self.edbapp.materials.materials.keys())
         assert material_list
         assert len(material_list) > 0

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -3031,9 +3031,10 @@ class TestClass:
         mats = materials.read_materials("some path")
         assert mats == expected_res
 
-    def test_150_material_load_syslib_amat(self):
+    def test_150_material_load_amat(self):
         """Load material from an AMAT file."""
-        assert self.edbapp.materials.load_syslib_amat()
+        mat_file = os.path.join(self.edbapp.base_path, "syslib", "Materials.amat")
+        assert self.edbapp.materials.load_amat(mat_file)
         material_list = list(self.edbapp.materials.materials.keys())
         assert material_list
         assert len(material_list) > 0

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -3029,8 +3029,37 @@ class TestClass:
         assert mats == expected_res
 
     def test_150_material_load_syslib_amat(self):
+        """Load material from an amat file."""
+        assert self.edbapp.materials.load_syslib_amat()
         material_list = list(self.edbapp.materials.materials.keys())
         assert material_list
         assert len(material_list) > 0
         assert self.edbapp.materials.materials["Rogers RO3003 (tm)"].loss_tangent == 0.0013
         assert self.edbapp.materials.materials["Rogers RO3003 (tm)"].permittivity == 3.0
+
+    def test_151_materials_read_materials(self):
+        """Read materials."""
+        path = os.path.join(local_path, "example_models", "syslib", "Materials.amat")
+        mats = self.edbapp.materials.read_materials(path)
+        key = "FC-78"
+        assert key in mats
+        assert mats[key]["thermal_conductivity"] == 0.062
+        assert mats[key]["mass_density"] == 1700
+        assert mats[key]["specific_heat"] == 1050
+        assert mats[key]["thermal_expansion_coeffcient"] == 0.0016
+        key = "Polyflon CuFlon (tm)"
+        assert key in mats
+        assert mats[key]["permittivity"] == 2.1
+        assert mats[key]["tangent_delta"] == 0.00045
+        key = "Water(@360K)"
+        assert key in mats
+        assert mats[key]["thermal_conductivity"] == 0.6743
+        assert mats[key]["mass_density"] == 967.4
+        assert mats[key]["specific_heat"] == 4206
+        assert mats[key]["thermal_expansion_coeffcient"] == 0.0006979
+        key = "steel_stainless"
+        assert mats[key]["conductivity"] == 1100000
+        assert mats[key]["thermal_conductivity"] == 13.8
+        assert mats[key]["mass_density"] == 8055
+        assert mats[key]["specific_heat"] == 480
+        assert mats[key]["thermal_expansion_coeffcient"] == 1.08e-005

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -8,6 +8,7 @@ import sys
 from unittest.mock import mock_open
 
 from mock import MagicMock
+from mock import PropertyMock
 from mock import patch
 import pytest
 
@@ -3012,10 +3013,12 @@ class TestClass:
         assert len(edbapp.nets["DDR4_DM3"].find_dc_short()) == 0
         edbapp.close()
 
+    @patch("pyaedt.edb_core.materials.Materials.materials", new_callable=PropertyMock)
     @patch.object(builtins, "open", new_callable=mock_open, read_data=MATERIALS)
-    def test_149_materials_read_materials(self, mock_file_open):
+    def test_149_materials_read_materials(self, mock_file_open, mock_materials_property):
         """Read materials from an AMAT file."""
-        materials = Materials(MagicMock(materials=["copper"]))
+        mock_materials_property.return_value = ["copper"]
+        materials = Materials(MagicMock())
         expected_res = {
             "Polyflon CuFlon (tm)": {"permittivity": 2.1, "tangent_delta": 0.00045},
             "Water(@360K)": {

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -3014,7 +3014,7 @@ class TestClass:
 
     @patch.object(builtins, "open", new_callable=mock_open, read_data=MATERIALS)
     def test_149_materials_read_materials(self, mock_file_open):
-        """Read materials from an amat file."""
+        """Read materials from an AMAT file."""
         materials = Materials(MagicMock(materials=["copper"]))
         expected_res = {
             "Polyflon CuFlon (tm)": {"permittivity": 2.1, "tangent_delta": 0.00045},
@@ -3029,7 +3029,7 @@ class TestClass:
         assert mats == expected_res
 
     def test_150_material_load_syslib_amat(self):
-        """Load material from an amat file."""
+        """Load material from an AMAT file."""
         assert self.edbapp.materials.load_syslib_amat()
         material_list = list(self.edbapp.materials.materials.keys())
         assert material_list

--- a/doc/source/Getting_started/Troubleshooting.rst
+++ b/doc/source/Getting_started/Troubleshooting.rst
@@ -135,11 +135,12 @@ Failure connecting to the gRPC server
 On Linux, PyAEDT may fail to initialize a new instance of the gRPC server
 or connect to an existing server session.
 This may be due to:
- - Firewall
- - Proxy
- - Permissions
- - License
- - Scheduler (for example if the gRPC server was started from LSF or Slurm)
+
+- Firewall
+- Proxy
+- Permissions
+- License
+- Scheduler (for example if the gRPC server was started from LSF or Slurm)
 
 For issues related to use of a proxy server, you may set the following environment variable to
 disable the proxy server for the *localhost*.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -318,6 +318,7 @@ html_context = {
 # specify the location of your github repo
 html_theme_options = {
     "github_url": "https://github.com/ansys/pyaedt",
+    "navigation_with_keys": False,
     "show_prev_next": False,
     "show_breadcrumbs": True,
     "collapse_navigation": True,

--- a/pyaedt/edb_core/materials.py
+++ b/pyaedt/edb_core/materials.py
@@ -861,22 +861,21 @@ class Materials(object):
             return True
 
     @pyaedt_function_handler()
-    def load_syslib_amat(self, filename="Materials.amat"):
-        """Load materials from an AMAT file located in the project system library.
+    def load_amat(self, amat_file):
+        """Load materials from an AMAT file.
 
         Parameters
         ----------
-        filename : str
-            Name of the AMAT file.
+        amat_file : str
+            Full path to the amat file to read and add to the Edb.
 
         Returns
         -------
         bool
         """
-        mat_file = os.path.join(self._syslib, filename)
-        if not os.path.exists(mat_file):
-            self._pedb.logger.error("File path {} does not exist.".format(mat_file))
-        material_dict = self.read_materials(mat_file)
+        if not os.path.exists(amat_file):
+            self._pedb.logger.error("File path {} does not exist.".format(amat_file))
+        material_dict = self.read_materials(amat_file)
         for material_name, material in material_dict.items():
             if not material_name in list(self.materials.keys()):
                 new_material = self.add_material(name=material_name)
@@ -897,13 +896,13 @@ class Materials(object):
 
     @staticmethod
     @pyaedt_function_handler()
-    def read_materials(mat_file):
+    def read_materials(amat_file):
         """Read materials from an AMAT file.
 
         Parameters
         ----------
-        filename : str
-            Name of the AMAT file.
+        amat_file : str
+            Full path to the amat file to read.
 
         Returns
         -------
@@ -941,7 +940,7 @@ class Materials(object):
             "mass_density",
         ]
 
-        with open(mat_file, "r") as amat_fh:
+        with open(amat_file, "r") as amat_fh:
             raw_lines = amat_fh.read().splitlines()
             mat_found = ""
             for line in raw_lines:

--- a/pyaedt/edb_core/materials.py
+++ b/pyaedt/edb_core/materials.py
@@ -827,7 +827,7 @@ class Materials(object):
 
     @pyaedt_function_handler()
     def add_material_from_aedt(self, material_name):
-        """Add a material read from ``syslib AMAT`` library.
+        """Add a material read from a ``syslib AMAT`` library.
 
         Parameters
         ----------
@@ -867,7 +867,7 @@ class Materials(object):
         Parameters
         ----------
         amat_file : str
-            Full path to the amat file to read and add to the Edb.
+            Full path to the AMAT file to read and add to the Edb.
 
         Returns
         -------
@@ -902,7 +902,7 @@ class Materials(object):
         Parameters
         ----------
         amat_file : str
-            Full path to the amat file to read.
+            Full path to the AMAT file to read.
 
         Returns
         -------

--- a/pyaedt/edb_core/materials.py
+++ b/pyaedt/edb_core/materials.py
@@ -911,6 +911,11 @@ class Materials(object):
         """
 
         def get_line_float_value(line):
+            """Retrieve the float value expected in the line of an AMAT file.
+            The associated string is expected to follow one of the following cases:
+            - simple('permittivity', 12.)
+            - permittivity='12'.
+            """
             try:
                 return float(re.split(",|=", line)[-1].strip(")'"))
             except ValueError:

--- a/pyaedt/edb_core/materials.py
+++ b/pyaedt/edb_core/materials.py
@@ -827,7 +827,7 @@ class Materials(object):
 
     @pyaedt_function_handler()
     def add_material_from_aedt(self, material_name):
-        """Add a material read from ``syslib amat`` library.
+        """Add a material read from ``syslib AMAT`` library.
 
         Parameters
         ----------
@@ -862,12 +862,12 @@ class Materials(object):
 
     @pyaedt_function_handler()
     def load_syslib_amat(self, filename="Materials.amat"):
-        """Load materials from an amat file located in the project system library.
+        """Load materials from an AMAT file located in the project system library.
 
         Parameters
         ----------
         filename : str
-            Name of the amat file.
+            Name of the AMAT file.
 
         Returns
         -------
@@ -898,12 +898,12 @@ class Materials(object):
     @staticmethod
     @pyaedt_function_handler()
     def read_materials(mat_file):
-        """Read materials from an amat file.
+        """Read materials from an AMAT file.
 
         Parameters
         ----------
         filename : str
-            Name of the amat file.
+            Name of the AMAT file.
 
         Returns
         -------

--- a/pyaedt/edb_core/materials.py
+++ b/pyaedt/edb_core/materials.py
@@ -908,7 +908,7 @@ class Materials(object):
         Returns
         -------
         dict
-            {material name: dict of material property to value}
+            {material name: dict of material property to value}.
         """
 
         def get_line_float_value(line):

--- a/pyaedt/generic/LoadAEDTFile.py
+++ b/pyaedt/generic/LoadAEDTFile.py
@@ -155,7 +155,7 @@ def _decode_recognized_subkeys(sk, d):
         if m and m.group("SKEY1") == "simple":  # extra verification. SKEY2 is with spaces, so it's not considered here.
             elems = _separate_list_elements(m.group("LIST1"))
             if elems[0] == "thermal_expansion_coeffcient":
-                elems[0] = "thermal_expansion_coefficient"  # fix a typo in the amat files. AEDT supports both strings!
+                elems[0] = "thermal_expansion_coefficient"  # fix a typo in the AMAT files. AEDT supports both strings!
             d[elems[0]] = str(elems[1])  # convert to string as it is dedicated to material props
             return True
     elif re.search(r"^\w+IDMap\(.*\)$", sk, re.IGNORECASE):  # check if the format is AAKeyIDMap('10'=56802, '7'=56803)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ tests = [
     "matplotlib==3.8.0; python_version > '3.8'",
     "numpy==1.21.6; python_version <= '3.9'",
     "numpy==1.26.0; python_version > '3.9'",
+    "mock",
     "openpyxl==3.1.2",
     "osmnx",
     "pandas==1.3.5; python_version == '3.7'",


### PR DESCRIPTION
This PR is a proposition to refact how EDB reads materials file
    
Problem
Current implementation leverages load_entire_aedt_file from pyaedt.generic.LoadAEDTFile.
    
Solution
The proposed solution consists in reworking the way amat are read and loaded. First, we only allow to load amat that are located in AEDT's syslib directory. By default, the file that is read is "Materials.amat".
Since we only work with syslib, the code related to personallib has been removed.
    
Note
The proposed solutions is inspired from https://github.com/ansys/pyaedt/pull/3711. The resulting code refacts the PR's code to have fewers LOC and fixes many errors that were part of the PR.
