### PR TITLE
CI: remove potential vale warnings

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -19,22 +19,15 @@ concurrency:
 
 jobs:
   docs-style:
-    name: Documentation Style Check
+    name: "Check documentation style"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-  
-      - name: Running Vale
-        uses: errata-ai/vale-action@reviewdog
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: "Check documentation style"
+        uses: ansys/actions/doc-style@v4
         with:
-          files: doc
-          reporter: github-pr-check
-          level: error
-          filter_mode: nofilter
-          fail_on_error: true
-          vale_flags: "--config=doc/.vale.ini"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          vale-config: "doc/.vale.ini"
+          vale-version: "2.29.6"
 
   docs_build:
     runs-on: ubuntu-20.04

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -1,51 +1,46 @@
-ANSYS
-Ansys
-ansys
-AEDB
-API
-AEDT
-AEDT API
 2D Extractor
+2D modeler
+3D modeler
+_static
+AEDB
+AEDT
 airbox
 airgap
+(?i)Ansys
+API
 autosave
 busbar
 busbars
 Bz
-circuit
-Circuit
-com
-COM
+[Cc]ircuit
+codecov
+[Cc]om
 COM interface
-Components
-components
+[Cc]omponents
+Conda
 CPython
 DesignXploration
 docstring
-Docstrings
-docstrings
+[Dd]ocstrings
 doppler
 EDB
-EDB API
+EDT
 efields
 EMIT
 getters
 globals
-gRPC
-GRPC
+[Gg]gRPC
 HFSS
-HFSS 3D Layout
 Huray
 Icepak
 IronPython
+[Ll]ayout
 limitilines
-Layout
-layout
 matplotlib
 Maxwell 2D
 Maxwell 3D
 Maxwell Circuit
-Mechanical
+[Mm]echanical
 multiphysics
 multiplot
 namespaces
@@ -53,52 +48,39 @@ netlist
 Nexxim
 numpy
 numpydoc
-optimetrics
-Optimetrics
+[Oo]ptimetrics
 padstack
 padstacks
 parametrics
-polyline
-polylines
-Polyline
-Postprocessing
 PMs
+[Pp]olyline
+polylines
+Postprocessing
+pwl
 pyaedt
 PyAEDT
-PyAnsys
-PyPI
+(?i)PyAnsys
+[Pp]y[Pp][Ii]
 Python
+Python.NET
 pyvista
 Q2D Extractor
-Q3D Extractor
 Q3D
+Q3D Extractor
 RC
+reusability
 RF
 RMXprt
 scipy
-Siwave
 setters
+Siwave
+Slurm
 Spyder
+Stackup 3D
 stackups
 stripline
 subcircuit
+[Tt]oolkits
 Twin Builder
 Uncomment
 vias
-_static
-pwl
-Conda
-PyAnsys
-codecov
-mechanical
-reusability
-pypi
-EDT
-pyansys
-Slurm
-Python.NET
-Toolkits
-toolkits
-3D modeler
-2D modeler
-Stackup 3D


### PR DESCRIPTION
At least since version 2.29.3 of vale, titles are also checked by vale. Thus, multiple warning started appearing due to non deterministic behavior when using multiple (differently-cased) entries for the same terme.

The proposed solution consists in reworking the accept.txt file until no more warnings are generated.