### PR TITLE
Add jupytext header

### DIFF
--- a/examples/02-HFSS/Array.py
+++ b/examples/02-HFSS/Array.py
@@ -1,3 +1,17 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: sphinx
+#       format_version: '1.1'
+#       jupytext_version: 1.14.5
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
 """
 HFSS: component antenna array
 -----------------------------
@@ -6,31 +20,33 @@ the analysis, solves it, and uses postprocessing functions to create plots using
 PyVista without opening the HFSS user interface. This examples runs only on Windows using CPython.
 """
 ##########################################################
-# Perform required imports
-# ~~~~~~~~~~~~~~~~~~~~~~~~
+# # Perform required imports
+#
 # Perform required imports.
 
 import os
 import pyaedt
 
 ##########################################################
-# Set non-graphical mode
-# ~~~~~~~~~~~~~~~~~~~~~~
+# ## Set non-graphical mode
+#
 # Set non-graphical mode. 
 # You can set ``non_graphical`` either to ``True`` or ``False``.
 
 non_graphical = False
 
 ##########################################################
-# Download 3D component
-# ~~~~~~~~~~~~~~~~~~~~~
+# ## Download 3D component
+#
 # Download the 3D component that is needed to run the example.
+
 example_path = pyaedt.downloads.download_3dcomponent()
 
 ##########################################################
-# Launch HFSS and save project
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ## Launch HFSS and save project
+#
 # Launch HFSS and save the project.
+
 project_name = pyaedt.generate_unique_project_name(project_name="array")
 hfss = pyaedt.Hfss(projectname=project_name,
                    specified_version="2023.2",
@@ -41,12 +57,12 @@ hfss = pyaedt.Hfss(projectname=project_name,
 print("Project name " + project_name)
 
 ##########################################################
-# Read array definition from JSON file
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ## Read array definition from JSON file
+#
 # Read the array definition from a JSON file. A JSON file
 # can contain all information needed to import and set up a
 # full array in HFSS.
-# 
+#
 # If a 3D component is not available in the design, it is loaded
 # into the dictionary from the path that you specify. The following
 # code edits the dictionary to point to the location of the A3DCOMP file.
@@ -57,8 +73,8 @@ dict_in["cells"][(3, 3)] = {"name": "Circ_Patch_5GHz1"}
 array = hfss.add_3d_component_array_from_json(dict_in)
 
 ##########################################################
-# Modify cells
-# ~~~~~~~~~~~~
+# ## Modify cells
+#
 # Make center element passive and rotate corner elements.
 
 array.cells[1][1].is_active = False
@@ -68,8 +84,8 @@ array.cells[2][0].rotation = 90
 array.cells[2][2].rotation = 90
 
 ##########################################################
-# Set up simulation
-# ~~~~~~~~~~~~~~~~~
+# ## Set up simulation
+#
 # Set up a simulation and analyze it.
 
 setup = hfss.create_setup()
@@ -79,8 +95,8 @@ setup.props["MaximumPasses"] = 3
 hfss.analyze(num_cores=4)
 
 ##########################################################
-# Get far field data
-# ~~~~~~~~~~~~~~~~~~
+# ## Get far field data
+#
 # Get far field data. After the simulation completes, the far
 # field data is generated port by port and stored in a data class.
 
@@ -88,8 +104,8 @@ ffdata = hfss.get_antenna_ffd_solution_data(sphere_name="Infinite Sphere1", setu
                                             frequencies=[5e9])
 
 ##########################################################
-# Generate contour plot
-# ~~~~~~~~~~~~~~~~~~~~~
+# ## Generate contour plot
+#
 # Generate a contour plot. You can define the Theta scan
 # and Phi scan.
 
@@ -97,8 +113,8 @@ ffdata.plot_farfield_contour(qty_str='RealizedGain', convert_to_db=True,
                              title='Contour at {}Hz'.format(ffdata.frequency))
 
 ##########################################################
-# Generate 2D cutout plots
-# ~~~~~~~~~~~~~~~~~~~~~~~~
+# ## Generate 2D cutout plots
+#
 # Generate 2D cutout plots. You can define the Theta scan
 # and Phi scan.
 
@@ -113,8 +129,8 @@ ffdata.plot_2d_cut(primary_sweep="phi", secondary_sweep_value=30,
                    convert_to_db=True)
 
 ##########################################################
-# Generate 3D polar plots in Matplotlib
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ## Generate 3D polar plots in Matplotlib
+#
 # Generate 3D polar plots in Matplotlib. You can define
 # the Theta scan and Phi scan.
 
@@ -122,8 +138,8 @@ ffdata.polar_plot_3d(qty_str='RealizedGain',
                      convert_to_db=True)
 
 ##########################################################
-# Generate 3D plots in PyVista
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ## Generate 3D plots in PyVista
+#
 # Generate 3D plots in PyVista. You can define the Theta and Phi
 # scan angles. You can change the easy-to-use interactive plot
 # that is generated on the fly. 
@@ -134,8 +150,11 @@ ffdata.polar_plot_3d_pyvista(qty_str='RealizedGain',
                              show=False)
 
 ##########################################################
-# Release AEDT
-# ~~~~~~~~~~~~
+# ## Release AEDT
+#
 # Release AEDT.
 
 hfss.release_desktop()
+
+""
+


### PR DESCRIPTION
Added the jupytext header for sphinx to the example 02-HFSS/Array.py.  This makes it possble to directly view and edit the example with the jupyter notebook editor while developing examples if the jupytext plugin is installed. Markdown cells use markdown instead of restructured text.