### PR TITLE
Improve variations in create_report

### DIFF
--- a/pyaedt/modules/PostProcessor.py
+++ b/pyaedt/modules/PostProcessor.py
@@ -1615,7 +1615,7 @@ class PostProcessorCommon(object):
             ]
         report.expressions = expressions
         report.domain = domain
-        if not variations and domain == "Sweep" :
+        if not variations and domain == "Sweep":
             variations = self._app.available_variations.nominal_w_values_dict
             if variations:
                 variations["Freq"] = "All"

--- a/pyaedt/modules/PostProcessor.py
+++ b/pyaedt/modules/PostProcessor.py
@@ -1615,7 +1615,13 @@ class PostProcessorCommon(object):
             ]
         report.expressions = expressions
         report.domain = domain
-        if not variations:
+        if not variations and domain == "Sweep" :
+            variations = self._app.available_variations.nominal_w_values_dict
+            if variations:
+                variations["Freq"] = "All"
+            else:
+                variations = {"Freq": ["All"]}
+        elif not variations and domain != "Sweep":
             variations = self._app.available_variations.nominal_w_values_dict
         if primary_sweep_variable:
             report.primary_sweep = primary_sweep_variable


### PR DESCRIPTION
At the moment if variations is not provided as input to the method and there are no available variations in the design, report is empty. 