### PR TITLE
Fix parameter check in `create_frequency_sweep` & add related test

### DIFF
--- a/_unittest/test_11_Setup.py
+++ b/_unittest/test_11_Setup.py
@@ -58,7 +58,10 @@ class TestClass:
         assert self.aedtapp.get_sweeps("My_HFSS_Setup")
         sweep2 = setup1.add_sweep(sweepname="test_sweeptype", sweeptype="invalid")
         assert sweep2.props["Type"] == "Interpolating"
-        setup1.create_frequency_sweep(freqstart=1, freqstop="500MHz")
+        sweep3 = setup1.create_frequency_sweep(freqstart=1, freqstop="500MHz")
+        assert sweep3.props["Type"] == "Discrete"
+        sweep4 = setup1.create_frequency_sweep("GHz", 23, 25, 401, sweep_type="Fast")
+        assert sweep4.props["Type"] == "Fast"
 
     def test_02_create_circuit_setup(self):
         circuit = Circuit(specified_version=desktop_version)

--- a/pyaedt/modules/SolveSetup.py
+++ b/pyaedt/modules/SolveSetup.py
@@ -2247,12 +2247,12 @@ class SetupHFSS(Setup, object):
 
         # Set default values for num_of_freq_points if a value was not passed. Also,
         # check that sweep_type is valid.
-        if num_of_freq_points is None and sweep_type in ["Interpolating", "Fast"]:
-            num_of_freq_points = 401
-        elif num_of_freq_points is None and sweep_type == "Discrete":
-            num_of_freq_points = 5
+        if sweep_type in ["Interpolating", "Fast"]:
+            num_of_freq_points = num_of_freq_points or 401
+        elif sweep_type == "Discrete":
+            num_of_freq_points = num_of_freq_points or 5
         else:
-            raise AttributeError("Invalid in `sweep_type`. It has to be either 'Discrete', 'Interpolating', or 'Fast'")
+            raise ValueError("Invalid `sweep_type`. It has to be either 'Discrete', 'Interpolating', or 'Fast'")
 
         if sweepname is None:
             sweepname = generate_unique_name("Sweep")


### PR DESCRIPTION
The implementation introduced in #3636 for filling `nums_of_freq_points` is incorrect.
https://github.com/ansys/pyaedt/blob/62b6750a6b6e803cefa15c87e80329b1cb929f36/pyaedt/modules/SolveSetup.py#L2248-L2255
The exception will occur if `num_of_freq_points` isn't `None`, no matter what `sweep_type` is. The exception type of `ValueError` is more appropriate since it indicates correct types but wrong values.

A related test is included.