### PR TITLE
Fix `KeyError` in `enable_adaptive_setup_multifrequency`

### DIFF
--- a/_unittest/test_11_Setup.py
+++ b/_unittest/test_11_Setup.py
@@ -59,7 +59,7 @@ class TestClass:
         sweep2 = setup1.add_sweep(sweepname="test_sweeptype", sweeptype="invalid")
         assert sweep2.props["Type"] == "Interpolating"
         setup1.create_frequency_sweep(freqstart=1, freqstop="500MHz")
-    
+
     def test_01c_create_hfss_setup_auto_open(self):
         for setup in self.aedtapp.get_setups():
             self.aedtapp.delete_setup(setup)

--- a/_unittest/test_11_Setup.py
+++ b/_unittest/test_11_Setup.py
@@ -64,6 +64,7 @@ class TestClass:
         assert sweep4.props["Type"] == "Fast"
 
     def test_01c_create_hfss_setup_auto_open(self):
+        self.aedtapp.duplicate_design("auto_open")
         for setup in self.aedtapp.get_setups():
             self.aedtapp.delete_setup(setup)
         self.aedtapp.set_auto_open()
@@ -71,7 +72,6 @@ class TestClass:
         setup1.enable_adaptive_setup_multifrequency([1.9, 2.4], 0.02)
         assert setup1.update({"MaximumPasses": 20})
         assert setup1.props["SolveType"] == "MultiFrequency"
-        self.aedtapp.set_auto_open(False)
 
     def test_02_create_circuit_setup(self):
         circuit = Circuit(specified_version=desktop_version)
@@ -87,6 +87,7 @@ class TestClass:
         setup1.enable()
 
     def test_03_non_valid_setup(self):
+        self.aedtapp.set_active_design("HFSSDesign")
         self.aedtapp.duplicate_design("non_valid")
         setup1 = self.aedtapp.create_setup("My_HFSS_Setup2", self.aedtapp.SETUPS.HFSSDrivenAuto)
         assert not setup1.enable_adaptive_setup_multifrequency([1, 2, 3])

--- a/_unittest/test_11_Setup.py
+++ b/_unittest/test_11_Setup.py
@@ -59,6 +59,15 @@ class TestClass:
         sweep2 = setup1.add_sweep(sweepname="test_sweeptype", sweeptype="invalid")
         assert sweep2.props["Type"] == "Interpolating"
         setup1.create_frequency_sweep(freqstart=1, freqstop="500MHz")
+    
+    def test_01c_create_hfss_setup_auto_open(self):
+        for setup in self.aedtapp.get_setups():
+            self.aedtapp.delete_setup(setup)
+        self.aedtapp.set_auto_open()
+        setup1 = self.aedtapp.get_setup("Auto1")
+        setup1.enable_adaptive_setup_multifrequency([1.9, 2.4], 0.02)
+        assert setup1.update({"MaximumPasses": 20})
+        assert setup1.props["SolveType"] == "MultiFrequency"
 
     def test_02_create_circuit_setup(self):
         circuit = Circuit(specified_version=desktop_version)

--- a/_unittest/test_11_Setup.py
+++ b/_unittest/test_11_Setup.py
@@ -71,6 +71,7 @@ class TestClass:
         setup1.enable_adaptive_setup_multifrequency([1.9, 2.4], 0.02)
         assert setup1.update({"MaximumPasses": 20})
         assert setup1.props["SolveType"] == "MultiFrequency"
+        self.aedtapp.set_auto_open(False)
 
     def test_02_create_circuit_setup(self):
         circuit = Circuit(specified_version=desktop_version)

--- a/pyaedt/modules/SolveSetup.py
+++ b/pyaedt/modules/SolveSetup.py
@@ -2629,7 +2629,7 @@ class SetupHFSS(Setup, object):
             return False
         self.auto_update = False
         self.props["SolveType"] = "MultiFrequency"
-        if "MultipleAdaptiveFreqsSetup" not in self.props:
+        if "MultipleAdaptiveFreqsSetup" not in self.props:  # pragma no cover
             self.props["MultipleAdaptiveFreqsSetup"] = {}
         for el in list(self.props["MultipleAdaptiveFreqsSetup"].keys()):
             del self.props["MultipleAdaptiveFreqsSetup"][el]

--- a/pyaedt/modules/SolveSetup.py
+++ b/pyaedt/modules/SolveSetup.py
@@ -2629,6 +2629,8 @@ class SetupHFSS(Setup, object):
             return False
         self.auto_update = False
         self.props["SolveType"] = "MultiFrequency"
+       # props["MultipleAdaptiveFreqsSetup"] could potentially be nonexistent.
+       # A known case is the setup automatically created by setting auto-open region.
         if "MultipleAdaptiveFreqsSetup" not in self.props:  # pragma no cover
             self.props["MultipleAdaptiveFreqsSetup"] = {}
         for el in list(self.props["MultipleAdaptiveFreqsSetup"].keys()):

--- a/pyaedt/modules/SolveSetup.py
+++ b/pyaedt/modules/SolveSetup.py
@@ -2629,6 +2629,8 @@ class SetupHFSS(Setup, object):
             return False
         self.auto_update = False
         self.props["SolveType"] = "MultiFrequency"
+        if "MultipleAdaptiveFreqsSetup" not in self.props:
+            self.props["MultipleAdaptiveFreqsSetup"] = {}
         for el in list(self.props["MultipleAdaptiveFreqsSetup"].keys()):
             del self.props["MultipleAdaptiveFreqsSetup"][el]
         i = 0

--- a/pyaedt/modules/SolveSetup.py
+++ b/pyaedt/modules/SolveSetup.py
@@ -2629,8 +2629,8 @@ class SetupHFSS(Setup, object):
             return False
         self.auto_update = False
         self.props["SolveType"] = "MultiFrequency"
-       # props["MultipleAdaptiveFreqsSetup"] could potentially be nonexistent.
-       # A known case is the setup automatically created by setting auto-open region.
+        # props["MultipleAdaptiveFreqsSetup"] could potentially be nonexistent.
+        # A known case is the setup automatically created by setting auto-open region.
         if "MultipleAdaptiveFreqsSetup" not in self.props:  # pragma no cover
             self.props["MultipleAdaptiveFreqsSetup"] = {}
         for el in list(self.props["MultipleAdaptiveFreqsSetup"].keys()):


### PR DESCRIPTION
`props["MultipleAdaptiveFreqsSetup"]` could potentially be nonexistent.
A known case is the setup automatically created by setting auto-open region.
Related test case added.