### PR TITLE
Added skip for unit tests that fail when running AEDT with COM

### DIFF
--- a/_unittest/test_03_Materials.py
+++ b/_unittest/test_03_Materials.py
@@ -270,7 +270,7 @@ class TestClass:
         self.aedtapp["$df"] = 0.01
         assert mat.set_djordjevic_sarkar_model(dk="$dk", df="$df")
 
-    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in COM mode")
     def test_13_get_materials_in_project(self):
         used_materials = self.aedtapp.materials.get_used_project_material_names()
         assert isinstance(used_materials, list)

--- a/_unittest/test_03_Materials.py
+++ b/_unittest/test_03_Materials.py
@@ -1,5 +1,6 @@
 import os
 
+from _unittest.conftest import config
 from _unittest.conftest import local_path
 import pytest
 
@@ -269,6 +270,7 @@ class TestClass:
         self.aedtapp["$df"] = 0.01
         assert mat.set_djordjevic_sarkar_model(dk="$dk", df="$df")
 
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
     def test_13_get_materials_in_project(self):
         used_materials = self.aedtapp.materials.get_used_project_material_names()
         assert isinstance(used_materials, list)

--- a/_unittest/test_05_Mesh.py
+++ b/_unittest/test_05_Mesh.py
@@ -103,7 +103,7 @@ class TestClass:
             == "High"
         )
 
-    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in COM mode")
     def test_05_delete_mesh_ops(self):
         assert self.aedtapp.mesh.delete_mesh_operations("surface")
         assert len(self.aedtapp.mesh.meshoperation_names) == 2

--- a/_unittest/test_05_Mesh.py
+++ b/_unittest/test_05_Mesh.py
@@ -1,3 +1,4 @@
+from _unittest.conftest import config
 from _unittest.conftest import desktop_version
 import pytest
 
@@ -102,6 +103,7 @@ class TestClass:
             == "High"
         )
 
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
     def test_05_delete_mesh_ops(self):
         assert self.aedtapp.mesh.delete_mesh_operations("surface")
         assert len(self.aedtapp.mesh.meshoperation_names) == 2

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -867,7 +867,7 @@ class TestClass:
         assert self.aedtapp.assign_flux_tangential(box.faces[0], "FluxExample")
         assert self.aedtapp.assign_flux_tangential(box.faces[0].id, "FluxExample")
 
-    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in COM mode")
     @pytest.mark.skipif(desktop_version < "2023.2", reason="Method available in beta from 2023.2")
     def test_53_assign_layout_force(self, layout_comp):
         nets_layers = {

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -867,6 +867,7 @@ class TestClass:
         assert self.aedtapp.assign_flux_tangential(box.faces[0], "FluxExample")
         assert self.aedtapp.assign_flux_tangential(box.faces[0].id, "FluxExample")
 
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
     @pytest.mark.skipif(desktop_version < "2023.2", reason="Method available in beta from 2023.2")
     def test_53_assign_layout_force(self, layout_comp):
         nets_layers = {

--- a/_unittest/test_41_3dlayout_modeler.py
+++ b/_unittest/test_41_3dlayout_modeler.py
@@ -656,6 +656,7 @@ class TestClass:
         assert p2.name == "poly_test_41_void"
         assert not self.aedtapp.modeler.create_polygon_void("Top", points2, "another_object", name="poly_43_void")
 
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
     @pytest.mark.skipif(config["desktopVersion"] < "2023.2", reason="Working only from 2023 R2")
     def test_42_post_processing(self, add_app):
         test_post1 = add_app(project_name=test_post, application=Maxwell3d, subfolder=test_subfolder)

--- a/_unittest/test_41_3dlayout_modeler.py
+++ b/_unittest/test_41_3dlayout_modeler.py
@@ -656,7 +656,7 @@ class TestClass:
         assert p2.name == "poly_test_41_void"
         assert not self.aedtapp.modeler.create_polygon_void("Top", points2, "another_object", name="poly_43_void")
 
-    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in COM mode")
     @pytest.mark.skipif(config["desktopVersion"] < "2023.2", reason="Working only from 2023 R2")
     def test_42_post_processing(self, add_app):
         test_post1 = add_app(project_name=test_post, application=Maxwell3d, subfolder=test_subfolder)

--- a/_unittest/test_98_Icepak.py
+++ b/_unittest/test_98_Icepak.py
@@ -625,6 +625,7 @@ class TestClass:
         assert self.aedtapp.monitor.all_monitors == {}
         assert not self.aedtapp.monitor.delete_monitor("Test")
 
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
     def test_50_advanced3dcomp_export(self):
         self.aedtapp.insert_design("advanced3dcompTest")
         surf1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
@@ -713,6 +714,7 @@ class TestClass:
         surf1.delete()
         fan_obj_3d.delete()
 
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
     def test_51_advanced3dcomp_import(self):
         self.aedtapp.insert_design("test_3d_comp")
         surf1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
@@ -814,6 +816,7 @@ class TestClass:
             comp_file=os.path.join(file_path, file_name), targetCS="Global", auxiliary_dict=False, name="test"
         )
 
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
     def test_52_flatten_3d_components(self):
         self.aedtapp.insert_design("test_52")
         cs2 = self.aedtapp.modeler.create_coordinate_system(name="CS2")

--- a/_unittest/test_98_Icepak.py
+++ b/_unittest/test_98_Icepak.py
@@ -625,7 +625,7 @@ class TestClass:
         assert self.aedtapp.monitor.all_monitors == {}
         assert not self.aedtapp.monitor.delete_monitor("Test")
 
-    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in COM mode")
     def test_50_advanced3dcomp_export(self):
         self.aedtapp.insert_design("advanced3dcompTest")
         surf1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
@@ -714,7 +714,7 @@ class TestClass:
         surf1.delete()
         fan_obj_3d.delete()
 
-    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in COM mode")
     def test_51_advanced3dcomp_import(self):
         self.aedtapp.insert_design("test_3d_comp")
         surf1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
@@ -816,7 +816,7 @@ class TestClass:
             comp_file=os.path.join(file_path, file_name), targetCS="Global", auxiliary_dict=False, name="test"
         )
 
-    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in com mode")
+    @pytest.mark.skipif(not config["use_grpc"], reason="Not running in COM mode")
     def test_52_flatten_3d_components(self):
         self.aedtapp.insert_design("test_52")
         cs2 = self.aedtapp.modeler.create_coordinate_system(name="CS2")


### PR DESCRIPTION
Some unit tests will fail when opening desktop with COM, because some methods are only supported when AEDT runs in GRPC mode. 
This PR add a skip decorator for unit tests that fail when running AEDT with COM.
NOTE that CI unit tests run **always** in GRPC mode, so this modification is only necessary when running tests locally for development purposes.