### PR TITLE
Make license session test more consistent and meaningful

### DIFF
--- a/_unittest_solvers/test_26_emit.py
+++ b/_unittest_solvers/test_26_emit.py
@@ -1203,6 +1203,8 @@ class TestClass:
         with os.scandir(dot_ansys_directory) as dir:
             for file in dir:
                 filename_pieces = file.name.split('.')
+                # Since machine names can contain periods, there may be over five splits here
+                # We only care about the first split and last three splits
                 if len(filename_pieces) >= 5:
                     if (filename_pieces[0] == 'ansyscl' and 
                         filename_pieces[-3] == str(pid) and

--- a/_unittest_solvers/test_26_emit.py
+++ b/_unittest_solvers/test_26_emit.py
@@ -1,6 +1,7 @@
 # Import required modules
 import os
 import sys
+import tempfile
 
 from _unittest_solvers.conftest import config
 import pytest
@@ -1194,9 +1195,9 @@ class TestClass:
         do_run()
 
         # Find the license log for this process
-        appdata_local_path = os.getenv('LOCALAPPDATA')
+        appdata_local_path = tempfile.gettempdir()
         pid = os.getpid()
-        dot_ansys_directory = os.path.join(appdata_local_path, 'Temp\\.ansys')
+        dot_ansys_directory = os.path.join(appdata_local_path, '.ansys')
         
         license_file_path = ''
         with os.scandir(dot_ansys_directory) as dir:


### PR DESCRIPTION
Before, the license session test compared times in different scenarios. This relies on the license checkout/checkin times being consistent, which caused some intermittent failures depending on machine and license setup. The new test counts the number of checkout/checkins instead.