### PR TITLE
Fix typo in IBIS spec, 'seeries' to 'series'

### DIFF
--- a/pyaedt/generic/ibis_v7.json
+++ b/pyaedt/generic/ibis_v7.json
@@ -62,7 +62,7 @@
 		"L Series": "",
 		"Rl Series": "",
 		"C Series": "",
-		"Lc Seeries": "",
+		"Lc Series": "",
 		"Rc Series": "",
 		"Series Current": "",
 		"Series MOSFET": "",


### PR DESCRIPTION
It seemed like a typo, confirmed in latest IBIS spec https://ibis.org/ver7.2/