### PR TITLE
Enhancement/allow 3dcomp file loading

### DIFF
--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -205,7 +205,7 @@ class Design(AedtObjects):
             not is_ironpython
             and project_name
             and os.path.exists(project_name)
-            and os.path.splitext(project_name)[1] == ".aedt"
+            and (os.path.splitext(project_name)[1] == ".aedt" or os.path.splitext(project_name)[1] == ".a3dcomp")
         ):
             t = threading.Thread(target=load_aedt_thread, args=(project_name,))
             t.start()


### PR DESCRIPTION
Allow reading of ".a3dcomp" files in to pyaedt session. currently, only project name can contain only ".aedt" files but this change will allow also project name to contain only ".a3dcomp" files