### PR TITLE
pyvista parallel projection

### DIFF
--- a/pyaedt/generic/plot.py
+++ b/pyaedt/generic/plot.py
@@ -1522,6 +1522,7 @@ class ModelPlotter(CommonPlotter):
         """
         self.pv = pv.Plotter(notebook=self.is_notebook, off_screen=self.off_screen, window_size=self.windows_size)
         self.pv.enable_ssao()
+        self.pv.enable_parallel_projection()
         self.meshes = None
         if self.background_image:
             self.pv.add_background_image(self.background_image)


### PR DESCRIPTION
enable_parallel_projection() gives a traditional view of the object.

Traditional view
![image](https://github.com/ansys/pyaedt/assets/27995305/228da336-4366-4e54-ae5d-a6ef093540e8)

compare to 
![image](https://github.com/ansys/pyaedt/assets/27995305/8bfd7c24-b1fc-4021-96b7-9c283ed7562f)
