### PR TITLE
modified \pyaedt\pyaedt\modules\SetupTemplates.py

### DIFF
--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -562,6 +562,7 @@ NexximAMI = OrderedDict(
         "OutputQuantities": OutputQuantities,
         "NoiseOutputQuantities": NoiseOutputQuantities,
         "Name": "AMIAnalysis",
+        "InputType": 1,
         "AMIAnalysis": [32, False, False],
     }
 )


### PR DESCRIPTION
	-. add key for NexximAMI setup
	-. "InputType": 1, @line# 565