### PR TITLE
CI: extend full documentation timeout

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Retrieve PyAEDT version
         id: version
         run: |
-          echo "::set-output name=PYAEDT_VERSION::$(python -c "from pyaedt import __version__; print(__version__)")"
+          echo "PYAEDT_VERSION=$(python -c 'from pyaedt import __version__; print(__version__)')" >> $GITHUB_OUTPUT
           echo "PyAEDT version is: $(python -c "from pyaedt import __version__; print(__version__)")"
 
       # - name: Cache docs build directory

--- a/.github/workflows/full_documentation.yml
+++ b/.github/workflows/full_documentation.yml
@@ -34,7 +34,7 @@ jobs:
     # The type of runner that the job will run on
     name: full_documentation
     runs-on: [windows-latest, pyaedt]
-    timeout-minutes: 480
+    timeout-minutes: 720
     strategy:
       matrix:
         python-version: ['3.10']

--- a/.github/workflows/full_documentation.yml
+++ b/.github/workflows/full_documentation.yml
@@ -65,7 +65,7 @@ jobs:
         id: version
         run: |
           testenv\Scripts\Activate.ps1
-          echo "::set-output name=PYAEDT_VERSION::$(python -c "from pyaedt import __version__; print(__version__)")"
+          echo "PYAEDT_VERSION=$(python -c 'from pyaedt import __version__; print(__version__)')" >> $GITHUB_OUTPUT
           echo "PyAEDT version is: $(python -c "from pyaedt import __version__; print(__version__)")"
 
       - name: Create HTML Documentations

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install pyaedt
         run: |

--- a/.github/workflows/wheelhouse.yml
+++ b/.github/workflows/wheelhouse.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Retrieve PyAEDT version
         run: |
           testenv\Scripts\Activate.ps1
-          echo "::set-output name=PYAEDT_VERSION::$(python -c "from pyaedt import __version__; print(__version__)")"
+          echo "PYAEDT_VERSION=$(python -c 'from pyaedt import __version__; print(__version__)')" >> $GITHUB_OUTPUT
           echo "PyAEDT version is: $(python -c "from pyaedt import __version__; print(__version__)")"
         id: version
 

--- a/.github/workflows/wheelhouse_linux.yml
+++ b/.github/workflows/wheelhouse_linux.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Retrieve PyAEDT version
         run: |
-          echo "::set-output name=PYAEDT_VERSION::$(python -c "from pyaedt import __version__; print(__version__)")"
+          echo "PYAEDT_VERSION=$(python -c 'from pyaedt import __version__; print(__version__)')" >> $GITHUB_OUTPUT
           echo "PyAEDT version is: $(python -c "from pyaedt import __version__; print(__version__)")"
         id: version
 


### PR DESCRIPTION
The release of v0.7.9 got canceled because the new examples seems to have increased the total execution time to reach 8 hours. This commit adds 4 extra hours to finish the full_documentation job.

Note: we should reconsider the strategy to build our documentation (I know that moving the example to another project was a discussion and it might really be helpfull here).
