### PR TITLE
CI: fix full documentation upload step

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -92,7 +92,7 @@ jobs:
           python doc/print_errors.py
 
 #      - name: Upload Documentation
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: Documentation
 #          path: doc/_build/html

--- a/.github/workflows/full_documentation.yml
+++ b/.github/workflows/full_documentation.yml
@@ -114,7 +114,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     steps:
       - name: Deploy the stable documentation
-        uses: ansys/actions/doc-deploy-stable@v5
+        uses: ansys/actions/doc-deploy-stable@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -135,7 +135,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
 
       - name: Display structure of downloaded files
         run: ls -R
@@ -153,7 +153,7 @@ jobs:
           echo "VERSION_MEILI=$VERSION_MEILI" >> $GITHUB_ENV
 
       - name: "Deploy the stable documentation index for PyAEDT API"
-        uses: ansys/actions/doc-deploy-index@v5
+        uses: ansys/actions/doc-deploy-index@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/${{ env.VERSION }}
           index-name: pyaedt-v${{ env.VERSION_MEILI }}
@@ -162,7 +162,7 @@ jobs:
           pymeilisearchopts: --stop_urls \"EDBAPI\" # Add EDB API as another index.
 
       - name: "Deploy the stable documentation index for EDB API"
-        uses: ansys/actions/doc-deploy-index@v5
+        uses: ansys/actions/doc-deploy-index@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/${{ env.VERSION }}/EDBAPI/
           index-name: pyedb-v${{ env.VERSION_MEILI }}

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
 
       - name: Deploy development documentation
-        uses: ansys/actions/doc-deploy-dev@v5
+        uses: ansys/actions/doc-deploy-dev@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,13 +70,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
 
       - name: Display structure of downloaded files
         run: ls -R
       
       - name: "Deploy the dev documentation index for PyAEDT API"
-        uses: ansys/actions/doc-deploy-index@v5
+        uses: ansys/actions/doc-deploy-index@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev
           index-name: pyaedt-vdev
@@ -85,7 +85,7 @@ jobs:
           pymeilisearchopts: --stop_urls \"EDBAPI\" # Add EDB API as another index to show it in dropdown button
 
       - name: "Deploy the dev documentation index for EDB API"
-        uses: ansys/actions/doc-deploy-index@v5
+        uses: ansys/actions/doc-deploy-index@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev/EDBAPI/
           index-name: pyedb-vdev


### PR DESCRIPTION
Problem: it seems that using the new version (v4) of upload-artifact adds some upper bound on the number of files to be uploaded.

Solution: reverting our actions to use v3 and make changes compatible with other ansys actions, i.e. changing some ansys/action/... to v4

Associated issue : https://github.com/actions/upload-artifact/issues/485