### PR TITLE
Fix desktop reference counting

### DIFF
--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -410,3 +410,12 @@ class TestClass:
         assert "AmbRadTemp" in design_settings_dict
         assert "GravityVec" in design_settings_dict
         assert "GravityDir" in design_settings_dict
+
+    def test_41_desktop_reference_counting(self, desktop):
+        num_references = desktop._connected_app_instances
+        with Hfss() as hfss:
+            assert hfss
+            assert desktop._connected_app_instances == num_references + 1
+            hfss.set_active_design(hfss.design_name)
+            assert desktop._connected_app_instances == num_references + 1
+        assert desktop._connected_app_instances == num_references

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -142,7 +142,7 @@ class Design(AedtObjects):
         if self._desktop_class._connected_app_instances <= 0 and self._desktop_class._initialized_from_design:
             self.release_desktop(self.close_on_exit, self.close_on_exit)
 
-    def __enter__(self):
+    def __enter__(self):  # pragma: no cover
         self._desktop_class._connected_app_instances += 1
         return self
 

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -137,13 +137,14 @@ class Design(AedtObjects):
     def __exit__(self, ex_type, ex_value, ex_traceback):
         if ex_type:
             exception_to_desktop(ex_value, ex_traceback)
-        if self._desktop_class._connected_designs > 1:
-            self._desktop_class._connected_designs -= 1
+        if self._desktop_class._connected_app_instances > 1:
+            self._desktop_class._connected_app_instances -= 1
         elif self._desktop_class._initialized_from_design:
             self.release_desktop(self.close_on_exit, self.close_on_exit)
 
     def __enter__(self):
-        pass
+        self._desktop_class._connected_app_instances += 1
+        return self
 
     @pyaedt_function_handler()
     def __getitem__(self, variable_name):
@@ -234,8 +235,6 @@ class Design(AedtObjects):
             port,
             aedt_process_id,
         )
-        self._desktop_class._connected_designs += 1
-
         self.student_version = self._desktop_class.student_version
         if self.student_version:
             settings.disable_bounding_box_sat = True

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -137,7 +137,7 @@ class Design(AedtObjects):
     def __exit__(self, ex_type, ex_value, ex_traceback):
         if ex_type:
             exception_to_desktop(ex_value, ex_traceback)
-        if self._desktop_class._connected_app_instances > 0:
+        if self._desktop_class._connected_app_instances > 0:  # pragma: no cover
             self._desktop_class._connected_app_instances -= 1
         if self._desktop_class._connected_app_instances <= 0 and self._desktop_class._initialized_from_design:
             self.release_desktop(self.close_on_exit, self.close_on_exit)

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -139,7 +139,7 @@ class Design(AedtObjects):
             exception_to_desktop(ex_value, ex_traceback)
         if self._desktop_class._connected_app_instances > 0:
             self._desktop_class._connected_app_instances -= 1
-        if self._desktop_class._connected_app_instances < 1 and self._desktop_class._initialized_from_design:
+        if self._desktop_class._connected_app_instances <= 0 and self._desktop_class._initialized_from_design:
             self.release_desktop(self.close_on_exit, self.close_on_exit)
 
     def __enter__(self):

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -137,9 +137,9 @@ class Design(AedtObjects):
     def __exit__(self, ex_type, ex_value, ex_traceback):
         if ex_type:
             exception_to_desktop(ex_value, ex_traceback)
-        if self._desktop_class._connected_app_instances > 1:
+        if self._desktop_class._connected_app_instances > 0:
             self._desktop_class._connected_app_instances -= 1
-        elif self._desktop_class._initialized_from_design:
+        if self._desktop_class._connected_app_instances < 1 and self._desktop_class._initialized_from_design:
             self.release_desktop(self.close_on_exit, self.close_on_exit)
 
     def __enter__(self):

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -154,9 +154,6 @@ class Circuit(FieldAnalysisCircuit, object):
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)
 
-    def __enter__(self):
-        return self
-
     def _get_number_from_string(self, stringval):
         value = stringval[stringval.find("=") + 1 :].strip().replace("{", "").replace("}", "").replace(",", ".")
         value = value.replace("µ", "u")

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -484,7 +484,7 @@ class Desktop(object):
         self._initialized_from_design = True if Desktop._invoked_from_design else False
         Desktop._invoked_from_design = False
 
-        self._connected_designs = 0
+        self._connected_app_instances = 0
 
         """Initialize desktop."""
         self.launched_by_pyaedt = False

--- a/pyaedt/emit.py
+++ b/pyaedt/emit.py
@@ -190,10 +190,6 @@ class Emit(Design, object):
         return self._couplings
 
     @pyaedt_function_handler()
-    def __enter__(self):
-        return self
-
-    @pyaedt_function_handler()
     def version(self, detailed=False):
         """
         Get version information.

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -201,9 +201,6 @@ class Hfss(FieldAnalysis3D, object):
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)
 
-    def __enter__(self):
-        return self
-
     @property
     def field_setups(self):
         """List of AEDT radiation fields.

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -148,9 +148,6 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)
 
-    def __enter__(self):
-        return self
-
     @pyaedt_function_handler()
     def create_edge_port(
         self,

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -171,9 +171,6 @@ class Icepak(FieldAnalysis3D):
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)
 
-    def __enter__(self):
-        return self
-
     @property
     def problem_type(self):
         """Problem type of the Icepak design. Options are ``"TemperatureAndFlow"``, ``"TemperatureOnly"``,

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -21,9 +21,6 @@ from pyaedt.modules.SetupTemplates import SetupKeys
 
 
 class Maxwell(object):
-    def __enter__(self):
-        return self
-
     def __init__(self):
         pass
 

--- a/pyaedt/maxwellcircuit.py
+++ b/pyaedt/maxwellcircuit.py
@@ -204,6 +204,3 @@ class MaxwellCircuit(AnalysisMaxwellCircuit, object):
             return file_to_export
         except:
             return False
-
-    def __enter__(self):
-        return self

--- a/pyaedt/mechanical.py
+++ b/pyaedt/mechanical.py
@@ -130,9 +130,6 @@ class Mechanical(FieldAnalysis3D, object):
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)
 
-    def __enter__(self):
-        return self
-
     @pyaedt_function_handler()
     def assign_em_losses(
         self,

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -82,9 +82,6 @@ class QExtractor(FieldAnalysis3D, object):
         for el in list(self.omatrix.ListReduceMatrixes()):
             self.matrices.append(Matrix(self, el))
 
-    def __enter__(self):
-        return self
-
     @property
     def excitations(self):
         """Get all excitation names.

--- a/pyaedt/rmxprt.py
+++ b/pyaedt/rmxprt.py
@@ -239,9 +239,6 @@ class Rmxprt(FieldAnalysisRMxprt):
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)
 
-    def __enter__(self):
-        return self
-
     @property
     def design_type(self):
         """Machine design type."""

--- a/pyaedt/twinbuilder.py
+++ b/pyaedt/twinbuilder.py
@@ -563,6 +563,3 @@ class TwinBuilder(AnalysisTwinBuilder, object):
         if is_loaded:
             app.close_project(save_project=False)
         return True
-
-    def __enter__(self):
-        return self


### PR DESCRIPTION
Increment the desktop instance's "application reference count" in `Design.__enter__` instead of `Design.__init__` to avoid increasing the reference count incorrectly when, for example, `Hfss.set_active_design` is called.

Also remove unnecessarily duplicated `__enter__` definitions in each application subclass, leaving only `Design.__enter__`.

Fixes #4092