### PR TITLE
issue-4102-reverting-implementation-in-get_scalar_field_value

### DIFF
--- a/pyaedt/modules/PostProcessor.py
+++ b/pyaedt/modules/PostProcessor.py
@@ -2350,10 +2350,17 @@ class PostProcessor(PostProcessorCommon, object):
                 else:
                     variation_dict.append("0deg")
 
-        self.ofieldsreporter.ClcEval(solution, variation_dict)
-        value = self.ofieldsreporter.GetTopEntryValue(solution, variation_dict)
+        file_name = os.path.join(self._app.working_directory, generate_unique_name("temp_fld") + ".fld")
+        self.ofieldsreporter.CalculatorWrite(file_name, ["Solution:=", solution], variation_dict)
+        value = None
+        if os.path.exists(file_name) or settings.remote_rpc_session:
+            with open_file(file_name, "r") as f:
+                lines = f.readlines()
+                lines = [line.strip() for line in lines]
+                value = lines[-1]
+            os.remove(file_name)
         self.ofieldsreporter.CalcStack("clear")
-        return float(value[0])
+        return float(value)
 
     @pyaedt_function_handler()
     def export_field_file_on_grid(


### PR DESCRIPTION
The simplified implementation GetTopEntryValue works fine in small models but it is failing in the big model (mesh ~27M). Therefore I am reverting this implementation to the previous one with temp file exporting and reading it to extract value which we verified that works fine with bigger models. GetTopEntryValue was working fine with versions <=22R2 but something happened in later versions on the native scripting side.