### PR TITLE
MAINT: fix CI by fixing scipy and scikit-rf versions

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -3201,17 +3201,3 @@ class TestClass:
         assert edbapp.components.instances["Test"].ind_value == "0"
         assert edbapp.components.instances["Test"].cap_value == "0"
         assert edbapp.components.instances["Test"].center == [0.06800000116, 0.01649999875]
-
-    def test_161_create_polygon_check(self):
-        example_folder = os.path.join(local_path, "example_models", test_subfolder)
-        source_path_edb = os.path.join(example_folder, "ANSYS-HSD_V1.aedb")
-        target_path_edb = os.path.join(self.local_scratch.path, "test_component", "test.aedb")
-        self.local_scratch.copyfolder(source_path_edb, target_path_edb)
-        edbapp = Edb(target_path_edb, desktop_version)
-        edbapp.modeler.create_polygon(
-            main_shape=[[0.0, 0.0], [0.0, 10e-3], [10e-3, 10e-3], [10e-3, 0]], layer_name="1_Top", net_name="test"
-        )
-        poly_test = [poly for poly in edbapp.modeler.polygons if poly.net_name == "test"]
-        assert len(poly_test) == 1
-        assert poly_test[0].center == [0.005, 0.005]
-        assert poly_test[0].bbox == [0.0, 0.0, 0.01, 0.01]

--- a/pyaedt/edb_core/layout.py
+++ b/pyaedt/edb_core/layout.py
@@ -557,7 +557,7 @@ class EdbLayout(object):
             polygonData = self.shape_to_polygon_data(main_shape)
         else:
             polygonData = main_shape
-        if not polygonData or polygonData.IsNull():
+        if polygonData is False or polygonData is None or polygonData.IsNull():
             self._logger.error("Failed to create main shape polygon data")
             return False
         for void in voids:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,10 @@ tests = [
     "scikit-learn==1.3.1; python_version > '3.7'",
     "SRTM.py",
     "utm",
-    "scikit-rf",
+    # FIXME: remove scipy dependency and change scikit-rf version once scikit-rf is fixed
+    # see https://github.com/scikit-rf/scikit-rf/issues/1005
+    "scipy==1.11.4",
+    "scikit-rf==0.30.0",
 ]
 doc = [
     "ansys-sphinx-theme==0.13.1",
@@ -100,7 +103,10 @@ doc = [
     "sphinxcontrib-websupport==1.2.5; python_version <= '3.7'",
     "SRTM.py",
     "utm",
-    "scikit-rf",
+    # FIXME: remove scipy dependency and change scikit-rf version once scikit-rf is fixed
+    # see https://github.com/scikit-rf/scikit-rf/issues/1005
+    "scipy==1.11.4",
+    "scikit-rf==0.30.0",
     "openpyxl==3.1.2",
     "sphinx_design",
     "sphinx_jinja",
@@ -121,7 +127,10 @@ full = [
     "pyvista==0.38.0; python_version <= '3.7'",
     "SRTM.py",
     "utm",
-    "scikit-rf",
+    # FIXME: remove scipy dependency and change scikit-rf version once scikit-rf is fixed
+    # see https://github.com/scikit-rf/scikit-rf/issues/1005
+    "scipy==1.11.4",
+    "scikit-rf==0.30.0",
     "openpyxl==3.1.2",
 ]
 all = [
@@ -141,7 +150,10 @@ all = [
     "pyvista==0.38.0; python_version <= '3.7'",
     "SRTM.py",
     "utm",
-    "scikit-rf",
+    # FIXME: remove scipy dependency and change scikit-rf version once scikit-rf is fixed
+    # see https://github.com/scikit-rf/scikit-rf/issues/1005
+    "scipy==1.11.4",
+    "scikit-rf==0.30.0",
     "openpyxl==3.1.2",
 ]
 


### PR DESCRIPTION
There is a side effect on scikit-rf 0.30.0 as it uses scipy without bounding the version and that method linspace, used by scikit-rf is no longuer available through scipy import in scipy 1.12.0. (see https://github.com/scikit-rf/scikit-rf/issues/1005)

**Note**: this should be 'reverted' later on to use scikit-rf new version as it should fix the current issue.

**Extra note**: a commit revert is also added to this PR as it was added on main by mistake and is failing (see https://github.com/ansys/pyaedt/commit/37218a5c6d1da2b8149a40abf8e4655c0011d2a3)