### PR TITLE
MAINT: use scikit-rf 0.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,7 @@ tests = [
     "scikit-learn==1.3.1; python_version > '3.7'",
     "SRTM.py",
     "utm",
-    # FIXME: remove scipy dependency and change scikit-rf version once scikit-rf is fixed
-    # see https://github.com/scikit-rf/scikit-rf/issues/1005
-    "scipy==1.11.4",
-    "scikit-rf==0.30.0",
+    "scikit-rf==0.31.0",
 ]
 doc = [
     "ansys-sphinx-theme==0.13.1",
@@ -103,10 +100,7 @@ doc = [
     "sphinxcontrib-websupport==1.2.5; python_version <= '3.7'",
     "SRTM.py",
     "utm",
-    # FIXME: remove scipy dependency and change scikit-rf version once scikit-rf is fixed
-    # see https://github.com/scikit-rf/scikit-rf/issues/1005
-    "scipy==1.11.4",
-    "scikit-rf==0.30.0",
+    "scikit-rf==0.31.0",
     "openpyxl==3.1.2",
     "sphinx_design",
     "sphinx_jinja",
@@ -127,10 +121,7 @@ full = [
     "pyvista==0.38.0; python_version <= '3.7'",
     "SRTM.py",
     "utm",
-    # FIXME: remove scipy dependency and change scikit-rf version once scikit-rf is fixed
-    # see https://github.com/scikit-rf/scikit-rf/issues/1005
-    "scipy==1.11.4",
-    "scikit-rf==0.30.0",
+    "scikit-rf==0.31.0",
     "openpyxl==3.1.2",
 ]
 all = [
@@ -150,10 +141,7 @@ all = [
     "pyvista==0.38.0; python_version <= '3.7'",
     "SRTM.py",
     "utm",
-    # FIXME: remove scipy dependency and change scikit-rf version once scikit-rf is fixed
-    # see https://github.com/scikit-rf/scikit-rf/issues/1005
-    "scipy==1.11.4",
-    "scikit-rf==0.30.0",
+    "scikit-rf==0.31.0",
     "openpyxl==3.1.2",
 ]
 


### PR DESCRIPTION
This change happens following the fix on scikit-rf side.

Reminder: scikit-rf was trying to import a specific function from scipy while not bounding the version of scipy. The newest version of scipy had no longer the required function leading to CI breaks on our side as we no longer could run the tests.

Btw, I was able to test this change on a container with python 3.7 and it was working fine.

Closes #4137 