### PR TITLE
MISC: add logger error when object not found

### DIFF
--- a/pyaedt/modeler/cad/Primitives.py
+++ b/pyaedt/modeler/cad/Primitives.py
@@ -92,6 +92,7 @@ class GeometryModeler(Modeler):
             return self.user_defined_components[partId]
         elif isinstance(partId, Object3d) or isinstance(partId, UserDefinedComponent):
             return partId
+        self.logger.error("Object '{}' not found.".format(partId))
         return None
 
     def __init__(self, app, is3d=True):


### PR DESCRIPTION
Following user feedback (#4001) this PR adds an extra error log to clarify the fact that some calls might not work as expected since some objects don't exist (or at least are not found)