### PR TITLE
fix: declare regex as raw string to avoid escape sequence deprecation

### DIFF
--- a/pyaedt/application/Variables.py
+++ b/pyaedt/application/Variables.py
@@ -278,7 +278,7 @@ def decompose_variable_value(variable_value, full_variables={}):
             float_value = float(variable_value)
         except ValueError:
             # search for a valid units string at the end of the variable_value
-            loc = re.search("[-+]?(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?", variable_value)
+            loc = re.search(r"[-+]?(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?", variable_value)
             units = _find_units_in_dependent_variables(variable_value, full_variables)
             if loc:
                 loc_units = loc.span()[1]


### PR DESCRIPTION
Declare regex as raw string to avoid escape sequence deprecation.