### PR TITLE
CI: Fix documentation workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,18 +19,6 @@ testing:
     - "_unittest_ironpython/run_unittests.py"
     - "_unittest_ironpython/run_unittests_batchmode.cmd"
 
-# TODO : Remove once EDB is extracted from PyAEDT
-edb:
-- changed-files:
-  - any-glob-to-any-file:
-    - "examples/00-EDB/*"
-    - "examples/01-HFSS3DLayout/EDB_in_3DLayout.py"
-    - "examples/01-HFSS3DLayout/Dcir_in_3DLayout.py"
-    - "examples/05-Q3D/Q3D_from_EDB.py"
-    - "examples/05-Q3D/Q3D_DC_IR.py"
-    - "pyaedt/edb_core/**/*"
-    - "pyaedt/edb.py"
-
 examples:
 - changed-files:
   - any-glob-to-any-file:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -30,10 +30,6 @@
   description: Anything related to testing
   color: 5802B8
 
-- name: edb
-  description: Anything related to the EDB API
-  color: C4C25D
-
 - name: examples
   description: Anything related to the examples
   color: 3C2E5F

--- a/.github/workflows/full_documentation.yml
+++ b/.github/workflows/full_documentation.yml
@@ -85,13 +85,6 @@ jobs:
           path: doc/_build/html
           retention-days: 7
 
-      - name: Upload HTML documentation artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: documentation-html-edb
-          path: doc/_build/html/EDBAPI
-          retention-days: 7
-
 #      - name: Upload PDF documentation artifact
 #        uses: actions/upload-artifact@v4
 #        with:
@@ -159,14 +152,3 @@ jobs:
           index-name: pyaedt-v${{ env.VERSION_MEILI }}
           host-url: ${{ vars.MEILISEARCH_HOST_URL }}
           api-key: ${{ env.MEILISEARCH_API_KEY }}
-          pymeilisearchopts: --stop_urls \"EDBAPI\" # Add EDB API as another index.
-
-      - name: "Deploy the stable documentation index for EDB API"
-        uses: ansys/actions/doc-deploy-index@v4
-        with:
-          cname: ${{ env.DOCUMENTATION_CNAME }}/version/${{ env.VERSION }}/EDBAPI/
-          index-name: pyedb-v${{ env.VERSION_MEILI }}
-          host-url: ${{ vars.MEILISEARCH_HOST_URL }}
-          api-key: ${{ env.MEILISEARCH_API_KEY }}
-          doc-artifact-name: documentation-html-edb # Add only EDB API as page in this index.
-          pymeilisearchopts: --port 8001 #serve in another port

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -45,12 +45,6 @@ jobs:
           path: doc/_build/html
           retention-days: 7
 
-      - name: Upload HTML documentation artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation-html-edb
-          path: doc/_build/html/EDBAPI
-          retention-days: 7
 
   docs_upload:
     needs: docs_build
@@ -82,17 +76,6 @@ jobs:
           index-name: pyaedt-vdev
           host-url: ${{ vars.MEILISEARCH_HOST_URL }}
           api-key: ${{ env.MEILISEARCH_API_KEY }}
-          pymeilisearchopts: --stop_urls \"EDBAPI\" # Add EDB API as another index to show it in dropdown button
-
-      - name: "Deploy the dev documentation index for EDB API"
-        uses: ansys/actions/doc-deploy-index@v4
-        with:
-          cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev/EDBAPI/
-          index-name: pyedb-vdev
-          host-url: ${{ vars.MEILISEARCH_HOST_URL }}
-          api-key: ${{ env.MEILISEARCH_API_KEY }}
-          doc-artifact-name: documentation-html-edb # Add only EDB API as page in this index.
-          pymeilisearchopts: --port 8001 # serve in another port as 8000 is deafult
 
   # docstring_testing:
   #   runs-on: Windows


### PR DESCRIPTION
Currently, some workflows still try to interact with pieces of EDB documentation that is no longer created while building pyaedt documentation. On top of this cleanup, the automatic labeler leveraged to synchronize changes from pyaedt and pyedb is being removed.