### PR TITLE
MAINT: Depecrate python version 3.7

### DIFF
--- a/_unittest/test_warnings.py
+++ b/_unittest/test_warnings.py
@@ -1,0 +1,23 @@
+import sys
+from unittest.mock import patch
+import warnings
+
+from pyaedt import LATEST_DEPRECATED_PYTHON_VERSION
+from pyaedt import deprecation_warning
+
+
+@patch.object(warnings, "warn")
+def test_deprecation_warning(mock_warn):
+    deprecation_warning()
+
+    current_version = sys.version_info[:2]
+    if current_version <= LATEST_DEPRECATED_PYTHON_VERSION:
+        str_current_version = "{}.{}".format(*sys.version_info[:2])
+        expected = (
+            "Current python version ({}) is deprecated in PyAEDT. We encourage you "
+            "to upgrade to the latest version to benefit from the latest features "
+            "and security updates.".format(str_current_version)
+        )
+        mock_warn.assert_called_once_with(expected, PendingDeprecationWarning)
+    else:
+        mock_warn.assert_not_called()

--- a/pyaedt/__init__.py
+++ b/pyaedt/__init__.py
@@ -1,14 +1,50 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
+import warnings
 
 if os.name == "nt":
     os.environ["PYTHONMALLOC"] = "malloc"
 
+LATEST_DEPRECATED_PYTHON_VERSION = (3, 7)
+
+
+def deprecation_warning():
+    """Warning message informing users that some Python versions are deprecated in PyAEDT."""
+    # Store warnings showwarning
+    existing_showwarning = warnings.showwarning
+
+    # Define and use custom showwarning
+    def custom_show_warning(message, category, filename, lineno, file=None, line=None):
+        """Custom warning used to remove <stdin>:loc: pattern."""
+        print(f"{category.__name__}: {message}")
+
+    warnings.showwarning = custom_show_warning
+
+    current_version = sys.version_info[:2]
+    if current_version <= LATEST_DEPRECATED_PYTHON_VERSION:
+        str_current_version = "{}.{}".format(*sys.version_info[:2])
+        warnings.warn(
+            "Current python version ({}) is deprecated in PyAEDT. We encourage you "
+            "to upgrade to the latest version to benefit from the latest features "
+            "and security updates.".format(str_current_version),
+            PendingDeprecationWarning,
+        )
+
+    # Restore warnings showwarning
+    warnings.showwarning = existing_showwarning
+
+
+deprecation_warning()
+
+#
+
 pyaedt_path = os.path.dirname(__file__)
-
 __version__ = "0.8.dev0"
-
 version = __version__
+
+#
+
 import pyaedt.downloads as downloads
 from pyaedt.generic import constants
 import pyaedt.generic.DataHandlers as data_handler

--- a/pyaedt/__init__.py
+++ b/pyaedt/__init__.py
@@ -17,7 +17,7 @@ def deprecation_warning():
     # Define and use custom showwarning
     def custom_show_warning(message, category, filename, lineno, file=None, line=None):
         """Custom warning used to remove <stdin>:loc: pattern."""
-        print(f"{category.__name__}: {message}")
+        print("{}: {}".format(category.__name__, message))
 
     warnings.showwarning = custom_show_warning
 


### PR DESCRIPTION
This PR consists in triggering a deprecation warning when one uses PyAEDT with a python version <= 3.7
It is tested and implemented to be easily extended to any new python version.