### PR TITLE
CI: Update workflows runs-on

### DIFF
--- a/.github/workflows/full_documentation.yml
+++ b/.github/workflows/full_documentation.yml
@@ -33,7 +33,7 @@ jobs:
   full_documentation:
     # The type of runner that the job will run on
     name: full_documentation
-    runs-on: [windows-latest, pyaedt]
+    runs-on: [Windows, self-hosted, pyaedt]
     timeout-minutes: 720
     strategy:
       matrix:

--- a/.github/workflows/ironpython.yml
+++ b/.github/workflows/ironpython.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: [windows-latest, pyaedt]
+    runs-on: [Windows, self-hosted, pyaedt]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,7 +30,7 @@ jobs:
   # This workflow contains a single job called "build"
   build_solvers:
     # The type of runner that the job will run on
-    runs-on: [ windows-latest, pyaedt ]
+    runs-on: [Windows, self-hosted, pyaedt]
     strategy:
       matrix:
         python-version: [ '3.10' ]
@@ -93,7 +93,7 @@ jobs:
 
   build:
     # The type of runner that the job will run on
-    runs-on: [windows-latest, pyaedt]
+    runs-on: [Windows, self-hosted, pyaedt]
     strategy:
       matrix:
         python-version: ['3.10']

--- a/.github/workflows/unit_tests_solvers.bkp
+++ b/.github/workflows/unit_tests_solvers.bkp
@@ -30,7 +30,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: [windows-latest, pyaedt]
+    runs-on: [Windows, self-hosted, pyaedt]
     strategy:
       matrix:
         python-version: ['3.10']


### PR DESCRIPTION
Notes: to refact the CI/CD we need to avoid using pyaedt self-hosted runners when not needed. However, the current workflow files leverage "windows-latest" and "pyaedt" which leads to using pyaedt self-hosted runners instead of github runners. Here we remove the use of "windows-latest" when the CI/CD should run on self-hosted runners.

On top of these changes, the self-hosted runners tag are going to be update to remove "windows-latest" from their labels. It does not make sense to keep it and might be confusing with Github runners. 