### PR TITLE
Add support in HFSS for creating anisotropic impedance boundary condition and for the assignment of impedance boundaries to faces

### DIFF
--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -3753,7 +3753,7 @@ class Hfss(FieldAnalysis3D, object):
             this parameter is disabled.
         is_infground : bool, optional
             Whether the impedance is an infinite ground. The default is ``False``.
-        coord_sys : optional
+        coord_sys : str, optional
             Name of the coordinate system for the xy plane. The default is ``"Global"``.
 
         Returns

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -226,8 +226,8 @@ class Hfss(FieldAnalysis3D, object):
     class BoundaryType(object):
         """Creates and manages boundaries."""
 
-        (PerfectE, PerfectH, Aperture, Radiation, Impedance, LayeredImp, LumpedRLC, FiniteCond, Hybrid, FEBI) = range(
-            0, 10
+        (PerfectE, PerfectH, Aperture, Radiation, Impedance, AnisotropicImp, LayeredImp, LumpedRLC, FiniteCond, Hybrid, FEBI) = range(
+            0, 11
         )
 
     @property

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -3047,7 +3047,7 @@ class Hfss(FieldAnalysis3D, object):
         is_infinite_gnd : bool, optional
             Whether the boundary is an infinite ground. The default is ``False``.
         props : dict, optional
-            Additional properties for the boundary. The default is an empty dict ``{}``.
+            Additional properties for the boundary. The default is ``{}``.
 
         Returns
         -------

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -3754,7 +3754,7 @@ class Hfss(FieldAnalysis3D, object):
         is_infground : bool, optional
             Whether the impedance is an infinite ground. The default is ``False``.
         coord_sys : optional
-            The name of the coordinate system for the xy plane. The default is ``Global``.
+            Name of the coordinate system for the xy plane. The default is ``"Global"``.
 
         Returns
         -------

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -4782,8 +4782,8 @@ class Hfss(FieldAnalysis3D, object):
         boundary to them.
 
         >>> impedance_box = hfss.modeler.create_box([0 , -100, 0], [200, 200, 200],
-        ...                                         name="ImpedanceForFaces")
-        >>> ids = hfss.modeler.get_object_faces("ImpedanceForFaces")[:3]
+        ...                                         name="ImpedanceBox")
+        >>> ids = hfss.modeler.get_object_faces("ImpedanceBox")[:3]
         >>> impedance = hfss.assign_impedance_boundary_to_faces(ids,
         ...     boundary_name="ImpedanceToFaces", resistance=60, reactance=-20)
         >>> type(impedance)
@@ -4802,6 +4802,94 @@ class Hfss(FieldAnalysis3D, object):
                      "Reactance":   str(reactance),}
             
             return self.create_boundary(self.BoundaryType.Impedance, faces_list, boundary_name, is_infground, props)
+        else:
+            return False
+
+    @pyaedt_function_handler()
+    def assign_anisotropic_impedance_boundary_to_face(
+        self, face_id, boundary_name="", ZxxResi=0, ZxxReac=0, ZxyResi=0, ZxyReac=0, ZyxResi=0, ZyxReac=0, ZyyResi=0, ZyyReac=0, is_infground=False, coord_sys="Global"
+        ):
+        """Assign an anisotropic impedance boundary to one face.
+
+        Parameters
+        ----------
+        face_id :
+            Face ID to assign the anisotropic impedance boundary condition to.
+        boundary_name : str, optional
+            Name of the boundary. The default is ``""``.
+        ZxxResi : optional
+            Resistance value of xx component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZxxReac : optional
+            Reactance value of xx component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZxyResi : optional
+            Resistance value of xy component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZxyReac : optional
+            Reactance value of xy component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZyxResi : optional
+            Resistance value of yx component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZyxReac : optional
+            Reactance value of yx component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZyyResi : optional
+            Resistance value of yy component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZyyReac : optional
+            Reactance value of yy component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        is_infground : bool, optional
+            Whether the impedance is an infinite ground. The default is ``False``.
+        coord_sys : optional
+            The name of the coordinate system for the xy plane. The default is ``Global``.
+
+        Returns
+        -------
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object if successful, ``False`` otherwise.
+
+        References
+        ----------
+
+        >>> oModule.AssignAnisotropicImpedance
+
+        Examples
+        --------
+
+        Create a box. Select the first face of this box and assign an anisotropic
+        impedance boundary to it.
+
+        >>> anisotropic_box = hfss.modeler.create_box([0 , -100, 0], [200, 200, 200],
+        ...                                           name="AnisotropicBox")
+        >>> face_id = hfss.modeler.get_object_faces("AnisotropicBox")[0]
+        >>> anisotropic = hfss.assign_anisotropic_impedance_boundary_to_face(face_id,
+        ...     boundary_name="AnisotropicToFace", ZxxResi=377, ZxyResi=50, ZyyReac=-20)
+        >>> type(anisotropic)
+        <class 'pyaedt.modules.Boundary.BoundaryObject'>
+
+        """
+
+        if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
+            face_list = self.modeler.convert_to_selections(face_id, True)
+            if not boundary_name:
+                boundary_name = generate_unique_name("Anisotropic")
+            elif boundary_name in self.modeler.get_boundaries_name():
+                boundary_name = generate_unique_name(boundary_name)
+                
+            props = {"ZxxResistance":   str(ZxxResi),
+                     "ZxxReactance":	str(ZxxReac),
+                     "ZxyResistance":   str(ZxyResi),
+                     "ZxyReactance":	str(ZxyReac),
+                     "ZyxResistance":   str(ZyxResi),
+                     "ZyxReactance":	str(ZyxReac),
+                     "ZyyResistance":   str(ZyyResi),
+                     "ZyyReactance":    str(ZyyReac),
+                     "CoordSystem":     str(coord_sys),}
+            
+            return self.create_boundary(self.BoundaryType.AnisotropicImp, face_list, boundary_name, is_infground, props)
         else:
             return False
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -4777,7 +4777,7 @@ class Hfss(FieldAnalysis3D, object):
         Parameters
         ----------
         faces_id :
-            Face ID(s) to assign the impedance boundary condition to.
+            One or more face IDs to assign the impedance boundary condition to.
         boundary_name : str, optional
             Name of the boundary. The default is ``""``.
         resistance : optional
@@ -4802,7 +4802,7 @@ class Hfss(FieldAnalysis3D, object):
         Examples
         --------
 
-        Create a box. Select the first 3 faces of this box and assign an impedance
+        Create a box. Select the first three faces of this box and assign an impedance
         boundary to them.
 
         >>> impedance_box = hfss.modeler.create_box([0 , -100, 0], [200, 200, 200],
@@ -4856,33 +4856,33 @@ class Hfss(FieldAnalysis3D, object):
         boundary_name : str, optional
             Name of the boundary. The default is ``""``.
         ZxxResi : optional
-            Resistance value of xx component in ohms. The default is ``0``. If ``None``,
+            Resistance value of the xx component in ohms. The default is ``0``. If ``None``,
             this parameter is disabled.
         ZxxReac : optional
-            Reactance value of xx component in ohms. The default is ``0``. If ``None``,
+            Reactance value of the xx component in ohms. The default is ``0``. If ``None``,
             this parameter is disabled.
         ZxyResi : optional
-            Resistance value of xy component in ohms. The default is ``0``. If ``None``,
+            Resistance value of the xy component in ohms. The default is ``0``. If ``None``,
             this parameter is disabled.
         ZxyReac : optional
-            Reactance value of xy component in ohms. The default is ``0``. If ``None``,
+            Reactance value of the xy component in ohms. The default is ``0``. If ``None``,
             this parameter is disabled.
         ZyxResi : optional
-            Resistance value of yx component in ohms. The default is ``0``. If ``None``,
+            Resistance value of the yx component in ohms. The default is ``0``. If ``None``,
             this parameter is disabled.
         ZyxReac : optional
-            Reactance value of yx component in ohms. The default is ``0``. If ``None``,
+            Reactance value of the yx component in ohms. The default is ``0``. If ``None``,
             this parameter is disabled.
         ZyyResi : optional
-            Resistance value of yy component in ohms. The default is ``0``. If ``None``,
+            Resistance value of the yy component in ohms. The default is ``0``. If ``None``,
             this parameter is disabled.
         ZyyReac : optional
-            Reactance value of yy component in ohms. The default is ``0``. If ``None``,
+            Reactance value of the yy component in ohms. The default is ``0``. If ``None``,
             this parameter is disabled.
         is_infground : bool, optional
             Whether the impedance is an infinite ground. The default is ``False``.
-        coord_sys : optional
-            The name of the coordinate system for the xy plane. The default is ``Global``.
+        coord_sys : str, optional
+            Name of the coordinate system for the xy plane. The default is ``"Global"``.
 
         Returns
         -------

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -226,9 +226,19 @@ class Hfss(FieldAnalysis3D, object):
     class BoundaryType(object):
         """Creates and manages boundaries."""
 
-        (PerfectE, PerfectH, Aperture, Radiation, Impedance, AnisotropicImp, LayeredImp, LumpedRLC, FiniteCond, Hybrid, FEBI) = range(
-            0, 11
-        )
+        (
+            PerfectE,
+            PerfectH,
+            Aperture,
+            Radiation,
+            Impedance,
+            AnisotropicImp,
+            LayeredImp,
+            LumpedRLC,
+            FiniteCond,
+            Hybrid,
+            FEBI,
+        ) = range(0, 11)
 
     @property
     def hybrid(self):
@@ -3692,11 +3702,23 @@ class Hfss(FieldAnalysis3D, object):
             )
             return self._create_boundary(sourcename, props, "Impedance")
         return False
-    
+
     @pyaedt_function_handler()
     def assign_anisotropic_impedance_to_sheet(
-        self, sheet_name, sourcename=None, ZxxResi=0, ZxxReac=0, ZxyResi=0, ZxyReac=0, ZyxResi=0, ZyxReac=0, ZyyResi=0, ZyyReac=0, is_infground=False, coord_sys="Global"
-        ):
+        self,
+        sheet_name,
+        sourcename=None,
+        ZxxResi=0,
+        ZxxReac=0,
+        ZxyResi=0,
+        ZxyReac=0,
+        ZyxResi=0,
+        ZyxReac=0,
+        ZyyResi=0,
+        ZyyReac=0,
+        is_infground=False,
+        coord_sys="Global",
+    ):
         """Create an anisotropic impedance taking one sheet.
 
         Parameters
@@ -3766,16 +3788,16 @@ class Hfss(FieldAnalysis3D, object):
             props = OrderedDict(
                 {
                     "Objects": [sheet_name],
-                    "CoordSystem":      str(coord_sys),
-                    "InfGroundPlane":   is_infground,
-                    "ZxxResistance":    str(ZxxResi),
-                    "ZxxReactance":	    str(ZxxReac),
-                    "ZxyResistance":    str(ZxyResi),
-                    "ZxyReactance":	    str(ZxyReac),
-                    "ZyxResistance":    str(ZyxResi),
-                    "ZyxReactance":	    str(ZyxReac),
-                    "ZyyResistance":    str(ZyyResi),
-                    "ZyyReactance":     str(ZyyReac),
+                    "CoordSystem": str(coord_sys),
+                    "InfGroundPlane": is_infground,
+                    "ZxxResistance": str(ZxxResi),
+                    "ZxxReactance": str(ZxxReac),
+                    "ZxyResistance": str(ZxyResi),
+                    "ZxyReactance": str(ZxyReac),
+                    "ZyxResistance": str(ZyxResi),
+                    "ZyxReactance": str(ZyxReac),
+                    "ZyyResistance": str(ZyyResi),
+                    "ZyyReactance": str(ZyyReac),
                 }
             )
             return self._create_boundary(sourcename, props, "Anisotropic Impedance")
@@ -4747,7 +4769,9 @@ class Hfss(FieldAnalysis3D, object):
         return self.create_boundary(self.BoundaryType.Radiation, faces_list, rad_name)
 
     @pyaedt_function_handler()
-    def assign_impedance_boundary_to_faces(self, faces_id, boundary_name="", resistance=50, reactance=0, is_infground=False):
+    def assign_impedance_boundary_to_faces(
+        self, faces_id, boundary_name="", resistance=50, reactance=0, is_infground=False
+    ):
         """Assign an impedance boundary to one or more faces.
 
         Parameters
@@ -4797,18 +4821,32 @@ class Hfss(FieldAnalysis3D, object):
                 boundary_name = generate_unique_name("Imped")
             elif boundary_name in self.modeler.get_boundaries_name():
                 boundary_name = generate_unique_name(boundary_name)
-                
-            props = {"Resistance":  str(resistance),
-                     "Reactance":   str(reactance),}
-            
+
+            props = {
+                "Resistance": str(resistance),
+                "Reactance": str(reactance),
+            }
+
             return self.create_boundary(self.BoundaryType.Impedance, faces_list, boundary_name, is_infground, props)
         else:
             return False
 
     @pyaedt_function_handler()
     def assign_anisotropic_impedance_boundary_to_face(
-        self, face_id, boundary_name="", ZxxResi=0, ZxxReac=0, ZxyResi=0, ZxyReac=0, ZyxResi=0, ZyxReac=0, ZyyResi=0, ZyyReac=0, is_infground=False, coord_sys="Global"
-        ):
+        self,
+        face_id,
+        boundary_name="",
+        ZxxResi=0,
+        ZxxReac=0,
+        ZxyResi=0,
+        ZxyReac=0,
+        ZyxResi=0,
+        ZyxReac=0,
+        ZyyResi=0,
+        ZyyReac=0,
+        is_infground=False,
+        coord_sys="Global",
+    ):
         """Assign an anisotropic impedance boundary to one face.
 
         Parameters
@@ -4878,17 +4916,19 @@ class Hfss(FieldAnalysis3D, object):
                 boundary_name = generate_unique_name("Anisotropic")
             elif boundary_name in self.modeler.get_boundaries_name():
                 boundary_name = generate_unique_name(boundary_name)
-                
-            props = {"ZxxResistance":   str(ZxxResi),
-                     "ZxxReactance":	str(ZxxReac),
-                     "ZxyResistance":   str(ZxyResi),
-                     "ZxyReactance":	str(ZxyReac),
-                     "ZyxResistance":   str(ZyxResi),
-                     "ZyxReactance":	str(ZyxReac),
-                     "ZyyResistance":   str(ZyyResi),
-                     "ZyyReactance":    str(ZyyReac),
-                     "CoordSystem":     str(coord_sys),}
-            
+
+            props = {
+                "ZxxResistance": str(ZxxResi),
+                "ZxxReactance": str(ZxxReac),
+                "ZxyResistance": str(ZxyResi),
+                "ZxyReactance": str(ZxyReac),
+                "ZyxResistance": str(ZyxResi),
+                "ZyxReactance": str(ZyxReac),
+                "ZyyResistance": str(ZyyResi),
+                "ZyyReactance": str(ZyyReac),
+                "CoordSystem": str(coord_sys),
+            }
+
             return self.create_boundary(self.BoundaryType.AnisotropicImp, face_list, boundary_name, is_infground, props)
         else:
             return False

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -4783,7 +4783,7 @@ class Hfss(FieldAnalysis3D, object):
 
         >>> impedance_box = hfss.modeler.create_box([0 , -100, 0], [200, 200, 200],
         ...                                         name="ImpedanceForFaces")
-        >>> ids = hfss.modeler["ImpedanceForFaces"].faces[:3]
+        >>> ids = hfss.modeler.get_object_faces("ImpedanceForFaces")[:3]
         >>> impedance = hfss.assign_impedance_boundary_to_faces(ids,
         ...     boundary_name="ImpedanceToFaces", resistance=60, reactance=-20)
         >>> type(impedance)

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -3685,6 +3685,94 @@ class Hfss(FieldAnalysis3D, object):
             )
             return self._create_boundary(sourcename, props, "Impedance")
         return False
+    
+    @pyaedt_function_handler()
+    def assign_anisotropic_impedance_to_sheet(
+        self, sheet_name, sourcename=None, ZxxResi=0, ZxxReac=0, ZxyResi=0, ZxyReac=0, ZyxResi=0, ZyxReac=0, ZyyResi=0, ZyyReac=0, is_infground=False, coord_sys="Global"
+        ):
+        """Create an anisotropic impedance taking one sheet.
+
+        Parameters
+        ----------
+        sheet_name : str
+            Name of the sheet to apply the boundary to.
+        sourcename : str, optional
+            Name of the anisotropic impedance. The default is ``None``.
+        ZxxResi : optional
+            Resistance value of xx component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZxxReac : optional
+            Reactance value of xx component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZxyResi : optional
+            Resistance value of xy component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZxyReac : optional
+            Reactance value of xy component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZyxResi : optional
+            Resistance value of yx component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZyxReac : optional
+            Reactance value of yx component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZyyResi : optional
+            Resistance value of yy component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        ZyyReac : optional
+            Reactance value of yy component in ohms. The default is ``0``. If ``None``,
+            this parameter is disabled.
+        is_infground : bool, optional
+            Whether the impedance is an infinite ground. The default is ``False``.
+        coord_sys : optional
+            The name of the coordinate system for the xy plane. The default is ``Global``.
+
+        Returns
+        -------
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object if successful, ``False`` otherwise.
+
+        References
+        ----------
+
+        >>> oModule.AssignAnisotropicImpedance
+
+        Examples
+        --------
+
+        Create a sheet and use it to create an anisotropic impedance.
+
+        >>> sheet = hfss.modeler.create_rectangle(hfss.PLANE.XY,
+        ...                                       [0, 0, 5], [10, 2], name="AnisotropicSheet")
+        >>> anisotropic_to_sheet = hfss.assign_anisotropic_impedance_to_sheet(sheet.name, "AnisotropicFromSheet",
+                                                                              ZxxResi=377, ZxyResi=50, ZyyReac=-20)
+        >>> type(anisotropic_to_sheet)
+        <class 'pyaedt.modules.Boundary.BoundaryObject'>
+
+        """
+
+        if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
+            if not sourcename:
+                sourcename = generate_unique_name("Anisotropic")
+            elif sourcename in self.modeler.get_boundaries_name():
+                sourcename = generate_unique_name(sourcename)
+            props = OrderedDict(
+                {
+                    "Objects": [sheet_name],
+                    "CoordSystem":      str(coord_sys),
+                    "InfGroundPlane":   is_infground,
+                    "ZxxResistance":    str(ZxxResi),
+                    "ZxxReactance":	    str(ZxxReac),
+                    "ZxyResistance":    str(ZxyResi),
+                    "ZxyReactance":	    str(ZxyReac),
+                    "ZyxResistance":    str(ZyxResi),
+                    "ZyxReactance":	    str(ZyxReac),
+                    "ZyyResistance":    str(ZyyResi),
+                    "ZyyReactance":     str(ZyyReac),
+                }
+            )
+            return self._create_boundary(sourcename, props, "Anisotropic Impedance")
+        return False
 
     @pyaedt_function_handler()
     def create_circuit_port_from_edges(


### PR DESCRIPTION
Hello,

I've never contributed before to any git project so feel free to help if I'm doing things wrongly.

This contribution add the support in HFSS for:
- assigning an anisotropic impedance boundary to a sheet;
- assigning an impedance boundary to 1 or more faces;
- assigning an anisotropic impedance boundary to a single face.

The issue I created (#4248) for that was closed but pyaedt was still missing theses features from standard IronPython.

