### PR TITLE
use 0.0.0.0 as hostname for rpyc servers

### DIFF
--- a/pyaedt/common_rpc.py
+++ b/pyaedt/common_rpc.py
@@ -1,6 +1,5 @@
 import os
 import signal
-import socket
 import sys
 import tempfile
 import time

--- a/pyaedt/common_rpc.py
+++ b/pyaedt/common_rpc.py
@@ -165,7 +165,7 @@ def pyaedt_service_manager(port=17878, aedt_version=None, student_version=False)
     os.environ["PYAEDT_SERVER_AEDT_NG"] = "True"
     os.environ["ANS_NODEPCHECK"] = str(1)
 
-    hostname = socket.gethostname()
+    hostname = "0.0.0.0"
     t = ThreadedServer(
         ServiceManager,
         hostname=hostname,
@@ -226,7 +226,7 @@ def launch_server(port=18000, ansysem_path=None, non_graphical=False, threaded=T
     os.environ["ANS_NO_MONO_CLEANUP"] = str(1)
     os.environ["ANS_NODEPCHECK"] = str(1)
 
-    hostname = socket.gethostname()
+    hostname = "0.0.0.0"
     if threaded:
         service = ThreadedServer
     else:


### PR DESCRIPTION
enables operation in all deployment types.

required for SAF integration