### PR TITLE
MAINT: Fix wrong version of pyedb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "fpdf2",
     "jsonschema",
     "pytomlpp; python_version < '3.12'",
-    "pyedb==0.4.2; python_version == '3.7'",
+    "pyedb==0.4.0; python_version == '3.7'",
     "pyedb>=0.5.0,<0.6; python_version > '3.7'",
 ]
 
@@ -52,7 +52,7 @@ tests = [
     "pandas==1.3.5; python_version == '3.7'",
     "pandas==2.0.3; python_version == '3.8'",
     "pandas==2.2.1; python_version > '3.9'",
-    "pyedb==0.4.2; python_version == '3.7'",
+    "pyedb==0.4.0; python_version == '3.7'",
     "pyedb>=0.5.0,<0.6; python_version > '3.7'",
     "pytest==8.0.2",
     "pytest-cov==4.1.0",


### PR DESCRIPTION
For some reasons, pyedb version 0.4.2 was not published in pypi. Therefore, when one wants to work with Python 3.7, we must specify version 0.4.0 instead.

NB: Caught this error while refactoring the CI/CD. Once used, we'll avoid such error to happen !