### PR TITLE
Remove the exception details -as e- when not needed.

### DIFF
--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -2080,7 +2080,7 @@ class Icepak(FieldAnalysis3D):
                 )
                 arg.append("Calculation:=")
                 arg.append([type, geometry_type, el, quantity, "", "Default"])
-            except Exception as e:
+            except Exception:
                 self.logger.warning("Object " + el + " not added.")
         if not output_dir:
             output_dir = self.working_directory

--- a/pyaedt/modeler/cad/Primitives.py
+++ b/pyaedt/modeler/cad/Primitives.py
@@ -549,7 +549,7 @@ class GeometryModeler(Modeler):
                     if value not in new_obs3d:
                         new_obs3d.append(value)
 
-        except Exception as e:
+        except Exception:
             new_obs3d = []
         return new_obs3d
 

--- a/pyaedt/modeler/cad/elements3d.py
+++ b/pyaedt/modeler/cad/elements3d.py
@@ -229,7 +229,7 @@ class VertexPrimitive(EdgeTypePrimitive, object):
             vertex_data = list(self.oeditor.GetVertexPosition(self.id))
             self._position = [float(i) for i in vertex_data]
             return self._position
-        except Exception as e:
+        except Exception:
             return None
 
     def __str__(self):

--- a/pyaedt/modeler/cad/polylines.py
+++ b/pyaedt/modeler/cad/polylines.py
@@ -533,7 +533,7 @@ class Polyline(Object3d):
                         break
                 else:
                     current_segment = segment_types[vertex_count]
-            except Exception as e:
+            except Exception:
                 raise IndexError("Number of segments inconsistent with the number of points!")
 
             if current_segment:

--- a/pyaedt/modules/Boundary.py
+++ b/pyaedt/modules/Boundary.py
@@ -274,7 +274,7 @@ class NativeComponentObject(BoundaryCommon, object):
         try:
             a = [i for i in self._app.excitations if i not in names]
             self.excitation_name = a[0].split(":")[0]
-        except Exception as e:
+        except Exception:
             self.excitation_name = self.name
         return True
 

--- a/pyaedt/modules/MaterialLib.py
+++ b/pyaedt/modules/MaterialLib.py
@@ -650,7 +650,7 @@ class Materials(object):
                 if el not in list(self.material_keys.keys()):
                     try:
                         self._aedmattolibrary(el)
-                    except Exception as e:
+                    except Exception:
                         self.logger.info("aedmattolibrary failed for material %s", el)
 
     @pyaedt_function_handler()


### PR DESCRIPTION
Prior to merge #4331, let's merge this one. It will make the removal of details exception as suggested by @SMoraisAnsys [here](https://github.com/ansys/pyaedt/pull/4331#issuecomment-1983528231) easier and less error prone.