### PR TITLE
MAINT: Remove install target full

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can install PyAEDT on CPython 3.7 through 3.10 from PyPI with this command:
 Install PyAEDT with all extra packages (matplotlib, numpy, pandas, pyvista):
 
 ```sh
-  pip install pyaedt[full]
+  pip install pyaedt[all]
 ```
 
 You can also install PyAEDT from Conda-Forge with this command:

--- a/README_CN.md
+++ b/README_CN.md
@@ -52,7 +52,7 @@
 ```
 4. 如果你需要其他库来做后期处理，可以使用以下方法来安装它们：
 ```sh
-pip install pyaedt[full]
+pip install pyaedt[all]
 ```
 
 ## 关于 PyAEDT

--- a/doc/source/Resources/PyAEDTInstallerFromDesktop.py
+++ b/doc/source/Resources/PyAEDTInstallerFromDesktop.py
@@ -146,7 +146,7 @@ def install_pyaedt():
         else:
             run_command('"{}" -m pip install --upgrade pip'.format(python_exe))
             run_command('"{}" --default-timeout=1000 install wheel'.format(pip_exe))
-            run_command('"{}" --default-timeout=1000 install pyaedt[full]'.format(pip_exe))
+            run_command('"{}" --default-timeout=1000 install pyaedt[all]'.format(pip_exe))
             # run_command('"{}" --default-timeout=1000 install git+https://github.com/ansys/pyaedt.git@main'.format(pip_exe))
             run_command('"{}" --default-timeout=1000 install jupyterlab'.format(pip_exe))
             run_command('"{}" --default-timeout=1000 install ipython -U'.format(pip_exe))
@@ -175,7 +175,7 @@ def install_pyaedt():
 
             run_command('"{}" install --no-cache-dir --no-index --find-links={} pyaedt'.format(pip_exe, unzipped_path))
         else:
-            run_command('"{}" --default-timeout=1000 install pyaedt[full]'.format(pip_exe))
+            run_command('"{}" --default-timeout=1000 install pyaedt[all]'.format(pip_exe))
 
     # if is_windows:
     #     pyaedt_setup_script = "{}/Lib/site-packages/pyaedt/misc/aedtlib_personalib_install.py".format(venv_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,25 +113,6 @@ doc = [
     "sphinx_design",
     "sphinx_jinja",
 ]
-full = [
-    "imageio",
-    "matplotlib==3.5.3; python_version == '3.7'",
-    "matplotlib==3.7.3; python_version == '3.8'",
-    "matplotlib==3.8.3; python_version > '3.8'",
-    "numpy==1.21.6; python_version <= '3.9'",
-    "numpy==1.26.4; python_version > '3.9'",
-    "pandas==1.3.5; python_version == '3.7'",
-    "pandas==2.0.3; python_version == '3.8'",
-    "pandas==2.2.1; python_version > '3.9'",
-    "osmnx",
-    "vtk==9.2.6",
-    "pyvista==0.43.3; python_version > '3.7'",
-    "pyvista==0.38.0; python_version <= '3.7'",
-    "SRTM.py",
-    "utm",
-    "scikit-rf==0.31.0",
-    "openpyxl==3.1.2",
-]
 all = [
     "imageio",
     "matplotlib==3.5.3; python_version == '3.7'",


### PR DESCRIPTION
We have two install targets expressing the same dependencies but it seems that only all is used and leveraged in our CI/CD.
I feel like there is no reason to keep the `full` target anymore.

Note: This is also more compliant with how other pyansys projects are working.