### PR TITLE
CI: Fix nightly documentation build

### DIFF
--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -40,7 +40,7 @@ jobs:
           make -C doc phtml
 
       - name: Upload documentation HTML artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: documentation-html
           path: doc/_build/html


### PR DESCRIPTION
Note: There was an incompatibility between the actions to download and upload artifacts. The versions being different, the artifact generated was not compatible.