### PR TITLE
MAINT: Fix version incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "jsonschema",
     "psutil",
     "pyedb>=0.4.0,<0.5; python_version == '3.7'",
-    "pyedb>=0.5.0,<0.6 || ==0.6.dev0; python_version > '3.7'",
+    "pyedb>=0.5.0,<0.6||==0.6.dev0; python_version > '3.7'",
     "pytomlpp; python_version < '3.12'",
     "rpyc>=6.0.0,<6.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "jsonschema",
     "psutil",
     "pyedb>=0.4.0,<0.5; python_version == '3.7'",
-    "pyedb>=0.5.0,<0.6; python_version > '3.7'",
+    "pyedb>=0.5.0,<0.6 || ==0.6.dev0; python_version > '3.7'",
     "pytomlpp; python_version < '3.12'",
     "rpyc>=6.0.0,<6.1",
 ]


### PR DESCRIPTION
Currently when one wants to build `pyedb` documentation, one needs to use `pyaedt` as some examples required it. However `pyaedt` needs `pyedb>=0.5.0,<0.6` and the development version of `pyedb` is `pyedb==0.6.dev0`. This leads to version incompatibilities.

The current PR provides a way to solve this but this is probably an issue with pypi release ...

Related to: https://github.com/ansys/pyaedt/issues/4385