### PR TITLE
right now Insertion loss is computed on first frequency point.

### DIFF
--- a/pyaedt/generic/touchstone_parser.py
+++ b/pyaedt/generic/touchstone_parser.py
@@ -105,13 +105,16 @@ class TouchstoneData(rf.Network):
 
         """
         temp_list = []
-        freq_idx = 0
-        s_db = self.s_db[freq_idx, :, :]
+        s_db = self.s_db[0:2, :, :]
         for i in self.port_tuples:
             if i[0] != i[1]:
-                loss = s_db[i[0], i[1]]
+                loss = s_db[0, i[0], i[1]]
                 if loss > threshold:
                     temp_list.append(i)
+                elif loss < -90:
+                    loss = s_db[1, i[0], i[1]]
+                    if loss > threshold:
+                        temp_list.append(i)
         return temp_list
 
     def plot_insertion_losses(self, threshold=-3, plot=True):


### PR DESCRIPTION
 Sometimes, touchstone files has no or wrong dc point. So it can be useful to check also the 2nd point. The method check the DC point and if it retuns a value lower than -90dB it checks the 2nd value.