### PR TITLE
FIX: Only one component per pins is created.

### DIFF
--- a/_unittest/test_01_3dlayout_edb.py
+++ b/_unittest/test_01_3dlayout_edb.py
@@ -381,7 +381,7 @@ class TestClass:
         comp = self.aedtapp.modeler.components["D1"]
         pins = {name: pin for name, pin in comp.pins.items() if name in ["D1-1", "D1-2", "D1-7"]}
         self.aedtapp.dissolve_component("D1")
-        comp = self.aedtapp.modeler.create_components_on_pins(list(pins.keys()))
+        comp = self.aedtapp.modeler.create_component_on_pins(list(pins.keys()))
         nets = [
             list(pins.values())[0].net_name,
             list(pins.values())[1].net_name,

--- a/pyaedt/modeler/pcb/Primitives3DLayout.py
+++ b/pyaedt/modeler/pcb/Primitives3DLayout.py
@@ -1490,7 +1490,7 @@ class Primitives3DLayout(object):
         return comp  #
 
     @pyaedt_function_handler()
-    def create_components_on_pins(
+    def create_component_on_pins(
         self,
         pins,
         definition_name=None,


### PR DESCRIPTION
Just renaming the method from `create_components_on_pins()` to `create_component_on_pins()` because based on the code, only one component can be created.