### PR TITLE
DOC: Use GIF in documentation

### DIFF
--- a/doc/source/User_guide/modeler.rst
+++ b/doc/source/User_guide/modeler.rst
@@ -57,3 +57,8 @@ All objects support executing any modeler operation, such as union or subtractio
      cyl = hfss.modeler["mycyl"]
      box.unite(cyl)
      box.subract(cyl)
+
+
+.. image:: ../Resources/objects_operations.gif
+  :width: 800
+  :alt: Object Modeler Operations

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,7 @@ import shutil
 # Additionally, when documenting images in formats other than the supported ones, 
 # make sure to specify their types.
 from sphinx.builders.latex import LaTeXBuilder
-LaTeXBuilder.supported_image_types = ["image/png", "image/pdf", "image/svg+xml", "image/webp" ]
+LaTeXBuilder.supported_image_types = ["image/png", "image/pdf", "image/gif", "image/svg+xml", "image/webp" ]
 
 from sphinx.writers.latex import CR
 from sphinx.writers.latex import LaTeXTranslator


### PR DESCRIPTION
When working on creating PDF files through CICD (#4468), we removed GIF files as they were not correctly handled.
This changes revert back the use of GIF and should allow our PDF file to work with GIF files.