### PR TITLE
CI: Fix nightly docs

### DIFF
--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Upload documentation HTML artifact
         uses: actions/upload-artifact@v3
         with:
-          name: Documentation
+          name: documentation-html
           path: doc/_build/html
           retention-days: 7
 

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -52,6 +52,12 @@ jobs:
         run: |
           python doc/print_errors.py
 
+      - name: Add assets to HTML docs
+        run: |
+          zip -r documentation-html.zip ./doc/_build/html
+          mv documentation-html.zip ./doc/_build/html/_static/assets/download/
+          cp doc/_build/latex/PyAEDT-Documentation-*.pdf ./doc/_build/html/_static/assets/download/pyaedt.pdf
+
       - name: Upload documentation HTML artifact
         uses: actions/upload-artifact@v3
         with:
@@ -62,12 +68,6 @@ jobs:
       - name: Documentation Build (PDF)
         run: |
           make -C doc pdf-no-examples
-
-      - name: Add assets to HTML docs
-        run: |
-          zip -r documentation-html.zip ./doc/_build/html
-          mv documentation-html.zip ./doc/_build/html/_static/assets/download/
-          cp doc/_build/latex/PyAEDT-Documentation-*.pdf ./doc/_build/html/_static/assets/download/pyaedt.pdf
 
       - name: Upload documentation PDF artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           python doc/print_errors.py
 
+      - name: Documentation Build (PDF)
+        run: |
+          make -C doc pdf-no-examples
+
       - name: Add assets to HTML docs
         run: |
           zip -r documentation-html.zip ./doc/_build/html
@@ -64,10 +68,6 @@ jobs:
           name: documentation-html
           path: doc/_build/html
           retention-days: 7
-
-      - name: Documentation Build (PDF)
-        run: |
-          make -C doc pdf-no-examples
 
       - name: Upload documentation PDF artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Recent updates didn't follow expected input of doc-deploy action (wrong file name uploaded).
On top of that, the PDF was inserted after the upload step was performed :/