### PR TITLE
DOC: Remove download button from release

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -342,13 +342,6 @@ html_theme_options = {
             "url": "https://github.com/ansys/pyaedt/discussions",
             "icon": "fa fa-comment fa-fw",
         },
-        {
-            "name": "Download documentation in PDF",
-            # NOTE: Changes to this URL must be reflected in CICD documentation build
-            "url": f"https://{cname}/version/{switcher_version}/_static/assets/download/pyaedt.pdf",
-            # noqa: E501
-            "icon": "fa fa-file-pdf fa-fw",
-        },
     ],
     "switcher": {
         "json_url": f"https://{cname}/versions.json",
@@ -364,6 +357,18 @@ html_theme_options = {
         },
     },
 }
+
+# Only add button to download PDF in dev mode as the building PDF for the full documentation is too long
+if switcher_version == "dev":
+    html_theme_options["icon_links"].append(
+        {
+            "name": "Download documentation in PDF",
+            # NOTE: Changes to this URL must be reflected in CICD documentation build
+            "url": f"https://{cname}/version/{switcher_version}/_static/assets/download/pyaedt.pdf",
+            # noqa: E501
+            "icon": "fa fa-file-pdf fa-fw",
+        }
+    )
 
 html_static_path = ["_static"]
 


### PR DESCRIPTION
Currently the PDF button is present in dev mode (as expected) but also when a new release is created. However, we currently don't  create the PDF for the full documentation as it takes too long to generate.
This should restrict PDF download to dev mode documentation.