### PR TITLE
Match headings in left nav pane and card titles

### DIFF
--- a/doc/source/User_guide/index.rst
+++ b/doc/source/User_guide/index.rst
@@ -4,10 +4,9 @@
 User guide
 ==========
 
-This section provides brief tutorials for helping you understand how to effectively use PyAEDT.
+This section provides brief tutorials for helping you understand how to use PyAEDT effectively.
 
-For additional practical demonstrations, see
-`PyAEDT examples <https://aedt.docs.pyansys.com/version/stable/examples>`_ page.
+For end-to-end examples, see `Examples <https://aedt.docs.pyansys.com/version/stable/examples>`_.
 
 
 .. grid:: 2
@@ -40,7 +39,7 @@ For additional practical demonstrations, see
 
             How to create a setup and run simulations.
 
-   .. grid-item-card:: Variables and Optimetrics
+   .. grid-item-card:: Variables
             :link: variables
             :link-type: doc
             :margin: 2 2 0 0

--- a/doc/source/User_guide/intro.rst
+++ b/doc/source/User_guide/intro.rst
@@ -1,5 +1,5 @@
-Minimal example
-===============
+Basic tutorial
+==============
 
 You can initiate AEDT in non-graphical mode from Python using this code:
 
@@ -11,15 +11,15 @@ You can initiate AEDT in non-graphical mode from Python using this code:
                  student_version=False):
         circuit = pyaedt.Circuit()
         ...
-        # Any error here will be caught by Desktop.
+        # Any error here is caught by AEDT.
         ...
-    # Desktop is automatically closed here.
+    # AEDT is automatically closed here.
 
 The preceding code launches AEDT and initializes a new Circuit design.
 
 .. image:: ../Resources/aedt_first_page.png
   :width: 800
-  :alt: Electronics Desktop launched
+  :alt: AEDT launched
 
 This code creates a project and saves it with PyAEDT:
 
@@ -33,8 +33,7 @@ This code creates a project and saves it with PyAEDT:
     cir.release_desktop(save_project=True, close_desktop=True)
     # Desktop is released here.
 
-Ansys EDB proprietary layout format is accessible through pyaedt using the following
-code:
+This code uses PyAEDT to access the Ansys EDB proprietary layout format:
 
 .. code:: python
 
@@ -42,7 +41,7 @@ code:
     import pyaedt
     edb = pyaedt.Edb("mylayout.aedb")
 
-    # User can launch Edb directly from PyEDB class.
+    # User can launch EDB directly from the PyEDB class.
 
     import pyedb
     edb = pyedb.Edb("mylayout.aedb")


### PR DESCRIPTION
In the "User guide" section of the doc, the left nav bar had different headings than for some of the cards on the landing page for this section. This PR makes them consistent.