### PR TITLE
REFACTOR: Generic modules to avoid bad practices

### DIFF
--- a/pyaedt/__init__.py
+++ b/pyaedt/__init__.py
@@ -49,7 +49,6 @@ import pyaedt.downloads as downloads
 from pyaedt.generic import constants
 import pyaedt.generic.DataHandlers as data_handler
 import pyaedt.generic.general_methods as general_methods
-from pyaedt.generic.general_methods import _pythonver
 from pyaedt.generic.general_methods import _retry_ntimes
 from pyaedt.generic.general_methods import generate_unique_folder_name
 from pyaedt.generic.general_methods import generate_unique_name

--- a/pyaedt/generic/clr_module.py
+++ b/pyaedt/generic/clr_module.py
@@ -3,6 +3,8 @@ import pkgutil
 import sys
 import warnings
 
+from pyaedt.aedt_logger import pyaedt_logger as logger
+
 modules = [tup[1] for tup in pkgutil.iter_modules()]
 pyaedt_path = os.path.dirname(os.path.dirname(__file__))
 cpython = "IronPython" not in sys.version and ".NETFramework" not in sys.version
@@ -49,7 +51,7 @@ else:
         is_clr = True
 
     except Exception:
-        pass
+        logger.error("An error occurred while loading clr.")
 
 
 try:  # work around a number formatting bug in the EDB API for non-English locales

--- a/pyaedt/generic/filesystem.py
+++ b/pyaedt/generic/filesystem.py
@@ -3,6 +3,8 @@ import random
 import shutil
 import string
 
+from pyaedt.aedt_logger import pyaedt_logger as logger
+
 
 def search_files(dirname, pattern="*"):
     """Search for files inside a directory given a specific pattern.
@@ -69,7 +71,7 @@ class Scratch:
             # TODO check why on Anaconda 3.7 get errors with os.path.exists
             shutil.rmtree(self._scratch_path, ignore_errors=True)
         except Exception:
-            pass
+            logger.error("An error occurred while removing {}".format(self._scratch_path))
 
     def copyfile(self, src_file, dst_filename=None):
         """

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -15,7 +15,6 @@ import json
 import math
 import os
 import re
-import secrets
 import string
 import sys
 import tempfile
@@ -676,6 +675,7 @@ def get_filename_without_extension(path):
     return os.path.splitext(os.path.split(path)[1])[0]
 
 
+# FIXME: Remove usage of random module once IronPython compatibility is removed
 @pyaedt_function_handler()
 def generate_unique_name(rootname, suffix="", n=6):
     """Generate a new name given a root name and optional suffix.
@@ -696,7 +696,15 @@ def generate_unique_name(rootname, suffix="", n=6):
 
     """
     alphabet = string.ascii_uppercase + string.digits
-    uName = "".join(secrets.choice(alphabet) for _ in range(n))
+    if is_ironpython:
+        import random
+
+        uName = "".join(random.choice(alphabet) for _ in range(n))  # nosec B311
+    else:
+        import secrets
+
+        uName = "".join(secrets.choice(alphabet) for _ in range(n))
+
     unique_name = rootname + "_" + uName
     if suffix:
         unique_name += "_" + suffix
@@ -1887,6 +1895,7 @@ def _arg2dict(arg, dict_out):
         raise ValueError("Incorrect data argument format")
 
 
+# FIXME: Remove usage of random module once IronPython compatibility is removed
 def _uname(name=None):
     """Append a 6-digit hash code to a specified name.
 
@@ -1901,8 +1910,15 @@ def _uname(name=None):
 
     """
     alphabet = string.ascii_uppercase + string.digits
-    generator = secrets.SystemRandom()
-    unique_name = "".join(secrets.SystemRandom.sample(generator, alphabet, 6))
+    if is_ironpython:
+        import random
+
+        unique_name = "".join(random.sample(alphabet, 6))  # nosec B311
+    else:
+        import secrets
+
+        generator = secrets.SystemRandom()
+        unique_name = "".join(secrets.SystemRandom.sample(generator, alphabet, 6))
     if name:
         return name + unique_name
     else:


### PR DESCRIPTION
As title says.

Changes:
- use 'secrets' module instead of random values created through 'random' module
- remove unused code, e.g. `xml.etree.cElementTree`