### PR TITLE
DOCS: Add download PDF button for release

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -353,17 +353,16 @@ html_theme_options = {
     },
 }
 
-# Only add button to download PDF in dev mode as the building PDF for the full documentation is too long
-if switcher_version == "dev":
-    html_theme_options["icon_links"].append(
-        {
-            "name": "Download documentation in PDF",
-            # NOTE: Changes to this URL must be reflected in CICD documentation build
-            "url": f"https://{cname}/version/{switcher_version}/_static/assets/download/pyaedt.pdf",
-            # noqa: E501
-            "icon": "fa fa-file-pdf fa-fw",
-        }
-    )
+# Add button to download PDF
+html_theme_options["icon_links"].append(
+    {
+        "name": "Download documentation in PDF",
+        # NOTE: Changes to this URL must be reflected in CICD documentation build
+        "url": f"https://{cname}/version/{switcher_version}/_static/assets/download/pyaedt.pdf",
+        # noqa: E501
+        "icon": "fa fa-file-pdf fa-fw",
+    }
+)
 
 html_static_path = ["_static"]
 


### PR DESCRIPTION
When the CICD refactoring was performed, doing the PDF file took too long and was not performed.
However this got fixed and we are even able to have this PDF file as an artifact.
Thus, we should also provide a download button for stable releases