### PR TITLE
FIX: design_type in desktop.py

### DIFF
--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -1376,7 +1376,7 @@ class Desktop(object):
         if not design_name:
             odesign = self.active_design(oproject)
         else:
-            odesign = self.active_design(oproject.design_name)
+            odesign = self.active_design(oproject, design_name)
         if odesign:
             return odesign.GetDesignType()
         return ""


### PR DESCRIPTION
For the case when the `design_name` argument is provided to `design_type()`, the wrong arguments were being provided to `self.active_design()`. It expects a project object as the first object and design_name string as the second argument.