### PR TITLE
FEAT: Add layout boundaries

### DIFF
--- a/_unittest/test_41_3dlayout_modeler.py
+++ b/_unittest/test_41_3dlayout_modeler.py
@@ -313,6 +313,8 @@ class TestClass:
         assert self.aedtapp.edit_source_from_file(
             port_wave.name, time_domain, is_time_domain=True, x_scale=1e-6, y_scale=1e-3, data_format="Voltage"
         )
+        self.aedtapp.boundaries[0].object_properties.props["Boundary Type"] = "PEC"
+        assert list(self.aedtapp.oboundary.GetAllBoundariesList())[0] == self.aedtapp.boundaries[0].name
 
     def test_14a_create_coaxial_port(self):
         port = self.aedtapp.create_coax_port("port_via", 0.5, "Top", "Lower")

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -325,7 +325,7 @@ class Design(AedtObjects):
             bb = list(self.oboundary.GetBoundaries())
         elif "GetAllBoundariesList" in self.oboundary.__dir__() and self.design_type == "HFSS 3D Layout Design":
             bb = list(self.oboundary.GetAllBoundariesList())
-            bb = [elem for sublist in zip(bb, ["LayoutBoundary"] * len(bb)) for elem in sublist]
+            bb = [elem for sublist in zip(bb, ["Port"] * len(bb)) for elem in sublist]
         elif "Boundaries" in self.get_oo_name(self.odesign):
             bb = self.get_oo_name(self.odesign, "Boundaries")
         if "GetHybridRegions" in self.oboundary.__dir__():
@@ -343,7 +343,7 @@ class Design(AedtObjects):
             bb.extend(ff)
         elif "Excitations" in self.get_oo_name(self.odesign) and self.design_type == "HFSS 3D Layout Design":
             ee = self.get_oo_name(self.odesign, "Excitations")
-            ee = [elem for sublist in zip(ee, ["LayoutExcitation"] * len(ee)) for elem in sublist]
+            ee = [elem for sublist in zip(ee, ["Port"] * len(ee)) for elem in sublist]
             current_excitations = ee[::2]
             current_excitation_types = ee[1::2]
 

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -323,6 +323,9 @@ class Design(AedtObjects):
         bb = []
         if "GetBoundaries" in self.oboundary.__dir__():
             bb = list(self.oboundary.GetBoundaries())
+        elif "GetAllBoundariesList" in self.oboundary.__dir__() and self.design_type == "HFSS 3D Layout Design":
+            bb = list(self.oboundary.GetAllBoundariesList())
+            bb = [elem for sublist in zip(bb, ["LayoutBoundary"] * len(bb)) for elem in sublist]
         elif "Boundaries" in self.get_oo_name(self.odesign):
             bb = self.get_oo_name(self.odesign, "Boundaries")
         if "GetHybridRegions" in self.oboundary.__dir__():
@@ -338,6 +341,11 @@ class Design(AedtObjects):
             current_excitation_types = ee[1::2]
             ff = [i.split(":")[0] for i in ee]
             bb.extend(ff)
+        elif "Excitations" in self.get_oo_name(self.odesign) and self.design_type == "HFSS 3D Layout Design":
+            ee = self.get_oo_name(self.odesign, "Excitations")
+            ee = [elem for sublist in zip(ee, ["LayoutExcitation"] * len(ee)) for elem in sublist]
+            current_excitations = ee[::2]
+            current_excitation_types = ee[1::2]
 
         # Parameters and Motion definitions
         if self.design_type in ["Maxwell 3D", "Maxwell 2D"]:

--- a/pyaedt/modules/Boundary.py
+++ b/pyaedt/modules/Boundary.py
@@ -113,7 +113,10 @@ class BoundaryCommon(PropsManager):
         except Exception:
             pass
         try:
-            if "MotionSetupList" in self._app.design_properties["ModelSetup"]:
+            if (
+                "ModelSetup" in self._app.design_properties
+                and "MotionSetupList" in self._app.design_properties["ModelSetup"]
+            ):
                 motion_list = "MotionSetupList"
                 setup = "ModelSetup"
                 # check moving part

--- a/pyaedt/modules/Boundary.py
+++ b/pyaedt/modules/Boundary.py
@@ -1848,6 +1848,15 @@ class BoundaryObject3dLayout(BoundaryCommon, object):
             child_object = self._app.odesign.GetChildObject("Excitations").GetChildObject(self.name)
         if child_object:
             return BinaryTreeNode(self.name, child_object, False)
+
+        if "Boundaries" in self._app.odesign.GetChildNames():
+            cc = self._app.odesign.GetChildObject("Boundaries")
+            if self.name in cc.GetChildNames():
+                child_object = self._app.odesign.GetChildObject("Boundaries").GetChildObject(self.name)
+            elif self.name in self._app.odesign.GetChildObject("Boundaries").GetChildNames():
+                child_object = self._app.odesign.GetChildObject("Boundaries").GetChildObject(self.name)
+            if child_object:
+                return BinaryTreeNode(self.name, child_object, False)
         return False
 
     @property


### PR DESCRIPTION
With this implementation, you can get the boundaries in a HFSS 3DLayout design, and then with the object_properties, you can manipulate these boundaries.

For instance:

aedtapp.boundaries[0].object_properties.props["Boundary Type"] = "PEC"

It was not possible before.

Close #3251 