### PR TITLE
FIX: Function handler to return False

### DIFF
--- a/_unittest/test_utils.py
+++ b/_unittest/test_utils.py
@@ -16,7 +16,7 @@ SETTINGS_ENABLE_ERROR_HANDLER = settings.enable_error_handler
 
 @pyaedt_function_handler(deprecated_arg="trigger_exception")
 def foo(trigger_exception=True):
-    """Some dummy function used for testing"""
+    """Some dummy function used for testing."""
     if trigger_exception:
         raise Exception("Dummy message.")
 

--- a/_unittest/test_utils.py
+++ b/_unittest/test_utils.py
@@ -23,7 +23,7 @@ def foo(trigger_exception=True):
 
 @patch("pyaedt.generic.desktop_sessions._desktop_sessions")
 def test_handler_release_on_exception(mock_sessions):
-    """Test handler while activating/deactivating error handler."""
+    """Test handler while activating or deactivating error handler."""
     mock_session = MagicMock()
     mock_sessions.values.return_value = [mock_session]
     settings.enable_error_handler = True

--- a/_unittest/test_utils.py
+++ b/_unittest/test_utils.py
@@ -1,0 +1,70 @@
+"""Test utility functions of PyAEDT.
+"""
+
+import logging
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from pyaedt import settings
+from pyaedt.generic.general_methods import pyaedt_function_handler
+
+SETTINGS_RELEASE_ON_EXCEPTION = settings.release_on_exception
+SETTINGS_ENABLE_ERROR_HANDLER = settings.enable_error_handler
+
+
+@pyaedt_function_handler(deprecated_arg="trigger_exception")
+def foo(trigger_exception=True):
+    """Some dummy function used for testing"""
+    if trigger_exception:
+        raise Exception("Dummy message.")
+
+
+@patch("pyaedt.generic.desktop_sessions._desktop_sessions")
+def test_handler_release_on_exception(mock_sessions):
+    """Test handler while activating/deactivating error handler."""
+    mock_session = MagicMock()
+    mock_sessions.values.return_value = [mock_session]
+    settings.enable_error_handler = True
+    settings.release_on_exception = True
+
+    # Check that release desktop is called once
+    foo()
+    assert mock_session.release_desktop.assert_called_once
+
+    # Check that release desktop is not called
+    settings.release_on_exception = False
+    foo()
+    assert mock_session.release_desktop.assert_called
+
+    # Teardown
+    settings.enable_error_handler = SETTINGS_ENABLE_ERROR_HANDLER
+    settings.release_on_exception = SETTINGS_RELEASE_ON_EXCEPTION
+
+
+def test_handler_enable_error_handler():
+    """Test handler while activating/deactivating error handler."""
+    settings.enable_error_handler = True
+    assert foo() == False
+
+    settings.enable_error_handler = False
+    with pytest.raises(Exception):
+        foo()
+
+    # Teardown
+    settings.enable_error_handler = SETTINGS_ENABLE_ERROR_HANDLER
+
+
+def test_handler_deprecation_log_warning(caplog):
+    """Test handler deprecation argument mechanism."""
+    EXPECTED_ARGUMENT = "Argument `deprecated_arg` is deprecated for method `foo`; use `trigger_exception` instead."
+
+    with caplog.at_level(logging.WARNING, logger="Global"):
+        foo(deprecated_arg=False)
+    assert len(caplog.records) == 1
+    assert "WARNING" == caplog.records[0].levelname
+    assert EXPECTED_ARGUMENT == caplog.records[0].message
+
+    foo(trigger_exception=False)
+    assert len(caplog.records) == 1

--- a/_unittest/test_utils.py
+++ b/_unittest/test_utils.py
@@ -12,13 +12,14 @@ from pyaedt.generic.general_methods import pyaedt_function_handler
 
 SETTINGS_RELEASE_ON_EXCEPTION = settings.release_on_exception
 SETTINGS_ENABLE_ERROR_HANDLER = settings.enable_error_handler
+ERROR_MESSAGE = "Dummy message."
 
 
 @pyaedt_function_handler(deprecated_arg="trigger_exception")
 def foo(trigger_exception=True):
     """Some dummy function used for testing."""
     if trigger_exception:
-        raise Exception("Dummy message.")
+        raise Exception(ERROR_MESSAGE)
 
 
 @patch("pyaedt.generic.desktop_sessions._desktop_sessions")
@@ -49,8 +50,9 @@ def test_handler_enable_error_handler():
     assert foo() == False
 
     settings.enable_error_handler = False
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         foo()
+    assert str(exec_info.value) == ERROR_MESSAGE
 
     # Teardown
     settings.enable_error_handler = SETTINGS_ENABLE_ERROR_HANDLER

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -181,7 +181,7 @@ def _check_types(arg):
     return ""
 
 
-def raise_exception(e):
+def raise_exception_or_return_false(e):
     if not settings.enable_error_handler:
         if settings.release_on_exception:
             from pyaedt.generic.desktop_sessions import _desktop_sessions
@@ -216,13 +216,13 @@ def _function_handler_wrapper(user_function, **deprecated_kwargs):
                 pyaedt_logger.error("")
             if settings.enable_file_logs:
                 settings.error(message)
-            raise_exception(e)
+            return raise_exception_or_return_false(e)
         except GrpcApiError as e:
             _exception(sys.exc_info(), user_function, args, kwargs, "AEDT grpc API call Error")
-            raise_exception(e)
+            return raise_exception_or_return_false(e)
         except BaseException as e:
             _exception(sys.exc_info(), user_function, args, kwargs, str(sys.exc_info()[1]).capitalize())
-            raise_exception(e)
+            return raise_exception_or_return_false(e)
 
     return wrapper
 


### PR DESCRIPTION
Following https://github.com/ansys/pyaedt/pull/4463, it seems that the `pyaedt_function_handler` function was not working correctly. Indeed, if an exception was raised and the settings were such that one would want the function handler to return False, no value was returned by the function (leading to a None return).

Some tests have been added to ensure that the behavior of the function does not changes without notice. They cover the following behaviors of the function handler:
- enable error handler;
- release on exception;
- argument deprecation mechanism.

Closes #4707