### PR TITLE
REFACTOR: Update mirror argument from "position" to "origin"

### DIFF
--- a/pyaedt/modeler/cad/components_3d.py
+++ b/pyaedt/modeler/cad/components_3d.py
@@ -511,12 +511,12 @@ class UserDefinedComponent(object):
         return self._primitives.duplicate_and_mirror(self.name, origin=origin, vector=vector, is_3d_comp=True)
 
     @pyaedt_function_handler()
-    def mirror(self, position, vector):
+    def mirror(self, origin, vector):
         """Mirror a selection.
 
         Parameters
         ----------
-        position : list, Position
+        origin : list, Position
             List of the ``[x, y, z]`` coordinates or
             the Application.Position object for the selection.
         vector : float
@@ -534,11 +534,11 @@ class UserDefinedComponent(object):
         >>> oEditor.Mirror
         """
         if self.is3dcomponent:
-            if self._primitives.mirror(self.name, position=position, vector=vector):
+            if self._primitives.mirror(self.name, origin=origin, vector=vector):
                 return self
         else:
             for part in self.parts:
-                self._primitives.mirror(part, position=position, vector=vector)
+                self._primitives.mirror(part, origin=origin, vector=vector)
             return self
         return False
 

--- a/pyaedt/modeler/cad/components_3d.py
+++ b/pyaedt/modeler/cad/components_3d.py
@@ -510,7 +510,7 @@ class UserDefinedComponent(object):
         """
         return self._primitives.duplicate_and_mirror(self.name, origin=origin, vector=vector, is_3d_comp=True)
 
-    @pyaedt_function_handler()
+    @pyaedt_function_handler(position="origin")
     def mirror(self, origin, vector):
         """Mirror a selection.
 

--- a/pyaedt/modeler/cad/object3d.py
+++ b/pyaedt/modeler/cad/object3d.py
@@ -1451,12 +1451,12 @@ class Object3d(object):
         return self._primitives.split(self.name, plane, sides)
 
     @pyaedt_function_handler()
-    def mirror(self, position, vector, duplicate=False):
+    def mirror(self, origin, vector, duplicate=False):
         """Mirror a selection.
 
         Parameters
         ----------
-        position : list of int or float
+        origin : list of int or float
             Cartesian ``[x, y, z]`` coordinates or
             the ``Application.Position`` object of a point in the plane used for the mirror operation.
         vector : list of float
@@ -1477,7 +1477,7 @@ class Object3d(object):
 
         >>> oEditor.Mirror
         """
-        if self._primitives.mirror(self.id, position=position, vector=vector, duplicate=duplicate):
+        if self._primitives.mirror(self.id, origin=origin, vector=vector, duplicate=duplicate):
             return self
         return False
 

--- a/pyaedt/modeler/cad/object3d.py
+++ b/pyaedt/modeler/cad/object3d.py
@@ -1450,7 +1450,7 @@ class Object3d(object):
         """
         return self._primitives.split(self.name, plane, sides)
 
-    @pyaedt_function_handler()
+    @pyaedt_function_handler(position="origin")
     def mirror(self, origin, vector, duplicate=False):
         """Mirror a selection.
 


### PR DESCRIPTION
Mirroring #4714 from https://github.com/marcobiasizzo (who cannot access secrets)

"""
In the mirror function of components_3d and object3d one of the argument is called position. To be coherent with other functions (also with mirror in primitives), the variable name is updated to origin.
"""

@marcobiasizzo Thanks again for your contribution !