### PR TITLE
REFACTOR: Encryption password handling

### DIFF
--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -1023,7 +1023,7 @@ class FieldAnalysis3D(Analysis, object):
         bool
             ``True`` when successful, ``False`` when failed.
         """
-        if not password:
+        if password is None:
             password = os.getenv("PYAEDT_ENCRYPTED_PASSWORD", "")
         native_comp_names = [nc.component_name for _, nc in self.native_components.items()]
         if not components:

--- a/pyaedt/modeler/cad/Primitives3D.py
+++ b/pyaedt/modeler/cad/Primitives3D.py
@@ -1369,7 +1369,7 @@ class Primitives3D(GeometryModeler):
             design_parameters="",
             coordinate_system="Global",
             name=None,
-            password="",
+            password=None,
             auxiliary_parameters=False,
     ):
         """Insert a new 3D component.
@@ -1389,7 +1389,7 @@ class Primitives3D(GeometryModeler):
         name : str, optional
             3D component name. The default is ``None``.
         password : str, optional
-            Password for encrypted components. The default is an empty string.
+            Password for encrypted components. The default value is ``None``.
         auxiliary_parameters : bool or str, optional
             Enable the advanced 3d component import. It is possible to set explicitly the json file.
             The default is ``False``.
@@ -1404,6 +1404,8 @@ class Primitives3D(GeometryModeler):
 
         >>> oEditor.Insert3DComponent
         """
+        if password is None:
+            password = os.getenv("PYAEDT_ENCRYPTED_PASSWORD", "")
         aedt_fh = open_file(input_file, "rb")
         if aedt_fh:
             temp = aedt_fh.read().splitlines()

--- a/pyaedt/modeler/cad/components_3d.py
+++ b/pyaedt/modeler/cad/components_3d.py
@@ -820,13 +820,13 @@ class UserDefinedComponent(object):
         )
 
     @pyaedt_function_handler(new_filepath="output_file")
-    def update_definition(self, password="", output_file="", local_update=False):
+    def update_definition(self, password=None, output_file="", local_update=False):
         """Update 3d component definition.
 
         Parameters
         ----------
         password : str, optional
-            Password for encrypted models. The default value is ``""``.
+            Password for encrypted models. The default value is ``None``.
         output_file : str, optional
             New path containing the 3d component file. The default value is ``""``, which means
             that the 3d component file has not changed.
@@ -838,7 +838,8 @@ class UserDefinedComponent(object):
         bool
             True if successful.
         """
-
+        if password is None:
+            password = os.getenv("PYAEDT_ENCRYPTED_PASSWORD", "")
         self._primitives._app.oeditor.UpdateComponentDefinition(
             [
                 "NAME:UpdateDefinitionData",
@@ -856,7 +857,7 @@ class UserDefinedComponent(object):
         return True
 
     @pyaedt_function_handler()
-    def edit_definition(self, password=""):
+    def edit_definition(self, password=None):
         """Edit 3d Definition. Open AEDT Project and return Pyaedt Object.
 
         Parameters
@@ -874,7 +875,8 @@ class UserDefinedComponent(object):
         from pyaedt.generic.design_types import get_pyaedt_app
 
         # from pyaedt.generic.general_methods import is_linux
-
+        if password is None:
+            password = os.getenv("PYAEDT_ENCRYPTED_PASSWORD", "")
         project_list = [i for i in self._primitives._app.project_list]
 
         self._primitives.oeditor.Edit3DComponentDefinition(

--- a/pyaedt/modeler/modeler3d.py
+++ b/pyaedt/modeler/modeler3d.py
@@ -70,8 +70,8 @@ class Modeler3D(Primitives3D):
         is_encrypted=False,
         allow_edit=False,
         security_message="",
-        password="",
-        edit_password="",
+        password=None,
+        edit_password=None,
         password_type="UserSuppliedPassword",
         hide_contents=False,
         replace_names=False,
@@ -112,10 +112,10 @@ class Modeler3D(Primitives3D):
             The default value is an empty string.
         password : str, optional
             Security password needed when adding the component.
-            The default value is an empty string.
+            The default value is ``None``.
         edit_password : str, optional
             Edit password.
-            The default value is an empty string.
+            The default value is ``None``.
         password_type : str, optional
             Password type. Options are ``UserSuppliedPassword`` and ``InternalPassword``.
             The default is ``UserSuppliedPassword``.
@@ -164,6 +164,11 @@ class Modeler3D(Primitives3D):
             return False
         if component_outline not in ["BoundingBox", "None"]:
             return False
+        if password is None:
+            password = os.getenv("PYAEDT_ENCRYPTED_PASSWORD", "")
+        if not edit_password:
+            edit_password = os.getenv("PYAEDT_ENCRYPTED_EDIT_PASSWORD", "")
+
         hide_contents_flag = is_encrypted and isinstance(hide_contents, list)
         arg = [
             "NAME:CreateData",


### PR DESCRIPTION
Hardcoding a default password is considered bad practice because it degrades security (easy to target for attackers and reverse engineering), flexibility (harder to rotate password), ....

As an alternative approach, we could use config files secrets or environment variables. This PR follows the environment variables that was used in #4672 to handle codacy warning.