### PR TITLE
FIX: metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,23 +6,32 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "pyaedt"
 dynamic = ["version"]
-description = "Higher-Level Pythonic Ansys Electronics Desktop Framework"
+description = "High-level Python API for Ansys Electronics Desktop Framework"
 readme = "README.md"
 requires-python = ">=3.7,<4"
 license = {file = "LICENSE"}
 authors = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
-maintainers = [{name = "PyAEDT developers", email = "massimo.capodiferro@ansys.com"}]
+maintainers = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
 classifiers = [
+    # General classifiers
     "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Intended Audience :: Manufacturing",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Libraries",
+    "Topic :: Scientific/Engineering :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    # Additional specific classifiers
+    "Operating System :: OS Independent",
 ]
 
 dependencies = [


### PR DESCRIPTION
This pull-request fixes the metadata included in the `pyproject.toml` file. In addition, new classifiers have been added. Related with #4775.