### PR TITLE
FEAT: Check License feature

### DIFF
--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -963,7 +963,6 @@ def is_license_feature_available(feature="electronics_desktop", count=1):  # pra
          ``None`` when licenser server is down.
     """
     import subprocess  # nosec B404
-    import tempfile
 
     aedt_install_folder = list(installed_versions().values())[0]
 
@@ -973,8 +972,8 @@ def is_license_feature_available(feature="electronics_desktop", count=1):  # pra
         ansysli_util_path = os.path.join(aedt_install_folder, "licensingclient", "winx64", "ansysli_util")
     my_env = os.environ.copy()
 
-    tempfile_status = tempfile.mktemp(suffix=".txt")
-    tempfile_checkout = tempfile.mktemp(suffix=".txt")
+    tempfile_status = tempfile.NamedTemporaryFile(suffix=".txt", delete=False).name
+    tempfile_checkout = tempfile.NamedTemporaryFile(suffix=".txt", delete=False).name
 
     # License server status
     cmd = [ansysli_util_path, "-statli"]

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -959,8 +959,7 @@ def is_license_feature_available(feature="electronics_desktop", count=1):  # pra
     Returns
     -------
     bool
-        ``True`` when feature available, ``False`` when feature not available, and
-         ``None`` when licenser server is down.
+        ``True`` when feature available, ``False`` when feature not available.
     """
     import subprocess  # nosec B404
 
@@ -992,8 +991,8 @@ def is_license_feature_available(feature="electronics_desktop", count=1):  # pra
                 break
 
     if is_server_down:
-        pyaedt_logger.info("License server process could not be found.")
-        return None
+        pyaedt_logger.warning("License server process could not be found.")
+        return False
 
     cmd = [ansysli_util_path, "-checkcount", str(count), "-checkout", feature]
 
@@ -1008,7 +1007,7 @@ def is_license_feature_available(feature="electronics_desktop", count=1):  # pra
         for line in f:
             checkout_lines.append(line)
     if "CHECKOUT FAILED" in checkout_lines[1] or len(checkout_lines) != 2:
-        pyaedt_logger.info(checkout_lines[0])
+        pyaedt_logger.warning(checkout_lines[0])
         return False
     return True
 


### PR DESCRIPTION
Close #4753 

@MelanieMichon We have implemented this method to check if the license server is down or if the license increment is available. The user should first check it, because for now is dangerous to add it inside the Desktop initialization. 

