### PR TITLE
FIX: Project classifier to be PyPI compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Topic :: Scientific/Engineering :: Libraries",
+    "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Scientific/Engineering :: Electronic Design Automation (EDA)",
     "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
Seems like changes in #4784 introduced a typo in the package classifier which lead to [release failure](https://github.com/ansys/pyaedt/actions/runs/9518607641/job/26260047110) when uploading to PyPI.

Here is a fix following [PyPI's classifiers](https://pypi.org/classifiers/).