### PR TITLE
FIX: Circuit argument deprecation miss

### DIFF
--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -154,6 +154,7 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods):
         projectname="project",
         specified_version="version",
         setup_name="setup",
+        new_desktop_session="new_desktop",
     )
     def __init__(
         self,


### PR DESCRIPTION
As title says.

Found this problem while working on the pyaedt-examples repo.