### PR TITLE
FIX: HFSS argument deprecation miss

### DIFF
--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -195,6 +195,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods):
         projectname="project",
         specified_version="version",
         setup_name="setup",
+        new_desktop_session="new_desktop",
     )
     def __init__(
         self,


### PR DESCRIPTION
As title says.

Like #4827, this PR should fix missing argument deprecation from #4777

Note: found this problem while working on the pyaedt-examples repo.