### PR TITLE
DOCS: Add v1.0 expected breaking changes

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,7 +16,7 @@ enabling straightforward and efficient automation in your workflow.
 .. note:: Expected breaking changes with version `1.0`
 
    If you want to know more about the breaking changes expected
-   if the incoming version `1.0`, see the :ref:`release_1_0`.
+   in the incoming version `1.0`, see the :ref:`release_1_0`.
 
 .. note::
     Also consider viewing the `PyEDB documentation <https://edb.docs.pyansys.com/version/stable/>`_.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,6 +13,11 @@ PyAEDT documentation  |version|
 PyAEDT is a Python client library that interacts directly with the Ansys Electronics Desktop (AEDT) API,
 enabling straightforward and efficient automation in your workflow.
 
+.. note:: Expected breaking changes with version `1.0`
+
+   If you want to know more about the breaking changes expected
+   if the incoming version `1.0`, see the :ref:`release_1_0`.
+
 .. note::
     Also consider viewing the `PyEDB documentation <https://edb.docs.pyansys.com/version/stable/>`_.
     PyEDB is a Python client library for processing complex and large layout designs in the Ansys

--- a/doc/source/release_1_0.rst
+++ b/doc/source/release_1_0.rst
@@ -10,8 +10,8 @@ of the codebase.
 Deprecation of function argument names
 --------------------------------------
 
-In the 1.0 release, several function argument names are deprecated and are no longer 
-allowed. You should review your code and check the warnings that are logged at run time.
+In the 1.0 release, several function argument names are deprecated. You should review 
+your code and check the warnings that are logged at run time.
 The following example shows a warning triggered by the use of an argument that is currently acceptable but is not going to work with version 1.0.
 
 .. code-block:: python
@@ -38,12 +38,14 @@ The changes to the structure follow:
 
     Old structure:
     --------------
+
     pyaedt/
     ├── application/
     └── ...
 
     New structure:
     --------------
+
     src/
     └── ansys/
         └── aedt/
@@ -52,6 +54,7 @@ The changes to the structure follow:
 
 When migrating to major release `1.0`, please update any references or imports in your project
 accordingly. An example of migration is shown below:
+
 **Old import:**
 
 .. code-block:: python

--- a/doc/source/release_1_0.rst
+++ b/doc/source/release_1_0.rst
@@ -10,10 +10,10 @@ of the sources.
 Deprecation of function argument names
 --------------------------------------
 
-In the next major version, several function argument names will be deprecated and will no longer
-be allowed. Please review your code and check the warning that are logged at run time.
+In the next major version, several function argument names are deprecated and are no longer 
+allowed. Please review your code and check the warning that are logged at run time.
 Below is an example of a warning triggered by the use of an argument that is currently tolerated
-but which will not work with version `1.0`.
+but which is not going to work with version `1.0`.
 
 .. code-block:: python
 
@@ -26,14 +26,14 @@ Expected log output:
 
     PyAEDT WARNING: Argument `designname` is deprecated for method `__init__`; use `design` instead.
 
-Restructuration of the codebase
--------------------------------
+Restructuring of the codebase
+-----------------------------
 
-To facilitate the maintenance of our package and to adhere to PyAnsys' guidelines, we are
-restructuring the codebase. The sources will be moved from `pyaedt` to `src.ansys.aedt`.
+To facilitate the maintenance of our package and to adhere to PyAnsys' guidelines, the codebase
+is being restructurated. The sources are to be moved from `pyaedt` to `src.ansys.aedt`.
 This change aims to improve the organization and maintainability of the codebase.
 
-The new structure will be as follows:
+The new structure is going to be as follow:
 
 .. code-block:: text
 
@@ -67,11 +67,11 @@ should be updated into
 Other changes to reach release 1.0
 ==================================
 
-In addition to the major changes described above, we are continuously making regular
-modifications to improve the quality of the project, its maintainability, its documentation, and
-to ensure we can meet user needs as efficiently as possible. This includes ensuring
-consistency on argument names; strengthening our CI/CD; extracting examples to a dedicated
-project to increase clarity, homogeneity and facilite integration; ...
+In addition to the major changes described above, modifications are continuously performed to
+improve the quality of the project, its maintainability, its documentation, and
+to ensure users' need are met as efficiently as possible. This includes ensuring
+consistency on argument names; improving data encapsulation; strengthening our CI/CD; extracting
+examples to a dedicated project to increase clarity, homogeneity and facilite integration; ...
 
 See `PyAEDT Milestone <https://github.com/ansys/pyaedt/milestone/3>`_ for more information on
 the status of the release.

--- a/doc/source/release_1_0.rst
+++ b/doc/source/release_1_0.rst
@@ -30,7 +30,7 @@ Restructuring of the codebase
 -----------------------------
 
 To facilitate the maintenance of PyAEDT and to adhere to PyAnsys' guidelines, the codebase
-is being restructed. The sources are to be moved from `pyaedt` to `src.ansys.aedt`.
+is being restructured. The sources are to be moved from `pyaedt` to `src.ansys.aedt`.
 This change aims to improve the organization and maintainability of the codebase.
 
 The new structure is going to be as follow:

--- a/doc/source/release_1_0.rst
+++ b/doc/source/release_1_0.rst
@@ -3,17 +3,16 @@
 Breaking changes in release 1.0
 ===============================
 
-This document outlines the breaking changes expected in the upcoming major version `1.0` of PyAEDT.
+This page describes the breaking changes expected in the upcoming major version 1.0 of PyAEDT.
 These changes include the deprecation of certain function argument names and the restructuring
-of the sources.
+of the codebase.
 
 Deprecation of function argument names
 --------------------------------------
 
-In the next major version, several function argument names are deprecated and are no longer 
-allowed. Please review your code and check the warning that are logged at run time.
-Below is an example of a warning triggered by the use of an argument that is currently tolerated
-but which is not going to work with version `1.0`.
+In the 1.0 release, several function argument names are deprecated and are no longer 
+allowed. You should review your code and check the warnings that are logged at run time.
+The following example shows a warning triggered by the use of an argument that is currently acceptable but is not going to work with version 1.0.
 
 .. code-block:: python
 
@@ -30,20 +29,20 @@ Restructuring of the codebase
 -----------------------------
 
 To facilitate the maintenance of PyAEDT and to adhere to PyAnsys' guidelines, the codebase
-is being restructured. The sources are to be moved from `pyaedt` to `src.ansys.aedt`.
-This change aims to improve the organization and maintainability of the codebase.
+is being restructured. The sources are to be moved from ``pyaedt`` to ``src.ansys.aedt``
+to improve the organization and maintainability of the codebase.
 
-The new structure is going to be as follow:
+The changes to the structure follow:
 
 .. code-block:: text
 
-    Old Structure:
+    Old structure:
     --------------
     pyaedt/
     ├── application/
     └── ...
 
-    New Structure:
+    New structure:
     --------------
     src/
     └── ansys/
@@ -53,25 +52,25 @@ The new structure is going to be as follow:
 
 When migrating to major release `1.0`, please update any references or imports in your project
 accordingly. An example of migration is shown below:
+**Old import:**
 
 .. code-block:: python
 
     from pyaedt import Circuit    
 
-should be updated into
+**New import:**
 
 .. code-block:: python
 
     from ansys.aedt import Circuit
 
-Other changes to reach release 1.0
-==================================
+Other changes in release 1.0
+============================
 
-In addition to the major changes described above, modifications are continuously performed to
+In addition to the major changes described earlier, modifications are continuously performed to
 improve the quality of the project, its maintainability, its documentation, and
 to ensure users' need are met as efficiently as possible. This includes ensuring
-consistency on argument names, improving data encapsulation, strengthening CI/CD, extracting
+consistent argument names, improving data encapsulation, strengthening CI/CD, and extracting
 examples to a dedicated project.
 
-See `PyAEDT Milestone <https://github.com/ansys/pyaedt/milestone/3>`_ for more information on
-the status of the release.
+For more information on the status of the 1.0 release, see `PyAEDT Milestone <https://github.com/ansys/pyaedt/milestone/3>` .

--- a/doc/source/release_1_0.rst
+++ b/doc/source/release_1_0.rst
@@ -4,7 +4,7 @@ Breaking changes in release 1.0
 ===============================
 
 This document outlines the breaking changes expected in the upcoming major version `1.0` of PyAEDT.
-These changes include the deprecation of certain function argument names and the restructuration
+These changes include the deprecation of certain function argument names and the restructuring
 of the sources.
 
 Deprecation of function argument names
@@ -29,8 +29,8 @@ Expected log output:
 Restructuring of the codebase
 -----------------------------
 
-To facilitate the maintenance of our package and to adhere to PyAnsys' guidelines, the codebase
-is being restructurated. The sources are to be moved from `pyaedt` to `src.ansys.aedt`.
+To facilitate the maintenance of PyAEDT and to adhere to PyAnsys' guidelines, the codebase
+is being restructed. The sources are to be moved from `pyaedt` to `src.ansys.aedt`.
 This change aims to improve the organization and maintainability of the codebase.
 
 The new structure is going to be as follow:
@@ -70,8 +70,8 @@ Other changes to reach release 1.0
 In addition to the major changes described above, modifications are continuously performed to
 improve the quality of the project, its maintainability, its documentation, and
 to ensure users' need are met as efficiently as possible. This includes ensuring
-consistency on argument names; improving data encapsulation; strengthening our CI/CD; extracting
-examples to a dedicated project to increase clarity, homogeneity and facilite integration; ...
+consistency on argument names, improving data encapsulation, strengthening CI/CD, extracting
+examples to a dedicated project.
 
 See `PyAEDT Milestone <https://github.com/ansys/pyaedt/milestone/3>`_ for more information on
 the status of the release.

--- a/doc/source/release_1_0.rst
+++ b/doc/source/release_1_0.rst
@@ -1,0 +1,77 @@
+.. _release_1_0:
+
+Breaking changes in release 1.0
+===============================
+
+This document outlines the breaking changes expected in the upcoming major version `1.0` of PyAEDT.
+These changes include the deprecation of certain function argument names and the restructuration
+of the sources.
+
+Deprecation of function argument names
+--------------------------------------
+
+In the next major version, several function argument names will be deprecated and will no longer
+be allowed. Please review your code and check the warning that are logged at run time.
+Below is an example of a warning triggered by the use of an argument that is currently tolerated
+but which will not work with version `1.0`.
+
+.. code-block:: python
+
+    from pyaedt import Circuit
+    c = Circuit(designname="whatever")
+
+Expected log output:
+
+.. code-block:: text
+
+    PyAEDT WARNING: Argument `designname` is deprecated for method `__init__`; use `design` instead.
+
+Restructuration of the codebase
+-------------------------------
+
+To facilitate the maintenance of our package and to adhere to PyAnsys' guidelines, we are
+restructuring the codebase. The sources will be moved from `pyaedt` to `src.ansys.aedt`.
+This change aims to improve the organization and maintainability of the codebase.
+
+The new structure will be as follows:
+
+.. code-block:: text
+
+    Old Structure:
+    --------------
+    pyaedt/
+    ├── application/
+    └── ...
+
+    New Structure:
+    --------------
+    src/
+    └── ansys/
+        └── aedt/
+            ├── application/
+            ├── ...
+
+When migrating to major release `1.0`, please update any references or imports in your project
+accordingly. An example of migration is shown below:
+
+.. code-block:: python
+
+    from pyaedt import Circuit    
+
+should be updated into
+
+.. code-block:: python
+
+    from ansys.aedt import Circuit
+
+Other changes to reach release 1.0
+==================================
+
+In addition to the major changes described above, we are continuously making regular
+modifications to improve the quality of the project, its maintainability, its documentation, and
+to ensure we can meet user needs as efficiently as possible. This includes ensuring
+consistency on argument names; strengthening our CI/CD; extracting examples to a dedicated
+project to increase clarity, homogeneity and facilite integration; ...
+
+See `PyAEDT Milestone <https://github.com/ansys/pyaedt/milestone/3>`_ for more information on
+the status of the release.


### PR DESCRIPTION
As we are approaching release `1.0` it would be great to notify users that some breaking changes are expected to happend when migration to this new major version.

This PR addresses this aspect by mentioning the argument deprecation and the expected directory restructuration.
On top of it, other changes are mentioned as the naming consistency, data encapsulation, examples extraction, ...

I hope to link this PR with another one to warn users of this incoming changes when they import pyaedt.