### PR TITLE
REFACTOR: Angle property getter in aedt 2023.2 and below is broken in GRPC and has to be bypassed.

### DIFF
--- a/_unittest/test_21_Circuit.py
+++ b/_unittest/test_21_Circuit.py
@@ -518,7 +518,7 @@ class TestClass:
             for i in range(10):
                 f.write("L{} net_{} net_{} 1e-9\n".format(i, i, i + 1))
                 f.write("C{} net_{} 0 5e-12\n".format(i, i + 1))
-        self.aedtapp.modeler.components.create_interface_port("net_0", (0, 0))
+        self.aedtapp.modeler.components.create_interface_port("net_0", (0, 0), angle=90)
         self.aedtapp.modeler.components.create_interface_port("net_10", (0.01, 0))
         lna = self.aedtapp.create_setup("mylna", self.aedtapp.SETUPS.NexximLNA)
         lna.props["SweepDefinition"]["Data"] = "LINC 0Hz 1GHz 101"

--- a/pyaedt/modeler/circuits/object3dcircuit.py
+++ b/pyaedt/modeler/circuits/object3dcircuit.py
@@ -690,7 +690,7 @@ class CircuitComponent(object):
             )
         else:  # pragma: no cover
             self._circuit_components._app.logger.warning(
-                "Angles are not supported by GRPC in AEDT versions lower than 2024.1."
+                "Angles are not supported by gRPC in AEDT versions lower than 2024 R1."
             )
 
         return self._angle

--- a/pyaedt/modeler/circuits/object3dcircuit.py
+++ b/pyaedt/modeler/circuits/object3dcircuit.py
@@ -688,6 +688,11 @@ class CircuitComponent(object):
                     "deg", ""
                 )
             )
+        else:  # pragma: no cover
+            self._circuit_components._app.logger.warning(
+                "Angles are not supported by GRPC in AEDT versions lower than 2024.1."
+            )
+
         return self._angle
 
     @angle.setter

--- a/pyaedt/modeler/circuits/object3dcircuit.py
+++ b/pyaedt/modeler/circuits/object3dcircuit.py
@@ -33,6 +33,7 @@ from pyaedt.generic.constants import AEDT_UNITS
 from pyaedt.generic.general_methods import _arg2dict
 from pyaedt.generic.general_methods import _dim_arg
 from pyaedt.generic.general_methods import pyaedt_function_handler
+from pyaedt.generic.settings import settings
 from pyaedt.modeler.cad.elements3d import _dict2arg
 from pyaedt.modeler.geometry_operators import GeometryOperators as go
 
@@ -681,7 +682,7 @@ class CircuitComponent(object):
                 if "Angle=" in info:
                     self._angle = float(info[6:])
                     break
-        else:
+        elif settings.aedt_version > "2023.2":
             self._angle = float(
                 self._oeditor.GetPropertyValue("BaseElementTab", self.composed_name, "Component Angle").replace(
                     "deg", ""


### PR DESCRIPTION

This is correctly working in 2024.1