### PR TITLE
REFACTOR: Cleanup rmxprt and pyaedt.modules files

### DIFF
--- a/pyaedt/modules/report_templates.py
+++ b/pyaedt/modules/report_templates.py
@@ -544,7 +544,7 @@ class CommonReport(object):
                 for i in oo1:
                     _traces.append(Trace(self._post.oreportsetup, "{}:{}:{}".format(self.plot_name, el, i)))
             except Exception:
-                pass
+                self._post._app.logger.debug("Something went wrong while processing element {el}.".format(el))
         return _traces
 
     @pyaedt_function_handler()

--- a/pyaedt/modules/report_templates.py
+++ b/pyaedt/modules/report_templates.py
@@ -544,7 +544,7 @@ class CommonReport(object):
                 for i in oo1:
                     _traces.append(Trace(self._post.oreportsetup, "{}:{}:{}".format(self.plot_name, el, i)))
             except Exception:
-                self._post._app.logger.debug("Something went wrong while processing element {el}.".format(el))
+                self._post._app.logger.debug("Something went wrong while processing element {}.".format(el))
         return _traces
 
     @pyaedt_function_handler()

--- a/pyaedt/modules/solutions.py
+++ b/pyaedt/modules/solutions.py
@@ -3268,7 +3268,9 @@ class FieldPlot:
                         else:
                             nonmodel_faces.append(str(index))
                     except Exception:
-                        pass
+                        self._postprocessor.logger.debug(
+                            "Something went wrong while processing surface {}.".format(index)
+                        )
             info.append("Surface")
             if model_faces:
                 info.append("FacesList")

--- a/pyaedt/rmxprt.py
+++ b/pyaedt/rmxprt.py
@@ -58,9 +58,10 @@ class RMXprtModule(object):
             if parameter_name in parameter_list:
                 prop_server = key
                 break
-        assert prop_server is not None, "Unknown parameter name {0} exists in component {1}.".format(
-            prop_server, self.component
-        )
+        if prop_server is None:
+            raise AssertionError(
+                "Unknown parameter name {0} exists in component {1}.".format(prop_server, self.component)
+            )
         return prop_server
 
     def __init__(self, oeditor):
@@ -269,8 +270,8 @@ class Rmxprt(FieldAnalysisRMxprt):
         )
         if not model_units or model_units == "mm":
             model_units = "mm"
-        else:
-            assert model_units == "in", "Invalid model units string {}".format(model_units)
+        elif model_units != "in":
+            raise AssertionError("Invalid model units string {}.".format(model_units))
         self.modeler.oeditor.SetMachineUnits(["NAME:Units Parameter", "Units:=", model_units, "Rescale:=", False])
         self.stator = Stator(self.modeler.oeditor)
         self.rotor = Rotor(self.modeler.oeditor)


### PR DESCRIPTION
As title says.

Note: contrary to previous refactoring, I used the following approach to be more compliant with what was expected to happen:
- logging at debug level in try: .. except: pass;
- raising `AssertionError` when calling assert in the code.

The first ensures that we can log information and don't confuse users.
The second ensures that the tolerant approach used through the function handler is kept and used.