### PR TITLE
FIX: AEDT port value in create_session

### DIFF
--- a/pyaedt/common_rpc.py
+++ b/pyaedt/common_rpc.py
@@ -318,7 +318,7 @@ def create_session(server_name, client_port=None, launch_aedt_on_server=False, a
                 aedt_port = client.root.check_port()
             cl.aedt(port=aedt_port, non_graphical=non_graphical)
             logger.info("Aedt started on port %s", aedt_port)
-            if cl.aedt_port is None:
+            if not cl.aedt_port:
                 cl.aedt_port = aedt_port
         return cl
     except Exception:


### PR DESCRIPTION
This is an attempt to fix #4844.

@maxcapodi78 The main change is that we both handle `None` and `0` as the same kind of result. Indeed, `0` seems to be the default value obtained if `_desktop_sessions` is empty. Note that I'm not sure if, in the case of existing desktop sessions, we shouldn't use directly `client.root.check_port()` to define `cl.aedt_port` directly.
Also, I was wondering how we could try to leverage `_desktop_sessions` from `pyaedt.generic.desktop_sessions` but I have the feeling that this shouldn't be updated unless a `Desktop` is created (which isn't performed right through the call `create_session` right ?)