### PR TITLE
FEAT: `clear_linked_data` method to Icepak

### DIFF
--- a/_unittest/test_98_Icepak.py
+++ b/_unittest/test_98_Icepak.py
@@ -307,6 +307,9 @@ class TestClass:
             "uUSB", "Setup1", "LastAdaptive", "2.5GHz", surface_list, HFSSpath, param_list, object_list
         )
 
+    def test_06_clear_linked_data(self):
+        assert self.aedtapp.clear_linked_data()
+
     def test_07_ExportStepForWB(self):
         file_path = self.local_scratch.path
         file_name = "WBStepModel"
@@ -321,8 +324,8 @@ class TestClass:
         assert self.aedtapp.assign_2way_coupling(setup_name, 2, True, 20)
         templates = SetupKeys().get_default_icepak_template(default_type="Natural Convection")
         assert templates
-        self.aedtapp.setups[0].props = templates["IcepakSteadyState"]
-        assert self.aedtapp.setups[0].update()
+        my_setup.props = templates["IcepakSteadyState"]
+        assert my_setup.update()
         assert SetupKeys().get_default_icepak_template(default_type="Default")
         assert SetupKeys().get_default_icepak_template(default_type="Forced Convection")
         with pytest.raises(AttributeError):

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -1085,8 +1085,7 @@ class Design(AedtObjects):
 
         Returns
         -------
-        type
-            Design object.
+        Design object
 
         References
         ----------

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -6464,6 +6464,28 @@ class Icepak(FieldAnalysis3D):
         """
         return SquareWaveDictionary(on_value, initial_time_off, on_time, off_time, off_value)
 
+    @pyaedt_function_handler
+    def clear_linked_data(self):
+        """
+        Clear the linked data of all the solution setups.
+
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+
+        References
+        ----------
+
+        >>> oDesign.ClearLinkedData
+        """
+        try:
+            self.odesign.ClearLinkedData()
+        except:
+            return False
+        else:
+            return True
+
 
 class IcepakDesignSettingsManipulation(DesignSettingsManipulation):
     def __init__(self, app):

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -6464,7 +6464,7 @@ class Icepak(FieldAnalysis3D):
         """
         return SquareWaveDictionary(on_value, initial_time_off, on_time, off_time, off_value)
 
-    @pyaedt_function_handler
+    @pyaedt_function_handler()
     def clear_linked_data(self):
         """
         Clear the linked data of all the solution setups.


### PR DESCRIPTION
- Added `clear_linked_data` method to Icepak.
- Changed the return type of `odesign`, to avoid warning in the IDE.