### PR TITLE
FIX: plotter show exiting plotting session

### DIFF
--- a/pyaedt/generic/plot.py
+++ b/pyaedt/generic/plot.py
@@ -1739,11 +1739,11 @@ class ModelPlotter(CommonPlotter):
             if extension in supported_export:
                 self.pv.save_graphic(export_image_path, raster=raster, painter=painter)
             else:
-                self.pv.show(screenshot=export_image_path, full_screen=True)
+                self.pv.show(auto_close=False, screenshot=export_image_path, full_screen=True)
         elif show and self.is_notebook:  # pragma: no cover
-            self.pv.show()  # pragma: no cover
+            self.pv.show(auto_close=False)  # pragma: no cover
         elif show:
-            self.pv.show(full_screen=True)  # pragma: no cover
+            self.pv.show(auto_close=False, full_screen=True)  # pragma: no cover
 
         self.image_file = export_image_path
         return True
@@ -1910,7 +1910,7 @@ class ModelPlotter(CommonPlotter):
         else:
             self.pv.isometric_view()
         self.pv.camera.zoom(self.zoom)
-        cpos = self.pv.show(interactive=False, auto_close=False, interactive_update=not self.off_screen)
+        self.pv.show(interactive=False, auto_close=False, interactive_update=not self.off_screen)
 
         start = time.time()
         try:

--- a/pyaedt/modules/solutions.py
+++ b/pyaedt/modules/solutions.py
@@ -2592,7 +2592,7 @@ class FfdSolutionData(object):
         if image_path:
             p.show(screenshot=image_path)
         if show:  # pragma: no cover
-            p.show()
+            p.show(auto_close=False)
         return p
 
     @pyaedt_function_handler()

--- a/pyaedt/sbrplus/plot.py
+++ b/pyaedt/sbrplus/plot.py
@@ -166,7 +166,7 @@ class HDMPlotter(CommonPlotter):
         if snapshot_path:
             self.pv.show(screenshot=snapshot_path, full_screen=True)
         else:
-            self.pv.show()
+            self.pv.show(auto_close=False)
         return self.pv
 
     @pyaedt_function_handler()
@@ -222,7 +222,7 @@ class HDMPlotter(CommonPlotter):
         if snapshot_path:
             self.pv.show(screenshot=snapshot_path, full_screen=True)
         else:
-            self.pv.show()
+            self.pv.show(auto_close=False)
 
     @pyaedt_function_handler()
     def _add_objects(self):


### PR DESCRIPTION
Changes consists in handling the fact that some methods are using/returning a plotter and calling `show` on it. However, the default behavior leads to automatically closing the plotting session when user close the plot.

This PR changes this behavior by using `auto_close=False` in `pyvista`'s plotter call to method `show`.

Closes #4730