### PR TITLE
FIX: Pyvista not included in doc-no-examples dependencies

### DIFF
--- a/examples/02-HFSS/Array.py
+++ b/examples/02-HFSS/Array.py
@@ -148,7 +148,7 @@ ffdata.plot_cut(quantity='RealizedGain', primary_sweep="phi", secondary_sweep_va
 # Generate 3D polar plots in Matplotlib. You can define
 # the Theta scan and Phi scan.
 
-plot_3d = ffdata.plot_3d(quantity='RealizedGain', image_path=os.path.join(hfss.working_directory, "Image.jpg"),  show=False)
+plot_3d = ffdata.plot_3d(quantity='RealizedGain', image_path=os.path.join(working_directory, "Image.jpg"),  show=False)
 
 ##########################################################
 # Close all matplotlib figures

--- a/examples/02-HFSS/Array.py
+++ b/examples/02-HFSS/Array.py
@@ -148,7 +148,7 @@ ffdata.plot_cut(quantity='RealizedGain', primary_sweep="phi", secondary_sweep_va
 # Generate 3D polar plots in Matplotlib. You can define
 # the Theta scan and Phi scan.
 
-plot_3d = ffdata.plot_3d(quantity='RealizedGain', show=False)
+plot_3d = ffdata.plot_3d(quantity='RealizedGain', image_path=os.path.join(hfss.working_directory, "Image.jpg"),  show=False)
 
 ##########################################################
 # Close all matplotlib figures

--- a/examples/02-HFSS/Array.py
+++ b/examples/02-HFSS/Array.py
@@ -148,7 +148,7 @@ ffdata.plot_cut(quantity='RealizedGain', primary_sweep="phi", secondary_sweep_va
 # Generate 3D polar plots in Matplotlib. You can define
 # the Theta scan and Phi scan.
 
-ffdata.plot_3d(quantity='RealizedGain')
+plot_3d = ffdata.plot_3d(quantity='RealizedGain', show=False)
 
 ##########################################################
 # Close all matplotlib figures

--- a/examples/02-HFSS/HFSS_Dipole.py
+++ b/examples/02-HFSS/HFSS_Dipole.py
@@ -207,8 +207,8 @@ ffdata = hfss.get_antenna_data(frequencies=["1000MHz"], setup=hfss.nominal_adapt
 # Generate 2D cutout plot. You can define the Theta scan
 # and Phi scan.
 
-ffdata.plot_2d_cut(quantity='RealizedGain', primary_sweep="theta", secondary_sweep_value=0, title='FarField',
-                   quantity_format="dB20", is_polar=True)
+ffdata.farfield_data.plot_cut(quantity='RealizedGain', primary_sweep="theta", secondary_sweep_value=0, title='FarField',
+                              quantity_format="dB20", is_polar=True)
 
 ###############################################################################
 # Close AEDT

--- a/pyaedt/generic/farfield_visualization.py
+++ b/pyaedt/generic/farfield_visualization.py
@@ -310,7 +310,7 @@ class FfdSolutionData(object):
 
     @property
     def s_parameters(self):
-        """Passive s-parameters"""
+        """Passive s-parameters."""
         if self.touchstone_data:
             touchstone_frequencies = self.touchstone_data.f
             index = np.abs(touchstone_frequencies - self.frequency).argmin()
@@ -318,7 +318,7 @@ class FfdSolutionData(object):
 
     @property
     def incident_power_element(self):
-        """Incident power per element in watts"""
+        """Incident power per element in watts."""
         incident_power = {}
         for element_name, element_props in self.element_info.items():
             element_power = element_props.get("incident_power", None)
@@ -331,14 +331,14 @@ class FfdSolutionData(object):
 
     @property
     def incident_power(self):
-        """Total incident power in watts"""
+        """Total incident power in watts."""
         incident_power_element = self.incident_power_element
         if incident_power_element:
             return sum(incident_power_element.values())
 
     @property
     def accepted_power_element(self):
-        """Accepted power per element in watts"""
+        """Accepted power per element in watts."""
         power = {}
         for element_name, element_props in self.element_info.items():
             element_power = element_props.get("accepted_power", None)
@@ -350,14 +350,14 @@ class FfdSolutionData(object):
 
     @property
     def accepted_power(self):
-        """Total accepted power in watts"""
+        """Total accepted power in watts."""
         power_element = self.accepted_power_element
         if power_element:
             return sum(power_element.values())
 
     @property
     def radiated_power_element(self):
-        """Radiated power per element in watts"""
+        """Radiated power per element in watts."""
         power = {}
         for element_name, element_props in self.element_info.items():
             element_power = element_props.get("radiated_power", None)
@@ -369,14 +369,14 @@ class FfdSolutionData(object):
 
     @property
     def radiated_power(self):
-        """Total radiated power in watts"""
+        """Total radiated power in watts."""
         power_element = self.radiated_power_element
         if power_element:
             return sum(power_element.values())
 
     @property
     def active_s_parameters(self):
-        """Active s-parameters"""
+        """Active s-parameters."""
         if self.s_parameters is not None:
             active_s_parameter = {}
             incident_power_list = list(self.incident_power_element.values())
@@ -1659,14 +1659,17 @@ class FfdSolutionDataExporter:
 
     @property
     def model_info(self):
+        """List of models."""
         return self.__model_info
 
     @property
     def farfield_data(self):
+        """Farfield data."""
         return self.__farfield_data
 
     @property
     def metadata_file(self):
+        """Metadata file."""
         return self.__metadata_file
 
     @pyaedt_function_handler()

--- a/pyaedt/generic/farfield_visualization.py
+++ b/pyaedt/generic/farfield_visualization.py
@@ -1121,7 +1121,7 @@ class FfdSolutionData(object):
         show : bool, optional
             Whether to show the plot. The default is ``True``.
         show_as_standalone : bool, optional
-            Whether to show a plot as standalone. The default is ``True``.
+            Whether to show a plot as standalone. The default is ``False``.
         pyvista_object : :class:`Pyvista.Plotter`, optional
             PyVista instance defined externally. The default is ``None``.
         background : list or str, optional

--- a/pyaedt/generic/farfield_visualization.py
+++ b/pyaedt/generic/farfield_visualization.py
@@ -305,7 +305,7 @@ class FfdSolutionData(object):
 
     @property
     def touchstone_data(self):
-        """Touchstone data"""
+        """Touchstone data."""
         return self.__touchstone_data
 
     @property

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -1884,13 +1884,12 @@ class Hfss(FieldAnalysis3D, ScatteringMethods):
             Start direction for the port location.
             It should be one of the values for ``Application.AxisDir``, which are: ``XNeg``, ``YNeg``,
             ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
-             The default is ``Application.AxisDir.XNeg``.
+            The default is ``Application.AxisDir.XNeg``.
         name : str, optional
             Name of the source. The default is ``None``.
         source_on_plane : bool, optional
             Whether to create the source on the plane orthogonal to
             ``AxisDir``. The default is ``True``.
-
 
         Returns
         -------
@@ -1940,13 +1939,12 @@ class Hfss(FieldAnalysis3D, ScatteringMethods):
             Start direction for the port location.
             It should be one of the values for ``Application.AxisDir``, which are: ``XNeg``, ``YNeg``,
             ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
-             The default is ``Application.AxisDir.XNeg``.
+            The default is ``Application.AxisDir.XNeg``.
         name : str, optional
             Name of the source. The default is ``None``.
         source_on_plane : bool, optional
             Whether to create the source on the plane orthogonal to
             the start direction. The default is ``True``.
-
 
         Returns
         -------

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -5891,7 +5891,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods):
 
     @pyaedt_function_handler(filename="file_name")
     def get_hdm_plotter(self, file_name=None):
-        """Get the  HDM plotter``.
+        """Get the HDM plotter.
 
         Parameters
         ----------

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -4865,7 +4865,7 @@ class Icepak(FieldAnalysis3D):
         temperature="AmbientTemp",
         radiation_temperature="AmbientRadTemp",
         pressure="AmbientPressure",
-        velocity=["0m_per_sec", "0m_per_sec", "0m_per_sec"],
+        velocity=None,
     ):
         """
         Assign free opening boundary condition.
@@ -4920,6 +4920,8 @@ class Icepak(FieldAnalysis3D):
         >>> f_id = icepak.modeler["Region"].faces[0].id
         >>> icepak.assign_velocity_free_opening(f_id)
         """
+        if velocity is None:
+            velocity = ["0m_per_sec", "0m_per_sec", "0m_per_sec"]
         return self.assign_free_opening(
             assignment,
             boundary_name=boundary_name,

--- a/pyaedt/modules/PostProcessor.py
+++ b/pyaedt/modules/PostProcessor.py
@@ -3362,11 +3362,10 @@ class PostProcessor(PostProcessorCommon, object):
             Intrinsic variables required to compute the field before the export.
             These are typically: frequency, time and phase.
             It can be provided either as a dictionary or as a string.
-                If it is a dictionary, keys depend on the solution type and can be expressed as:
-                    - ``"Freq"`` or ``"Frequency"``
-                    - ``"Time"``
-                    - ``"Phase"``
-                in lower or camel case.
+                If it is a dictionary, keys depend on the solution type and can be expressed in lower or camel case as:
+                    - ``"Freq"`` or ``"Frequency"``.
+                    - ``"Time"``.
+                    - ``"Phase"``.
             If it is a string, it can either be ``"Freq"`` or ``"Time"`` depending on the solution type.
             The default is ``None`` in which case the intrinsics value is automatically computed based on the setup.
         plot_name : str, optional
@@ -3437,11 +3436,10 @@ class PostProcessor(PostProcessorCommon, object):
             Intrinsic variables required to compute the field before the export.
             These are typically: frequency, time and phase.
             It can be provided either as a dictionary or as a string.
-                If it is a dictionary, keys depend on the solution type and can be expressed as:
-                    - ``"Freq"`` or ``"Frequency"``
-                    - ``"Time"``
-                    - ``"Phase"``
-                in lower or camel case.
+                If it is a dictionary, keys depend on the solution type and can be expressed in lower or camel case as:
+                    - ``"Freq"`` or ``"Frequency"``.
+                    - ``"Time"``.
+                    - ``"Phase"``.
             If it is a string, it can either be ``"Freq"`` or ``"Time"`` depending on the solution type.
             The default is ``None`` in which case the intrinsics value is automatically computed based on the setup.
         plot_name : str, optional
@@ -3619,11 +3617,10 @@ class PostProcessor(PostProcessorCommon, object):
             Intrinsic variables required to compute the field before the export.
             These are typically: frequency, time and phase.
             It can be provided either as a dictionary or as a string.
-                If it is a dictionary, keys depend on the solution type and can be expressed as:
-                    - ``"Freq"`` or ``"Frequency"``
-                    - ``"Time"``
-                    - ``"Phase"``
-                in lower or camel case.
+                If it is a dictionary, keys depend on the solution type and can be expressed in lower or camel case as:
+                    - ``"Freq"`` or ``"Frequency"``.
+                    - ``"Time"``.
+                    - ``"Phase"``.
             If it is a string, it can either be ``"Freq"`` or ``"Time"`` depending on the solution type.
             The default is ``None`` in which case the intrinsics value is automatically computed based on the setup.
         name : str, optional
@@ -3711,11 +3708,10 @@ class PostProcessor(PostProcessorCommon, object):
             Intrinsic variables required to compute the field before the export.
             These are typically: frequency, time and phase.
             It can be provided either as a dictionary or as a string.
-                If it is a dictionary, keys depend on the solution type and can be expressed as:
-                    - ``"Freq"`` or ``"Frequency"``
-                    - ``"Time"``
-                    - ``"Phase"``
-                in lower or camel case.
+                If it is a dictionary, keys depend on the solution type and can be expressed in lower or camel case as:
+                    - ``"Freq"`` or ``"Frequency"``.
+                    - ``"Time"``.
+                    - ``"Phase"``.
             If it is a string, it can either be ``"Freq"`` or ``"Time"`` depending on the solution type.
             The default is ``None`` in which case the intrinsics value is automatically computed based on the setup.
         plot_on_surface : bool, optional
@@ -3865,11 +3861,10 @@ class PostProcessor(PostProcessorCommon, object):
             Intrinsic variables required to compute the field before the export.
             These are typically: frequency, time and phase.
             It can be provided either as a dictionary or as a string.
-                If it is a dictionary, keys depend on the solution type and can be expressed as:
-                    - ``"Freq"`` or ``"Frequency"``
-                    - ``"Time"``
-                    - ``"Phase"``
-                in lower or camel case.
+                If it is a dictionary, keys depend on the solution type and can be expressed in lower or camel case as:
+                    - ``"Freq"`` or ``"Frequency"``.
+                    - ``"Time"``.
+                    - ``"Phase"``.
             If it is a string, it can either be ``"Freq"`` or ``"Time"`` depending on the solution type.
             The default is ``None`` in which case the intrinsics value is automatically computed based on the setup.
         plot_name : str, optional
@@ -3949,11 +3944,10 @@ class PostProcessor(PostProcessorCommon, object):
             Intrinsic variables required to compute the field before the export.
             These are typically: frequency, time and phase.
             It can be provided either as a dictionary or as a string.
-                If it is a dictionary, keys depend on the solution type and can be expressed as:
-                    - ``"Freq"`` or ``"Frequency"``
-                    - ``"Time"``
-                    - ``"Phase"``
-                in lower or camel case.
+                If it is a dictionary, keys depend on the solution type and can be expressed in lower or camel case as:
+                    - ``"Freq"`` or ``"Frequency"``.
+                    - ``"Time"``.
+                    - ``"Phase"``.
             If it is a string, it can either be ``"Freq"`` or ``"Time"`` depending on the solution type.
             The default is ``None`` in which case the intrinsics value is automatically computed based on the setup.
         plot_name : str, optional
@@ -4355,11 +4349,10 @@ class PostProcessor(PostProcessorCommon, object):
             Intrinsic variables required to compute the field before the export.
             These are typically: frequency, time and phase.
             It can be provided either as a dictionary or as a string.
-                If it is a dictionary, keys depend on the solution type and can be expressed as:
-                    - ``"Freq"`` or ``"Frequency"``
-                    - ``"Time"``
-                    - ``"Phase"``
-                in lower or camel case.
+                If it is a dictionary, keys depend on the solution type and can be expressed in lower or camel case as:
+                    - ``"Freq"`` or ``"Frequency"``.
+                    - ``"Time"``.
+                    - ``"Phase"``.
             If it is a string, it can either be ``"Freq"`` or ``"Time"`` depending on the solution type.
             The default is ``None`` in which case the intrinsics value is automatically computed based on the setup.
         export_air_objects : bool, optional

--- a/pyaedt/modules/report_templates.py
+++ b/pyaedt/modules/report_templates.py
@@ -2141,7 +2141,7 @@ class Standard(CommonReport):
     @property
     def time_windowing(self):
         """Returns the TDR time windowing. Options are:
-             * ``0`` : Rectangular
+            * ``0`` : Rectangular
             * ``1`` : Bartlett
             * ``2`` : Blackman
             * ``3`` : Hamming

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""This module contains these classes: ``Q2d``, ``Q3d``, and ``QExtractor`."""
+"""This module contains these classes: ``Q2d``, ``Q3d``, and ``QExtractor``."""
 
 from __future__ import absolute_import  # noreorder
 

--- a/pyaedt/sbrplus/hdm_parser.py
+++ b/pyaedt/sbrplus/hdm_parser.py
@@ -47,9 +47,6 @@ class Parser:
     Parser class that loads an HDM-format export file from HFSS SBR+, interprets
     its header and its binary content. Except for the header, the binary content is
     not parsed until an explicit call to parse_message.
-    Usage:
-    parser = Parser('filename')
-    bundle = parser.parse_message()
     """
 
     def __init__(self, filename):

--- a/pyaedt/sbrplus/plot.py
+++ b/pyaedt/sbrplus/plot.py
@@ -77,6 +77,7 @@ class HDMPlotter(CommonPlotter):
 
     @pyaedt_function_handler()
     def add_hdm_bundle_from_file(self, filename, units=None):
+        """Add hdm bundle from file."""
         from pyaedt.sbrplus.hdm_parser import Parser
 
         if os.path.exists(filename):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ doc-no-examples = [
     "sphinx_design>=0.4.0,<0.7",
     "matplotlib>=3.5.0,<3.10",
     "scikit-rf>=0.30.0,<1.2",
+    "pyvista[io]>=0.38.0,<0.45",
 ]
 all = [
     "matplotlib>=3.5.0,<3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ doc-no-examples = [
     "sphinx_design>=0.4.0,<0.7",
     "matplotlib>=3.5.0,<3.10",
     "scikit-rf>=0.30.0,<1.2",
-    "pyvista[io]>=0.38.0,<0.45",
 ]
 all = [
     "matplotlib>=3.5.0,<3.10",


### PR DESCRIPTION
When merging https://github.com/ansys/pyaedt/pull/4893 the step `doc-build` was not performed because it requires `doc-style` which couldn't run because too many changes were performed.

This led to a main branch with documentation extended and missing `pyista` dependency.