### PR TITLE
CHORE: Update pre-commit to v0.4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,6 +396,7 @@ model.index\+
 # local environment settings used by e.g. Visual Studio Code
 /.env
 /doc/source/local_config.json
+/.venv*
 
 # test coverage output
 /.cov/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
   -   id: check-pre-commit-ci-config
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.4.2
+  rev: v0.4.3
   hooks:
     - id: add-license-headers
       files: '(pyaedt|examples|_unittest|_unittest_ironpython|_unittest_solvers)/.*\.(py)'


### PR DESCRIPTION
The new pre-commit release has [improvement](https://github.com/ansys/pre-commit-hooks/pull/217) on the licenser-header hook which should GREATLY reduce the overhead associated to that hook when doing a commit.

@dcrawforAtAnsys This is not the enhancement I mentioned previously as we were waiting for https://github.com/fsfe/reuse-tool/pull/1055 to be merged. However, this is a complementary approach that will save us a lot of time !