### PR TITLE
FIX: Use active design even if more than one of that design_type exists

### DIFF
--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -1037,39 +1037,8 @@ class Design(AedtObjects):
         warning_msg = ""
         names = self.get_oo_name(self.oproject)
         if names:
-            valids = []
-            for name in names:
-                des = self.get_oo_object(self.oproject, name)
-                des_type = None
-                if hasattr(des, "GetDesignType"):
-                    des_type = des.GetDesignType()
-                if des_type == self.design_type or (
-                    des_type == "RMxprt"
-                    and self.design_type
-                    in [
-                        "RMxprtSolution",
-                        "ModelCreation",
-                    ]
-                ):
-                    if self.design_type in [
-                        "Circuit Design",
-                        "Twin Builder",
-                        "HFSS 3D Layout Design",
-                        "EMIT",
-                        "Q3D Extractor",
-                        "RMxprtSolution",
-                        "ModelCreation",
-                    ]:
-                        valids.append(name)
-                    elif not self._temp_solution_type:
-                        valids.append(name)
-                    elif self._temp_solution_type in des.GetSolutionType():
-                        valids.append(name)
-            if len(valids) != 1:
-                warning_msg = "No consistent unique design is present. Inserting a new design."
-            else:
-                activedes = valids[0]
-                warning_msg = "Active Design set to {}".format(valids[0])
+            activedes = self.desktop_class.active_design(self.oproject, None, self.design_type).GetName()
+            warning_msg = "Active Design set to {}".format(activedes)
         # legacy support for version < 2021.2
         elif self.design_list:  # pragma: no cover
             self._odesign = self._oproject.GetDesign(self.design_list[0])

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -1037,8 +1037,12 @@ class Design(AedtObjects):
         warning_msg = ""
         names = self.get_oo_name(self.oproject)
         if names:
-            activedes = self.desktop_class.active_design(self.oproject, None, self.design_type).GetName()
-            warning_msg = "Active Design set to {}".format(activedes)
+            odesign_active = self.desktop_class.active_design(self.oproject, None, self.design_type)
+            if odesign_active.GetDesignType() == self.design_type:
+                activedes = odesign_active.GetName()
+                warning_msg = "Active Design set to {}".format(activedes)
+            else:
+                warning_msg = "No consistent unique design is present. Inserting a new design."
         # legacy support for version < 2021.2
         elif self.design_list:  # pragma: no cover
             self._odesign = self._oproject.GetDesign(self.design_list[0])


### PR DESCRIPTION
When making a new class instance such as Hfss() or any other design_type, the intended behavior is to get the active design, but if more than one design_types exist, it would always error with "No consistent unique design is present. Inserting a new design."

```
design: str, optional
Name of the design to select. The default is None, in which case an attempt is made to get an active design. If no designs are present, an empty design is created.
```

This is because it is simply checking if only one instance of that design_type exists in the project rather than actually getting the current active design.