### PR TITLE
FIX: Changed the default global log filename to use a unique id

### DIFF
--- a/pyaedt/generic/settings.py
+++ b/pyaedt/generic/settings.py
@@ -29,7 +29,8 @@ import uuid
 is_linux = os.name == "posix"
 
 
-def default_log_filename():
+def generate_log_filename():
+    """Generate a log filename."""
     base = "pyaedt"
     username = os.path.split(os.path.expanduser("~"))[-1]
     unique_id = uuid.uuid4()

--- a/pyaedt/generic/settings.py
+++ b/pyaedt/generic/settings.py
@@ -33,7 +33,7 @@ def default_log_filename():
     base = "pyaedt"
     username = os.path.split(os.path.expanduser("~"))[-1]
     unique_id = uuid.uuid4()
-    return f"{base}_{username}_{unique_id}.log"
+    return "{}_{}_{}.log".format(base, username, unique_id)
 
 
 class Settings(object):  # pragma: no cover

--- a/pyaedt/generic/settings.py
+++ b/pyaedt/generic/settings.py
@@ -24,8 +24,16 @@
 
 import os
 import time
+import uuid
 
 is_linux = os.name == "posix"
+
+
+def default_log_filename():
+    base = "pyaedt"
+    username = os.path.split(os.path.expanduser("~"))[-1]
+    unique_id = uuid.uuid4()
+    return f"{base}_{username}_{unique_id}.log"
 
 
 class Settings(object):  # pragma: no cover
@@ -64,7 +72,7 @@ class Settings(object):  # pragma: no cover
         self._force_error_on_missing_project = False
         self._enable_pandas_output = False
         self.time_tick = time.time()
-        self._global_log_file_name = "pyaedt_{}.log".format(os.path.split(os.path.expanduser("~"))[-1])
+        self._global_log_file_name = default_log_filename()
         self._enable_global_log_file = True
         self._enable_local_log_file = False
         self._global_log_file_size = 10

--- a/pyaedt/generic/settings.py
+++ b/pyaedt/generic/settings.py
@@ -73,7 +73,7 @@ class Settings(object):  # pragma: no cover
         self._force_error_on_missing_project = False
         self._enable_pandas_output = False
         self.time_tick = time.time()
-        self._global_log_file_name = default_log_filename()
+        self._global_log_file_name = generate_log_filename()
         self._enable_global_log_file = True
         self._enable_local_log_file = False
         self._global_log_file_size = 10


### PR DESCRIPTION
Changed the default global log filename to use a unique id to avoid conflicts in concurrent sessions.