### PR TITLE
CHORE: Add warning on python version

### DIFF
--- a/_unittest/test_warnings.py
+++ b/_unittest/test_warnings.py
@@ -27,7 +27,8 @@ from unittest.mock import patch
 import warnings
 
 from ansys.aedt.core import LATEST_DEPRECATED_PYTHON_VERSION
-from ansys.aedt.core import deprecation_warning, WARNING_MESSAGE
+from ansys.aedt.core import WARNING_MESSAGE
+from ansys.aedt.core import deprecation_warning
 
 
 @patch.object(warnings, "warn")

--- a/_unittest/test_warnings.py
+++ b/_unittest/test_warnings.py
@@ -27,7 +27,7 @@ from unittest.mock import patch
 import warnings
 
 from ansys.aedt.core import LATEST_DEPRECATED_PYTHON_VERSION
-from ansys.aedt.core import deprecation_warning
+from ansys.aedt.core import deprecation_warning, WARNING_MESSAGE
 
 
 @patch.object(warnings, "warn")
@@ -36,13 +36,7 @@ def test_deprecation_warning(mock_warn):
 
     current_version = sys.version_info[:2]
     if current_version <= LATEST_DEPRECATED_PYTHON_VERSION:
-        str_current_version = "{}.{}".format(*sys.version_info[:2])
-        expected = (
-            "Current python version ({}) is deprecated in PyAEDT. We encourage you "
-            "to upgrade to the latest version to benefit from the latest features "
-            "and security updates.".format(str_current_version)
-        )
-        mock_warn.assert_called_once_with(expected, PendingDeprecationWarning)
+        mock_warn.assert_called_once_with(WARNING_MESSAGE, FutureWarning)
     else:
         mock_warn.assert_not_called()
 

--- a/_unittest/test_warnings.py
+++ b/_unittest/test_warnings.py
@@ -30,16 +30,25 @@ from ansys.aedt.core import LATEST_DEPRECATED_PYTHON_VERSION
 from ansys.aedt.core import WARNING_MESSAGE
 from ansys.aedt.core import deprecation_warning
 
+VALID_PYTHON_VERSION = (LATEST_DEPRECATED_PYTHON_VERSION[0], LATEST_DEPRECATED_PYTHON_VERSION[1] + 1)
+
 
 @patch.object(warnings, "warn")
-def test_deprecation_warning(mock_warn):
+def test_deprecation_warning_with_deprecated_python_version(mock_warn, monkeypatch):
+    monkeypatch.setattr(sys, "version_info", LATEST_DEPRECATED_PYTHON_VERSION)
+
     deprecation_warning()
 
-    current_version = sys.version_info[:2]
-    if current_version <= LATEST_DEPRECATED_PYTHON_VERSION:
-        mock_warn.assert_called_once_with(WARNING_MESSAGE, FutureWarning)
-    else:
-        mock_warn.assert_not_called()
+    mock_warn.assert_called_once_with(WARNING_MESSAGE, FutureWarning)
+
+
+@patch.object(warnings, "warn")
+def test_deprecation_warning_with_valid_python_version(mock_warn, monkeypatch):
+    monkeypatch.setattr(sys, "version_info", VALID_PYTHON_VERSION)
+
+    deprecation_warning()
+
+    mock_warn.assert_not_called()
 
 
 @patch.object(warnings, "warn")

--- a/src/ansys/aedt/core/__init__.py
+++ b/src/ansys/aedt/core/__init__.py
@@ -29,7 +29,12 @@ import warnings
 if os.name == "nt":
     os.environ["PYTHONMALLOC"] = "malloc"
 
-LATEST_DEPRECATED_PYTHON_VERSION = (3, 7)
+LATEST_DEPRECATED_PYTHON_VERSION = (3, 9)
+WARNING_MESSAGE = "As part of ou ongoing efforts to align with the Python Scientific Community's " \
+    "best practices, we are moving towards adopting SPEC 0000 " \
+    "(https://scientific-python.org/specs/spec-0000/). To ensure compatibility and " \
+    "take full advantage of the latest features and improvements, we strongly " \
+    "recommend updating the Python version being used."
 
 
 def deprecation_warning():
@@ -46,13 +51,7 @@ def deprecation_warning():
 
     current_version = sys.version_info[:2]
     if current_version <= LATEST_DEPRECATED_PYTHON_VERSION:
-        str_current_version = "{}.{}".format(*sys.version_info[:2])
-        warnings.warn(
-            "Current python version ({}) is deprecated in PyAEDT. We encourage you "
-            "to upgrade to the latest version to benefit from the latest features "
-            "and security updates.".format(str_current_version),
-            PendingDeprecationWarning,
-        )
+        warnings.warn(WARNING_MESSAGE, FutureWarning)
 
     # Restore warnings showwarning
     warnings.showwarning = existing_showwarning

--- a/src/ansys/aedt/core/__init__.py
+++ b/src/ansys/aedt/core/__init__.py
@@ -30,11 +30,13 @@ if os.name == "nt":
     os.environ["PYTHONMALLOC"] = "malloc"
 
 LATEST_DEPRECATED_PYTHON_VERSION = (3, 9)
-WARNING_MESSAGE = "As part of ou ongoing efforts to align with the Python Scientific Community's " \
-    "best practices, we are moving towards adopting SPEC 0000 " \
-    "(https://scientific-python.org/specs/spec-0000/). To ensure compatibility and " \
-    "take full advantage of the latest features and improvements, we strongly " \
+WARNING_MESSAGE = (
+    "As part of ou ongoing efforts to align with the Python Scientific Community's "
+    "best practices, we are moving towards adopting SPEC 0000 "
+    "(https://scientific-python.org/specs/spec-0000/). To ensure compatibility and "
+    "take full advantage of the latest features and improvements, we strongly "
     "recommend updating the Python version being used."
+)
 
 
 def deprecation_warning():

--- a/src/ansys/aedt/core/__init__.py
+++ b/src/ansys/aedt/core/__init__.py
@@ -31,7 +31,7 @@ if os.name == "nt":
 
 LATEST_DEPRECATED_PYTHON_VERSION = (3, 9)
 WARNING_MESSAGE = (
-    "As part of ou ongoing efforts to align with the Python Scientific Community's "
+    "As part of our ongoing efforts to align with the Python Scientific Community's "
     "best practices, we are moving towards adopting SPEC 0000 "
     "(https://scientific-python.org/specs/spec-0000/). To ensure compatibility and "
     "take full advantage of the latest features and improvements, we strongly "


### PR DESCRIPTION
Since we want to follow other scientific Python packages, see [SPEC-0000](https://scientific-python.org/specs/spec-0000/), this PR adds a warning depending on the Python version detected. Currently, if one has version <= 3.9 then a `FutureWarning` is triggered.