### PR TITLE
FIX: gracefully handle exited processes

### DIFF
--- a/src/ansys/aedt/core/generic/general_methods.py
+++ b/src/ansys/aedt/core/generic/general_methods.py
@@ -1592,9 +1592,10 @@ def active_sessions(version=None, student_version=False, non_graphical=False):
                                 if i.pid == p.pid and (i.laddr.port > 50050 and i.laddr.port < 50200):
                                     return_dict[p.pid] = i.laddr.port
                                     break
-        except psutil.NoSuchProcess:  # pragma: no cover
-            # the process exited so it cannot be an active session
-            pass
+        except psutil.NoSuchProcess as e:  # pragma: no cover
+            pyaedt_logger.debug(
+                f"The process exited and cannot be an active session: {e}"
+            )
         except Exception as e:  # pragma: no cover
             pyaedt_logger.error(
                 f"A(n) {type(e)} error occurred while retrieving information for the active AEDT sessions: {e}"

--- a/src/ansys/aedt/core/generic/general_methods.py
+++ b/src/ansys/aedt/core/generic/general_methods.py
@@ -1592,8 +1592,13 @@ def active_sessions(version=None, student_version=False, non_graphical=False):
                                 if i.pid == p.pid and (i.laddr.port > 50050 and i.laddr.port < 50200):
                                     return_dict[p.pid] = i.laddr.port
                                     break
-        except Exception:
-            pyaedt_logger.error("An error occurred while retrieving information for the active AEDT sessions")
+        except psutil.NoSuchProcess:
+            # the process exited so it cannot be an active session
+            pass  # pragma: no cover
+        except Exception as e:
+            pyaedt_logger.error(
+                f"A(n) {type(e)} error occurred while retrieving information for the active AEDT sessions: {e}"
+            )  # pragma: no cover
     return return_dict
 
 

--- a/src/ansys/aedt/core/generic/general_methods.py
+++ b/src/ansys/aedt/core/generic/general_methods.py
@@ -1592,13 +1592,13 @@ def active_sessions(version=None, student_version=False, non_graphical=False):
                                 if i.pid == p.pid and (i.laddr.port > 50050 and i.laddr.port < 50200):
                                     return_dict[p.pid] = i.laddr.port
                                     break
-        except psutil.NoSuchProcess:
+        except psutil.NoSuchProcess:  # pragma: no cover
             # the process exited so it cannot be an active session
-            pass  # pragma: no cover
-        except Exception as e:
+            pass
+        except Exception as e:  # pragma: no cover
             pyaedt_logger.error(
                 f"A(n) {type(e)} error occurred while retrieving information for the active AEDT sessions: {e}"
-            )  # pragma: no cover
+            )
     return return_dict
 
 

--- a/src/ansys/aedt/core/generic/general_methods.py
+++ b/src/ansys/aedt/core/generic/general_methods.py
@@ -1593,9 +1593,7 @@ def active_sessions(version=None, student_version=False, non_graphical=False):
                                     return_dict[p.pid] = i.laddr.port
                                     break
         except psutil.NoSuchProcess as e:  # pragma: no cover
-            pyaedt_logger.debug(
-                f"The process exited and cannot be an active session: {e}"
-            )
+            pyaedt_logger.debug(f"The process exited and cannot be an active session: {e}")
         except Exception as e:  # pragma: no cover
             pyaedt_logger.error(
                 f"A(n) {type(e)} error occurred while retrieving information for the active AEDT sessions: {e}"


### PR DESCRIPTION
Ignore psutil.NoSuchProcess exceptions in
`pyaedt.generic.general_methods.active_sessions` to avoid issuing a spurious error when a process exits during the loop body.  Also improve reporting when another type of exception does occur to allow for easier debugging.

Fixes #5055 