### PR TITLE
DOCS: Fix blocking doc-build warnings

### DIFF
--- a/doc/source/release_1_0.rst
+++ b/doc/source/release_1_0.rst
@@ -90,7 +90,7 @@ An example of migration is shown below:
 
     from ansys.aedt.core.application.analysis_3d_layout import FieldAnalysis3DLayout
 
-The following table list the name changes with the old and new pathes:
+The following table list the name changes with the old and new paths:
 
 +----------------------------------------------------------------+--------------------------------------------------------------------------+
 | Old path without file rename                                   | New path with renamed file                                               |

--- a/src/ansys/aedt/core/modeler/cad/primitives_2d.py
+++ b/src/ansys/aedt/core/modeler/cad/primitives_2d.py
@@ -161,7 +161,6 @@ class Primitives2D(GeometryModeler, object):
             Additional keyword arguments to pass to set properties when creating the primitive.
            For more information, see ``ansys.aedt.core.modeler.cad.object_3d.Object3d``.
 
-
         Returns
         -------
         ansys.aedt.core.modeler.cad.object_3d.Object3d

--- a/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
@@ -91,15 +91,14 @@ class CircuitComponents(object):
     def get_wire_by_name(self, name):
         """Wire class by name.
 
-                Parameters
-                ----------
-                name : str
-                    Wire name.
+        Parameters
+        ----------
+        name : str
+            Wire name.
 
-                Returns
-                -------
-                :class:`ansys.aedt.core.modeler.circuits.object_3d_circuit.Wire`
-        `
+        Returns
+        -------
+        :class:`ansys.aedt.core.modeler.circuits.object_3d_circuit.Wire`
         """
         for _, w in self.wires.items():
             if w.name == name:
@@ -113,6 +112,7 @@ class CircuitComponents(object):
         """All schematic wires in the design.
 
         Returns
+        -------
         dict
             Wires.
         """

--- a/src/ansys/aedt/core/modeler/circuits/primitives_nexxim.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_nexxim.py
@@ -1485,7 +1485,7 @@ class NexximComponents(CircuitComponents):
         Parameters
         ----------
         pyaedt_app : :class:`ansys.aedt.core.q3d.Q3d` or :class:`ansys.aedt.core.q3d.Q2d` or
-        :class:`ansys.aedt.core.q3d.Hfss`.
+            :class:`ansys.aedt.core.q3d.Hfss`.
             pyaedt application object to include. It could be an Hfss object, a Q3d object or a Q2d.
         solution_name : str, optional
             Name of the solution and sweep. The default is ``"Setup1 : Sweep"``.


### PR DESCRIPTION
As for the farfield refactoring, the CICD does not run the doc-build due to doc-style not being triggered.
While cleaning up some documentation paths, it seems that an error got discovered and is currently blocking our CICD.
This PR aims at partially removing the doc warnings to allow the doc-build to pass the CICD.