### PR TITLE
TEST: Fix alias deprecation warning

### DIFF
--- a/src/ansys/aedt/core/__init__.py
+++ b/src/ansys/aedt/core/__init__.py
@@ -30,7 +30,7 @@ if os.name == "nt":
     os.environ["PYTHONMALLOC"] = "malloc"
 
 LATEST_DEPRECATED_PYTHON_VERSION = (3, 9)
-WARNING_MESSAGE = (
+PYTHON_VERSION_WARNING = (
     "As part of our ongoing efforts to align with the Python Scientific Community's "
     "best practices, we are moving towards adopting SPEC 0000 "
     "(https://scientific-python.org/specs/spec-0000/). To ensure compatibility and "
@@ -53,7 +53,7 @@ def deprecation_warning():
 
     current_version = sys.version_info[:2]
     if current_version <= LATEST_DEPRECATED_PYTHON_VERSION:
-        warnings.warn(WARNING_MESSAGE, FutureWarning)
+        warnings.warn(PYTHON_VERSION_WARNING, FutureWarning)
 
     # Restore warnings showwarning
     warnings.showwarning = existing_showwarning

--- a/src/pyaedt/__init__.py
+++ b/src/pyaedt/__init__.py
@@ -5,7 +5,7 @@ __version__ = __version__
 
 import warnings
 
-WARNING_MESSAGE = (
+ALIAS_WARNING = (
     "Module 'pyaedt' has become an alias to the new package structure. " \
     "Please update you imports to use the new architecture based on 'ansys.aedt.core'. " \
     "In addition, some files have been renamed to follow the PEP 8 naming convention. "
@@ -25,7 +25,7 @@ def alias_deprecation_warning():  # pragma: no cover
 
     warnings.showwarning = custom_show_warning
 
-    warnings.warn(WARNING_MESSAGE, FutureWarning)
+    warnings.warn(ALIAS_WARNING, FutureWarning)
 
     # Restore warnings showwarning
     warnings.showwarning = existing_showwarning


### PR DESCRIPTION
Previously the test on `pyaedt` alias deprecation warning was randomly failing. I have a guess that it is related to the fact that, some times, the process dealing with `test_alias_deprecation_warning` has already imported `pyaedt` previously, leading to a warning not being raised since the module was already loaded and the warning was recorded.

This PR propose a hardcoded test that will cleanup the warning registry and force the load of pyaedt. This way, we are sure that the warning is triggered. However, the check requires to use the line associated to calling the warning in `pyaedt.__init__.py`...
Unfortunately I wasn't able to obtain a better result with mocking OR with `pytest.warns`. I'll open an issue about this.
