### PR TITLE
CHORE: Update pyedb dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "jsonschema",
     "psutil",
     "pyedb>=0.4.0; python_version == '3.7'",
-    "pyedb>=0.20.0; python_version > '3.7'",
+    "pyedb>=0.24.0; python_version > '3.7'",
     "pytomlpp",
     "rpyc>=6.0.0,<6.1",
 ]


### PR DESCRIPTION
Recent development in pyedb made it difficult to work with recent version of pyedb and older one.
This should ensure that no one gets strange error due to the use of an old version of pyedb.