### PR TITLE
TEST: Improve test delegation warning

### DIFF
--- a/_unittest/test_warnings.py
+++ b/_unittest/test_warnings.py
@@ -30,6 +30,7 @@ from ansys.aedt.core import LATEST_DEPRECATED_PYTHON_VERSION
 from ansys.aedt.core import PYTHON_VERSION_WARNING
 from ansys.aedt.core import deprecation_warning
 from pyaedt import ALIAS_WARNING
+import pytest
 
 VALID_PYTHON_VERSION = (LATEST_DEPRECATED_PYTHON_VERSION[0], LATEST_DEPRECATED_PYTHON_VERSION[1] + 1)
 
@@ -60,11 +61,5 @@ def test_alias_deprecation_warning():
 
     import pyaedt
 
-    # Ensure that the warning will be triggered again
-    del pyaedt.__warningregistry__
-
-    importlib.reload(pyaedt)
-
-    # Hardcoded test where 28 is the line number associated to the warning call
-    # TODO: See if pytest.warns can be 'fixed' to work with module reload
-    assert (ALIAS_WARNING, FutureWarning, 28) in pyaedt.__warningregistry__
+    with pytest.warns(FutureWarning, match=ALIAS_WARNING):
+        importlib.reload(pyaedt)

--- a/src/pyaedt/__init__.py
+++ b/src/pyaedt/__init__.py
@@ -4,6 +4,7 @@ from ansys.aedt.core import *
 __version__ = __version__
 
 import warnings
+import os
 
 ALIAS_WARNING = (
     "Module 'pyaedt' has become an alias to the new package structure. " \
@@ -22,6 +23,9 @@ def alias_deprecation_warning():  # pragma: no cover
     def custom_show_warning(message, category, filename, lineno, file=None, line=None):
         """Custom warning used to remove <stdin>:loc: pattern."""
         print("{}: {}".format(category.__name__, message))
+        # NOTE: This line is added to ensure that pytest handle the warning correctly.
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            existing_showwarning(message, category, filename, lineno, file=file, line=line)
 
     warnings.showwarning = custom_show_warning
 


### PR DESCRIPTION
Follow up of #5073 which used an hardcoded test. This changes ensure that `pytest` handles correctly the warning which was not caught previsouly due to the modification to `warnings.showwarning`.