### PR TITLE
CI: Fix deploy stable docs index

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -523,7 +523,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install the package requirements
-        run: pip install -e .
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
 
       - name: Get the version to PyMeilisearch
         run: |


### PR DESCRIPTION
Last release had the deploy stable docs index job failing due to the changes in build backend (temporary `setuptools`).

See https://github.com/ansys/pyaedt/actions/runs/10474990009/job/29041977423

This PR aims at fixing that job.

