### PR TITLE
CHORE: Add git blame ignore revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,36 @@
+# One commit hash per line, and all commits in the file will be ignored by git blame.
+
+# Apply flake8 policy for unused imports (#449)
+f2ebb7a80978e1ea82328e9b6afd3f9484362552
+# Organize module imports (#448)
+98bb0a1bfd27f8174ef86a131b3f6eed09f562ad
+# Format line length (#445)
+b82041bb75d71b8e11b54f9dcfdfc696a1bcf68c
+# Format modeler files (#441)
+0174ae92359f49fb8215f16d715f3afe8598745f
+# Format example files (#444)
+41eb277bc05b6736c674af33d5b601c3bc9a33d3
+# Format ipy unittests (#443)
+522b13c6ed123be60eb6220bfe6fed35ba059ab8
+# Format unittests (#442)
+11d60aa7e31f3494d8a73c0223c924ff17eec985
+# Format modules files (#436)
+0798f3f4c2252c1c3c486b8400540939c5b42dc6
+# Format application files (#434)
+19b758272a6d9551a8837b5f2d3a6283974d3367
+# Format pyaedt files with black (#433)
+3c3f0c6e01336eae66199bb9e461319d18a435d7
+# Formatting - fix line length part 2 (#415)
+58bbdc280545f7345b7999db0f17c3ff666e0be2
+# Formatting - fix line length part 1 (#414)
+af6af2e6b5db5e1485bfddd2b9d0e363614ecfce
+# Formatting - blank lines (#412)
+babf97db629f2901f40ae080ac3a7e24084a1e87
+#  Formatting - whitespace on blank lines (#409)
+08e4ae515f7d5fd4a37e7baab7b321c907e66324
+# Formatting - indentations (#407)
+9ddfe050d95feaa022cc30cc64acabee16029c07
+# Remove trailing whitespace (#404)
+a4b5fe60c7d0a7db624d7ab160a0ce5e1f378759
+# Run autopep8 W291, remove trailing whitespace (#401)
+159bb43d42ad502c2440531d71cf7df6c780a8c9


### PR DESCRIPTION
This PR consist in adding a `.git-blame-ignore-revs` file. The interest of this file is that it allows to ignore specific revisions. For example, I'm discarding a few old commits that were mainly focused on formatting such that when you try to see what was the last change on a line of code, you have more chance to retrieve data associated to the commit which added the line of code (or modified the logic in it) and not the last format commit which updated the line.

The file name is important as it is the standard one and it can be leveraged by your IDE and Github. For example, with Visual Studio Code, I didn't have to do any configuration to make that work correctly (you just need to restart you IDE though).
Also it can be leveraged through Github in a Web browser ! See [Viewing a file - Github docs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)