### PR TITLE
DOCS: Add aedt log file in settings

### DIFF
--- a/doc/source/User_guide/settings.rst
+++ b/doc/source/User_guide/settings.rst
@@ -62,6 +62,8 @@ Below  is the content that can be updated through the YAML file.
         logger_file_path: null
         # Message format of the log entries
         logger_formatter: '%(asctime)s:%(destination)s:%(extra)s%(levelname)-8s:%(message)s'
+        # Path to the AEDT log file
+        aedt_log_file: null
 
     # Settings related to Linux systems running LSF scheduler
     lsf:


### PR DESCRIPTION
As title says. The latest added setting was missing from the user guide documentation.