### PR TITLE
DOCS: Fix pypi landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 *** PyAEDT README
 -->
 
-[![PyAEDT logo](https://github.com/ansys/pyaedt/blob/main/doc/source/_static/logo.png)](https://aedt.docs.pyansys.com)
+[![PyAEDT logo](https://raw.githubusercontent.com/ansys/pyaedt/blob/main/doc/source/_static/logo.png)](https://aedt.docs.pyansys.com)
 
 <p style="text-align: center;">
     <br> English | <a href="README_CN.md">中文</a>


### PR DESCRIPTION
Following [Roberto](https://github.com/ansys/pyansys-geometry/pull/1420) comment on `pyansys-geometry`'s pypi landing page, here is a fix for our own.

Below is the current page rendering:
![image](https://github.com/user-attachments/assets/a096bfb7-9393-4257-bbae-acb598d8c0d4)
