### PR TITLE
FEAT: Force an EMIT save after analysis

### DIFF
--- a/src/ansys/aedt/core/emit.py
+++ b/src/ansys/aedt/core/emit.py
@@ -330,3 +330,32 @@ class Emit(Design, object):
             )
             return None
         return self._units[unit_type]
+
+    @pyaedt_function_handler()
+    def save_project(self, file_name=None, overwrite=True, refresh_ids=False):
+        """Save the AEDT project and the current EMIT revision.
+
+        Parameters
+        ----------
+        file_name : str, optional
+            Full path and project name. The default is ````None``.
+        overwrite : bool, optional
+            Whether to overwrite the existing project. The default is ``True``.
+        refresh_ids : bool, optional
+            Whether to refresh object IDs after saving the project.
+            The default is ``False``.
+
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+
+        References
+        ----------
+        """
+        if self.__emit_api_enabled:
+            self._emit_api.save_project()
+
+        result = Design.save_project(file_name, overwrite, refresh_ids)
+
+        return result

--- a/src/ansys/aedt/core/emit.py
+++ b/src/ansys/aedt/core/emit.py
@@ -356,6 +356,6 @@ class Emit(Design, object):
         if self.__emit_api_enabled:
             self._emit_api.save_project()
 
-        result = Design.save_project(file_name, overwrite, refresh_ids)
+        result = Design.save_project(self, file_name, overwrite, refresh_ids)
 
         return result

--- a/src/ansys/aedt/core/emit_core/results/revision.py
+++ b/src/ansys/aedt/core/emit_core/results/revision.py
@@ -189,8 +189,8 @@ class Revision:
             if len(domain.interferer_names) > 1:
                 raise ValueError("Multiple interferers cannot be specified prior to AEDT version 2024 R1.")
         interaction = engine.run(domain)
-        # save the revision
-        self.emit_project._emit_api.save_project()
+        # save the project and revision
+        self.emit_project.save_project()
         return interaction
 
     @pyaedt_function_handler()
@@ -396,7 +396,7 @@ class Revision:
     @notes.setter
     def notes(self, notes):
         self.emit_project.odesign.SetResultNotes(self.name, notes)
-        self.emit_project._emit_api.save_project()
+        self.emit_project.save_project()
 
     @property
     def n_to_1_limit(self):


### PR DESCRIPTION
Instead of only forcing an EMIT API-level save on run, create an EMIT design-level save that saves both the AEDT project and the EMIT API-level save, and force both on run.