### PR TITLE
CI: Schedule dependabot on saturday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Europe/Paris"
     reviewers: 
       - "MaxJPRey"
       - "SMoraisAnsys"
@@ -18,7 +21,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Europe/Paris"
     reviewers: 
       - "MaxJPRey"
       - "SMoraisAnsys"


### PR DESCRIPTION
I'm glad that dependabot opens PR to ease how we upgrade our dependencies to new versions.
However, when this happens during the week, it consumes our VM while we might required them.
One option would be to schedule them early in the morning but that would just move the problem to people trying to contribute from USA / APAC.
This PR proposes to move those updates to saturday so that the impact on development is lowered. Ofc, this could be updated later on when we'll have access to containers !