### PR TITLE
CI: Avoid using self-hosted runners in drafts

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -24,36 +24,6 @@ concurrency:
 
 jobs:
 
-  test-job-0:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Tests step
-        run: |
-          echo "This job runs!"
-          echo "github.event_name: ${{ github.event_name}}"
-          echo "${{ toJson(github.event) }}"
-
-  test-job-1:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Tests step
-        run: |
-          echo "This job runs!"
-          echo "github.event_name: ${{ github.event_name}}"
-          echo "${{ toJson(github.event) }}"
-
-  test-job-2:
-    if: github.event_name != 'workflow_dispatch' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Tests step
-        run: |
-          echo "This job runs!"
-          echo "github.event_name: ${{ github.event_name}}"
-          echo "${{ toJson(github.event) }}"
-
   pr-title:
     if: github.event_name == 'pull_request'
     name: Check the title of the pull request
@@ -257,7 +227,7 @@ jobs:
 
   test-solvers-windows:
     name: Testing solvers and coverage (Windows)
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    if: github.event.pull_request.draft == false
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
@@ -318,7 +288,7 @@ jobs:
   # TODO: Si if we can use ansys/actions
   test-solvers-linux:
     name: Testing solvers and coverage (Linux)
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    if: github.event.pull_request.draft == false
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:
@@ -375,7 +345,7 @@ jobs:
 
   test-windows:
     name: Testing and coverage (Windows)
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    if: github.event.pull_request.draft == false
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
@@ -441,7 +411,7 @@ jobs:
   # TODO: Si if we can use ansys/actions
   test-linux:
     name: Testing and coverage (Linux)
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    if: github.event.pull_request.draft == false
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -24,6 +24,36 @@ concurrency:
 
 jobs:
 
+  test-job-0:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tests step
+        run: |
+          echo "This job runs!"
+          echo "github.event_name: ${{ github.event_name}}"
+          echo "${{ toJson(github.event) }}"
+
+  test-job-1:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tests step
+        run: |
+          echo "This job runs!"
+          echo "github.event_name: ${{ github.event_name}}"
+          echo "${{ toJson(github.event) }}"
+
+  test-job-2:
+    if: github.event_name != 'workflow_dispatch' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tests step
+        run: |
+          echo "This job runs!"
+          echo "github.event_name: ${{ github.event_name}}"
+          echo "${{ toJson(github.event) }}"
+
   pr-title:
     if: github.event_name == 'pull_request'
     name: Check the title of the pull request

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -227,6 +227,7 @@ jobs:
 
   test-solvers-windows:
     name: Testing solvers and coverage (Windows)
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
@@ -287,6 +288,7 @@ jobs:
   # TODO: Si if we can use ansys/actions
   test-solvers-linux:
     name: Testing solvers and coverage (Linux)
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:
@@ -343,6 +345,7 @@ jobs:
 
   test-windows:
     name: Testing and coverage (Windows)
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
@@ -408,6 +411,7 @@ jobs:
   # TODO: Si if we can use ansys/actions
   test-linux:
     name: Testing and coverage (Linux)
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -227,7 +227,7 @@ jobs:
 
   test-solvers-windows:
     name: Testing solvers and coverage (Windows)
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
@@ -288,7 +288,7 @@ jobs:
   # TODO: Si if we can use ansys/actions
   test-solvers-linux:
     name: Testing solvers and coverage (Linux)
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:
@@ -345,7 +345,7 @@ jobs:
 
   test-windows:
     name: Testing and coverage (Windows)
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
@@ -411,7 +411,7 @@ jobs:
   # TODO: Si if we can use ansys/actions
   test-linux:
     name: Testing and coverage (Linux)
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:

--- a/.github/workflows/manual_draft.yml
+++ b/.github/workflows/manual_draft.yml
@@ -1,0 +1,16 @@
+name: Manual draft workflow
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  test-job-0:
+    if: github.event.pull_request.draft == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tests step
+        run: |
+          echo "This job runs!"
+          echo "github.event_name: ${{ github.event_name}}"
+          echo "${{ toJson(github.event) }}"

--- a/.github/workflows/manual_draft.yml
+++ b/.github/workflows/manual_draft.yml
@@ -42,7 +42,7 @@ jobs:
 
   test-solvers-windows:
     name: Testing solvers and coverage (Windows)
-    if: github.event.pull_request.draft == true && github.event.inputs.test-solvers-windows == 'yes'
+    if: github.event.inputs.test-solvers-windows == 'yes'
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
@@ -103,7 +103,7 @@ jobs:
   # TODO: Si if we can use ansys/actions
   test-solvers-linux:
     name: Testing solvers and coverage (Linux)
-    if: github.event.pull_request.draft == true && github.event.inputs.test-solvers-linux == 'yes'
+    if: github.event.inputs.test-solvers-linux == 'yes'
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:
@@ -160,7 +160,7 @@ jobs:
 
   test-windows:
     name: Testing and coverage (Windows)
-    if: github.event.pull_request.draft == true && github.event.inputs.test-windows == 'yes'
+    if: github.event.inputs.test-windows == 'yes'
     needs: [smoke-tests]
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
@@ -226,7 +226,7 @@ jobs:
   # TODO: Si if we can use ansys/actions
   test-linux:
     name: Testing and coverage (Linux)
-    if: github.event.pull_request.draft == true && github.event.inputs.test-linux == 'yes'
+    if: github.event.inputs.test-linux == 'yes'
     needs: [smoke-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
     env:

--- a/.github/workflows/manual_draft.yml
+++ b/.github/workflows/manual_draft.yml
@@ -1,35 +1,33 @@
 name: Draft workflow
 
-# WARNING: Jobs are skipped when run in non draft PR to avoid using self-hosted runners
-
 on:
   workflow_dispatch:
     inputs:
       test-solvers-windows:
         description: "Testing solvers and coverage (Windows)"
-        required: true
-        defaut: 'no'
+        default: 'no'
+        type: choice
         options:
           - 'yes'
           - 'no'
       test-solvers-linux:
         description: "Testing solvers and coverage (Linux)"
-        required: true
-        defaut: 'no'
+        default: 'no'
+        type: choice
         options:
           - 'yes'
           - 'no'
       test-windows:
         description: "Testing solvers and coverage (Windows)"
-        required: true
-        defaut: 'no'
+        default: 'no'
+        type: choice
         options:
           - 'yes'
           - 'no'
       test-linux:
         description: "Testing solvers and coverage (Linux)"
-        required: true
-        defaut: 'no'
+        type: choice
+        default: 'no'
         options:
           - 'yes'
           - 'no'

--- a/.github/workflows/manual_draft.yml
+++ b/.github/workflows/manual_draft.yml
@@ -1,16 +1,290 @@
-name: Manual draft workflow
+name: Draft workflow
+
+# WARNING: Jobs are skipped when run in non draft PR to avoid using self-hosted runners
 
 on:
   workflow_dispatch:
+    inputs:
+      test-solvers-windows:
+        description: "Testing solvers and coverage (Windows)"
+        required: true
+        defaut: 'no'
+        options:
+          - 'yes'
+          - 'no'
+      test-solvers-linux:
+        description: "Testing solvers and coverage (Linux)"
+        required: true
+        defaut: 'no'
+        options:
+          - 'yes'
+          - 'no'
+      test-windows:
+        description: "Testing solvers and coverage (Windows)"
+        required: true
+        defaut: 'no'
+        options:
+          - 'yes'
+          - 'no'
+      test-linux:
+        description: "Testing solvers and coverage (Linux)"
+        required: true
+        defaut: 'no'
+        options:
+          - 'yes'
+          - 'no'
 
 jobs:
 
-  test-job-0:
-    if: github.event.pull_request.draft == true
-    runs-on: ubuntu-latest
+# # =================================================================================================
+# # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+# # =================================================================================================
+
+  test-solvers-windows:
+    name: Testing solvers and coverage (Windows)
+    if: github.event.pull_request.draft == true && github.event.inputs.test-solvers-windows == 'yes'
+    needs: [smoke-tests]
+    runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
-      - name: Tests step
+      - name: Install Git and checkout project
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: Create virtual environment
         run: |
-          echo "This job runs!"
-          echo "github.event_name: ${{ github.event_name}}"
-          echo "${{ toJson(github.event) }}"
+          python -m venv .venv
+          .venv\Scripts\Activate.ps1
+          python -m pip install pip -U
+          python -m pip install wheel setuptools -U
+          python -c "import sys; print(sys.executable)"
+
+      - name: Install pyaedt and tests dependencies
+        run: |
+          .venv\Scripts\Activate.ps1
+          pip install .[tests]
+          pip install pytest-azurepipelines
+
+      - name: Install CI dependencies (e.g. vtk-osmesa)
+        run: |
+          .venv\Scripts\Activate.ps1
+          # Uninstall conflicting dependencies
+          pip uninstall --yes vtk
+          pip install --extra-index-url https://wheels.vtk.org vtk-osmesa
+
+      - name: Run tests on _unittest_solvers
+        env:
+          PYTHONMALLOC: malloc
+        run: |
+          .venv\Scripts\Activate.ps1
+          pytest --durations=50 -v --cov=ansys.aedt.core --cov-report=xml --cov-report=html --junitxml=junit/test-results.xml _unittest_solvers
+
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov-system-solver-tests
+          file: ./coverage.xml
+          flags: system,solver
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-solver-results
+          path: junit/test-results.xml
+        if: ${{ always() }}
+
+# # =================================================================================================
+# # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+# # =================================================================================================
+
+  # TODO: Si if we can use ansys/actions
+  test-solvers-linux:
+    name: Testing solvers and coverage (Linux)
+    if: github.event.pull_request.draft == true && github.event.inputs.test-solvers-linux == 'yes'
+    needs: [smoke-tests]
+    runs-on: [ self-hosted, Linux, pyaedt ]
+    env:
+      ANSYSEM_ROOT242: '/opt/AnsysEM/v242/Linux64'
+      ANS_NODEPCHECK: '1'
+    steps:
+      - name: Install Git and checkout project
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: Create virtual environment
+        run: |
+          export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT242 }}/common/mono/Linux64/lib64:${{ env.ANSYSEM_ROOT242 }}/Delcross:$LD_LIBRARY_PATH
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org pip -U
+          python -m pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org wheel setuptools -U
+          python -c "import sys; print(sys.executable)"
+
+      - name: Install pyaedt and tests dependencies
+        run: |
+          export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT242 }}/common/mono/Linux64/lib64:${{ env.ANSYSEM_ROOT242 }}/Delcross:$LD_LIBRARY_PATH
+          source .venv/bin/activate
+          pip install .[tests]
+          pip install pytest-azurepipelines
+
+      - name: Run tests on _unittest_solvers
+        run: |
+          export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT242 }}/common/mono/Linux64/lib64:${{ env.ANSYSEM_ROOT242 }}/Delcross:$LD_LIBRARY_PATH
+          source .venv/bin/activate
+          pytest --durations=50 -v --cov=ansys.aedt.core --cov-report=xml --cov-report=html --junitxml=junit/test-results.xml _unittest_solvers
+
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov-system-solver-tests
+          file: ./coverage.xml
+          flags: system,solver
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-solver-results
+          path: junit/test-results.xml
+        if: ${{ always() }}
+
+# # =================================================================================================
+# # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+# # =================================================================================================
+
+  test-windows:
+    name: Testing and coverage (Windows)
+    if: github.event.pull_request.draft == true && github.event.inputs.test-windows == 'yes'
+    needs: [smoke-tests]
+    runs-on: [ self-hosted, Windows, pyaedt ]
+    steps:
+      - name: Install Git and checkout project
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: Create virtual environment
+        run: |
+          python -m venv .venv
+          .venv\Scripts\Activate.ps1
+          python -m pip install pip -U
+          python -m pip install wheel setuptools -U
+          python -c "import sys; print(sys.executable)"
+
+      - name: Install pyaedt and tests dependencies
+        run: |
+          .venv\Scripts\Activate.ps1
+          pip install .[tests]
+          pip install pytest-azurepipelines
+
+      - name: Install CI dependencies (e.g. vtk-osmesa)
+        run: |
+          .venv\Scripts\Activate.ps1
+          # Uninstall conflicting dependencies
+          pip uninstall --yes vtk
+          pip install --extra-index-url https://wheels.vtk.org vtk-osmesa
+
+      - name: Run tests on _unittest
+        uses: nick-fields/retry@v3
+        env:
+          PYTHONMALLOC: malloc
+        with:
+          max_attempts: 2
+          retry_on: error
+          timeout_minutes: 50
+          command: |
+            .venv\Scripts\Activate.ps1
+            pytest -n 4 --dist loadfile --durations=50 -v --cov=ansys.aedt.core --cov-report=xml --cov-report=html --junitxml=junit/test-results.xml _unittest
+
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov-system-tests
+          file: ./coverage.xml
+          flags: system
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-results
+          path: junit/test-results.xml
+        if: ${{ always() }}
+
+# # =================================================================================================
+# # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+# # =================================================================================================
+
+  # TODO: Si if we can use ansys/actions
+  test-linux:
+    name: Testing and coverage (Linux)
+    if: github.event.pull_request.draft == true && github.event.inputs.test-linux == 'yes'
+    needs: [smoke-tests]
+    runs-on: [ self-hosted, Linux, pyaedt ]
+    env:
+      ANSYSEM_ROOT242: '/opt/AnsysEM/v242/Linux64'
+      ANS_NODEPCHECK: '1'
+    steps:
+      - name: Install Git and checkout project
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: Create virtual environment
+        run: |
+          export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT242 }}/common/mono/Linux64/lib64:${{ env.ANSYSEM_ROOT242 }}/Delcross:$LD_LIBRARY_PATH
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org pip -U
+          python -m pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org wheel setuptools -U
+          python -c "import sys; print(sys.executable)"
+
+      - name: Install pyaedt and tests dependencies
+        run: |
+          export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT242 }}/common/mono/Linux64/lib64:${{ env.ANSYSEM_ROOT242 }}/Delcross:$LD_LIBRARY_PATH
+          source .venv/bin/activate
+          pip install .[tests]
+          pip install pytest-azurepipelines
+
+      - name: Install CI dependencies (e.g. vtk-osmesa)
+        run: |
+          source .venv/bin/activate
+          # Uninstall conflicting dependencies
+          pip uninstall --yes vtk
+          pip install --extra-index-url https://wheels.vtk.org vtk-osmesa
+
+      - name: Run tests on _unittest
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 2
+          retry_on: error
+          timeout_minutes: 50
+          command: |
+            export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT242 }}/common/mono/Linux64/lib64:${{ env.ANSYSEM_ROOT242 }}/Delcross:$LD_LIBRARY_PATH
+            source .venv/bin/activate
+            pytest -n 2 --dist loadfile --durations=50 -v --cov=ansys.aedt.core --cov-report=xml --cov-report=html --junitxml=junit/test-results.xml _unittest
+
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov-system-solver-tests
+          file: ./coverage.xml
+          flags: system,solver
+
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-solver-results
+          path: junit/test-results.xml
+        if: ${{ always() }}

--- a/.github/workflows/manual_draft.yml
+++ b/.github/workflows/manual_draft.yml
@@ -98,7 +98,6 @@ jobs:
 # # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 # # =================================================================================================
 
-  # TODO: Si if we can use ansys/actions
   test-solvers-linux:
     name: Testing solvers and coverage (Linux)
     if: github.event.inputs.test-solvers-linux == 'yes'
@@ -221,7 +220,6 @@ jobs:
 # # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 # # =================================================================================================
 
-  # TODO: Si if we can use ansys/actions
   test-linux:
     name: Testing and coverage (Linux)
     if: github.event.inputs.test-linux == 'yes'


### PR DESCRIPTION
Following a discussion with @Alberto-DM, this PR aims at reducing the use of our self hosted runners.

AFAIK, the best we can do with the current capabilities of Github is to avoid using our self hosted runners when one is working on a draft. This will allow other PRs, marked as ready to review, to use the self hosted runners instead of waiting for a draft PR finishing "wasting" resources. Since one could still want to trigger the jobs using our self hosted runners none the less, we should also allow people to run them by manually clicking on the run button.