### PR TITLE
FIX: Wrong call to logging atexit

### DIFF
--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -1685,7 +1685,7 @@ class Desktop(object):
 
         """
         if self.__closed is True:  # pragma: no cover
-            self.log.debug("Connection is already closed. Ignoring request.")
+            self.logger.debug("Connection is already closed. Ignoring request.")
             return
 
         return self.release_desktop(close_projects=True, close_on_exit=True)

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -1685,7 +1685,6 @@ class Desktop(object):
 
         """
         if self.__closed is True:  # pragma: no cover
-            self.logger.debug("Connection is already closed. Ignoring request.")
             return
 
         return self.release_desktop(close_projects=True, close_on_exit=True)


### PR DESCRIPTION
Removing the call to the debug log because it always end up failing if the desktop is already closed. Indeed, by triggering that log call at exit, we end up trying to write something but the log handler is closed/deleted.