### PR TITLE
FEAT: Prepare for EMIT Python 3.12 support.

### DIFF
--- a/_unittest_solvers/test_26_emit.py
+++ b/_unittest_solvers/test_26_emit.py
@@ -8,7 +8,10 @@ import pytest
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.generic import constants as consts
 
-if (3, 7) < sys.version_info < (3, 12) or ( (3,9) < sys.version_info < (3,13) and config["desktopVersion"] > "2024.2" ):
+# Prior to 2025R1, the Emit API supported Python 3.8,3.9,3.10,3.11
+# Starting with 2025R1, the Emit API supports Python 3.10,3.11,3.12
+if ( ( (3, 8) <= sys.version_info[0:2] <= (3, 11) and config["desktopVersion"] < "2025.1" ) or 
+    ( (3,10) <= sys.version_info[0:2] <= (3,12) and config["desktopVersion"] > "2024.2" ) ):
     from ansys.aedt.core import Emit
     from ansys.aedt.core import generate_unique_project_name
     from ansys.aedt.core.emit_core.emit_constants import EmiCategoryFilter
@@ -29,9 +32,9 @@ def aedtapp(add_app):
     return app
 
 
-@pytest.mark.skipif(is_linux, reason="Emit API fails on linux.")
-@pytest.mark.skipif(sys.version_info < (3,10), reason="Emit API is only available for Python 3.10+.")
-@pytest.mark.skipif(sys.version_info > (3,11) and config["desktopVersion"] < "2025.1", reason="Emit API is only available for Python 3.12 in AEDT version 2025.1 and later.")
+@pytest.mark.skipif(is_linux, reason="Emit API is not supported on linux.")
+@pytest.mark.skipif((sys.version_info < (3,8) or sys.version_info > (3,11)) and config["desktopVersion"] < "2025.1", reason="Emit API is only available for Python 3.8-3.11 in AEDT versions 2024.2 and prior.")
+@pytest.mark.skipif((sys.version_info < (3,10) or sys.version_info > (3,12)) and config["desktopVersion"] > "2024.2", reason="Emit API is only available for Python 3.10-3.12 in AEDT versions 2025.1 and later.")
 class TestClass:
 
     @pytest.fixture(autouse=True)
@@ -682,9 +685,7 @@ class TestClass:
     )
     def test_13_static_type_generation(self):
         domain = self.aedtapp.results.interaction_domain()
-        py_version = "EmitApiPython"
-        if sys.version_info > (3, 9):
-            py_version = f"EmitApiPython{sys.version_info[0]}{sys.version_info[1]}"
+        py_version = f"EmitApiPython{sys.version_info[0]}{sys.version_info[1]}"
         assert str(type(domain)) == "<class '{}.InteractionDomain'>".format(py_version)
 
         # assert str(type(TxRxMode)) == "<class '{}.tx_rx_mode'>".format(py_version)

--- a/_unittest_solvers/test_26_emit.py
+++ b/_unittest_solvers/test_26_emit.py
@@ -31,7 +31,7 @@ def aedtapp(add_app):
 
 @pytest.mark.skipif(is_linux, reason="Emit API fails on linux.")
 @pytest.mark.skipif(sys.version_info < (3,10), reason="Emit API is only available for Python 3.10+.")
-@pytest.mark.skipif(sys.version_info > (3,12) and config["desktopVersion"] < "2025.1", reason="Emit API is only available for Python 3.12 in AEDT version 2025.1 and later.")
+@pytest.mark.skipif(sys.version_info > (3,11) and config["desktopVersion"] < "2025.1", reason="Emit API is only available for Python 3.12 in AEDT version 2025.1 and later.")
 class TestClass:
 
     @pytest.fixture(autouse=True)
@@ -45,24 +45,8 @@ class TestClass:
         assert self.aedtapp.modeler
         assert self.aedtapp.oanalysis is None
         if self.aedtapp._aedt_version > "2023.1":
-            if sys.version_info.major == 3 and sys.version_info.minor == 7:
-                assert str(type(self.aedtapp._emit_api)) == "<class 'EmitApiPython.EmitApi'>"
-                assert self.aedtapp.results is not None
-            elif sys.version_info.major == 3 and sys.version_info.minor == 8:
-                assert str(type(self.aedtapp._emit_api)) == "<class 'EmitApiPython38.EmitApi'>"
-                assert self.aedtapp.results is not None
-            elif sys.version_info.major == 3 and sys.version_info.minor == 9:
-                assert str(type(self.aedtapp._emit_api)) == "<class 'EmitApiPython39.EmitApi'>"
-                assert self.aedtapp.results is not None
-            elif sys.version_info.major == 3 and sys.version_info.minor == 10:
-                assert str(type(self.aedtapp._emit_api)) == "<class 'EmitApiPython310.EmitApi'>"
-                assert self.aedtapp.results is not None
-            elif sys.version_info.major == 3 and sys.version_info.minor == 11:
-                assert str(type(self.aedtapp._emit_api)) == "<class 'EmitApiPython311.EmitApi'>"
-                assert self.aedtapp.results is not None
-            elif sys.version_info.major == 3 and sys.version_info.minor == 12:
-                assert str(type(self.aedtapp._emit_api)) == "<class 'EmitApiPython312.EmitApi'>"
-                assert self.aedtapp.results is not None
+            assert str(type(self.aedtapp._emit_api)) == f"<class 'EmitApiPython{sys.version_info.major}{sys.version_info.minor}.EmitApi'>"
+            assert self.aedtapp.results is not None
 
     @pytest.mark.skipif(config["desktopVersion"] <= "2022.1", reason="Skipped on versions earlier than 2021.2")
     def test_02_create_components(self, add_app):
@@ -698,14 +682,9 @@ class TestClass:
     )
     def test_13_static_type_generation(self):
         domain = self.aedtapp.results.interaction_domain()
-        if sys.version_info < (3, 10):
-            py_version = "EmitApiPython"
-        elif sys.version_info < (3, 11):
-            py_version = "EmitApiPython310"
-        elif sys.version_info < (3, 12):
-            py_version = "EmitApiPython311"
-        elif sys.version_info < (3, 13):
-            py_version = "EmitApiPython312"
+        py_version = "EmitApiPython"
+        if sys.version_info > (3, 9):
+            py_version = f"EmitApiPython{sys.version_info[0]}{sys.version_info[1]}"
         assert str(type(domain)) == "<class '{}.InteractionDomain'>".format(py_version)
 
         # assert str(type(TxRxMode)) == "<class '{}.tx_rx_mode'>".format(py_version)

--- a/src/ansys/aedt/core/modeler/schematic.py
+++ b/src/ansys/aedt/core/modeler/schematic.py
@@ -23,9 +23,7 @@
 # SOFTWARE.
 
 import random
-import sys
 import time
-import warnings
 
 from ansys.aedt.core.generic.constants import AEDT_UNITS
 from ansys.aedt.core.generic.general_methods import is_linux

--- a/src/ansys/aedt/core/modeler/schematic.py
+++ b/src/ansys/aedt/core/modeler/schematic.py
@@ -23,7 +23,9 @@
 # SOFTWARE.
 
 import random
+import sys
 import time
+import warnings
 
 from ansys.aedt.core.generic.constants import AEDT_UNITS
 from ansys.aedt.core.generic.general_methods import is_linux
@@ -32,8 +34,13 @@ from ansys.aedt.core.generic.settings import settings
 from ansys.aedt.core.modeler.cad.modeler import Modeler
 from ansys.aedt.core.modeler.circuits.object_3d_circuit import CircuitComponent
 from ansys.aedt.core.modeler.circuits.object_3d_circuit import Wire
-from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponent
-from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponents
+
+if (3,8) < sys.version_info < (3,13):
+    from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponent
+    from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponents
+else: # pragma: no cover
+    warnings.warn("EMIT API is only available for Python 3.9-3.12.")
+
 from ansys.aedt.core.modeler.circuits.primitives_maxwell_circuit import MaxwellCircuitComponents
 from ansys.aedt.core.modeler.circuits.primitives_nexxim import NexximComponents
 from ansys.aedt.core.modeler.circuits.primitives_twin_builder import TwinBuilderComponents

--- a/src/ansys/aedt/core/modeler/schematic.py
+++ b/src/ansys/aedt/core/modeler/schematic.py
@@ -33,11 +33,8 @@ from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.generic.settings import settings
 from ansys.aedt.core.modeler.cad.modeler import Modeler
 
-if (3, 8) < sys.version_info < (3, 12):
-    from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponent
-    from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponents
-else:  # pragma: no cover
-    warnings.warn("Emit API is only available for Python 3.8+,<3.12.")
+from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponent
+from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponents
 from ansys.aedt.core.modeler.circuits.object_3d_circuit import CircuitComponent
 from ansys.aedt.core.modeler.circuits.object_3d_circuit import Wire
 from ansys.aedt.core.modeler.circuits.primitives_maxwell_circuit import MaxwellCircuitComponents

--- a/src/ansys/aedt/core/modeler/schematic.py
+++ b/src/ansys/aedt/core/modeler/schematic.py
@@ -35,11 +35,11 @@ from ansys.aedt.core.modeler.cad.modeler import Modeler
 from ansys.aedt.core.modeler.circuits.object_3d_circuit import CircuitComponent
 from ansys.aedt.core.modeler.circuits.object_3d_circuit import Wire
 
-if (3, 8) < sys.version_info < (3, 13):
+if (3, 7) < sys.version_info < (3, 13):
     from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponent
     from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponents
 else:  # pragma: no cover
-    warnings.warn("EMIT API is only available for Python 3.9-3.12.")
+    warnings.warn("EMIT API is only available for Python 3.8-3.12.")
 
 from ansys.aedt.core.modeler.circuits.primitives_maxwell_circuit import MaxwellCircuitComponents
 from ansys.aedt.core.modeler.circuits.primitives_nexxim import NexximComponents

--- a/src/ansys/aedt/core/modeler/schematic.py
+++ b/src/ansys/aedt/core/modeler/schematic.py
@@ -35,10 +35,10 @@ from ansys.aedt.core.modeler.cad.modeler import Modeler
 from ansys.aedt.core.modeler.circuits.object_3d_circuit import CircuitComponent
 from ansys.aedt.core.modeler.circuits.object_3d_circuit import Wire
 
-if (3,8) < sys.version_info < (3,13):
+if (3, 8) < sys.version_info < (3, 13):
     from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponent
     from ansys.aedt.core.modeler.circuits.primitives_emit import EmitComponents
-else: # pragma: no cover
+else:  # pragma: no cover
     warnings.warn("EMIT API is only available for Python 3.9-3.12.")
 
 from ansys.aedt.core.modeler.circuits.primitives_maxwell_circuit import MaxwellCircuitComponents


### PR DESCRIPTION
Preparing EMIT to provide Python 3.12 starting with AEDT 2025.1.