### PR TITLE
CI: Upgrade artifact actions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           python doc/print_errors.py
 
-      - name: Upload HTML documentation without  artifact
+      - name: Upload HTML documentation
         uses: actions/upload-artifact@v4
         with:
           name: documentation-html

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -116,7 +116,7 @@ jobs:
           python doc/print_errors.py
 
       - name: Upload HTML documentation without  artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation-html
           path: doc/_build/html
@@ -127,7 +127,7 @@ jobs:
           make -C doc pdf
 
       - name: Upload PDF documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation-pdf
           path: doc/_build/latex/PyAEDT-Documentation-*.pdf
@@ -187,7 +187,7 @@ jobs:
           flags: system,solver
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-solver-results
           path: junit/test-results.xml
@@ -245,7 +245,7 @@ jobs:
           flags: system,solver
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-solver-results
           path: junit/test-results.xml
@@ -310,7 +310,7 @@ jobs:
           flags: system
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results
           path: junit/test-results.xml
@@ -380,7 +380,7 @@ jobs:
           flags: system,solver
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-solver-results
           path: junit/test-results.xml

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-solver-results
+          name: pytest-solver-windows
           path: junit/test-results.xml
         if: ${{ always() }}
 
@@ -247,7 +247,7 @@ jobs:
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-solver-results
+          name: pytest-solver-linux
           path: junit/test-results.xml
         if: ${{ always() }}
 
@@ -312,7 +312,7 @@ jobs:
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-results
+          name: pytest-windows
           path: junit/test-results.xml
         if: ${{ always() }}
 
@@ -382,7 +382,7 @@ jobs:
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-solver-results
+          name: pytest-linux
           path: junit/test-results.xml
         if: ${{ always() }}
 


### PR DESCRIPTION
The problem that was preventing us to use `download/upload-artifact` actions seems to be [fixed](https://github.com/actions/upload-artifact/issues/485#issuecomment-2397660452.), see https://github.com/actions/upload-artifact/pull/625.

If that's correct, it will be a really good news because we'll be able to leverage ansys actions even more !

> Note: Remind that v3 and v4 have incompatible format and that was preventing us to use ansys actions.
