### PR TITLE
CI: Fix conflict in artifact action version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -423,7 +423,7 @@ jobs:
     needs: [release]
     steps:
       - name: Deploy the stable documentation
-        uses: ansys/actions/doc-deploy-stable@v4
+        uses: ansys/actions/doc-deploy-stable@v5
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -453,7 +453,7 @@ jobs:
           echo "VERSION_MEILI=$VERSION_MEILI" >> $GITHUB_ENV
 
       - name: Deploy the latest documentation index
-        uses: ansys/actions/doc-deploy-index@v4
+        uses: ansys/actions/doc-deploy-index@v5
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/${{ env.VERSION }}
           index-name: pyaedt-v${{ env.VERSION_MEILI }}

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
 
   doc-build:
-    name: Documentation build with examples
+    name: Documentation build
     runs-on: [ self-hosted, Windows, pyaedt ]
     timeout-minutes: 720
     steps:
@@ -110,7 +110,7 @@ jobs:
     needs: doc-build
     steps:
       - name: Upload development documentation
-        uses: ansys/actions/doc-deploy-dev@v4
+        uses: ansys/actions/doc-deploy-dev@v5
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -122,7 +122,7 @@ jobs:
     needs: upload-dev-doc
     steps:
       - name: Deploy the latest documentation index
-        uses: ansys/actions/doc-deploy-index@v4
+        uses: ansys/actions/doc-deploy-index@v5
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev
           index-name: pyaedt-vdev


### PR DESCRIPTION
Bumping actions related to artifact download / upload requires to bump ansys/doc-deploy-* actions.
Currently we are uploading with upload-artifact@v4 (which requires download@v4) however the doc-deploy actions use v3 :/
