### PR TITLE
FIX: Close on exit unless asked not to

### DIFF
--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -689,8 +689,9 @@ class Desktop(object):
         # save the current desktop session in the database
         _desktop_sessions[self.aedt_process_id] = self
 
-        # Register the desktop closure to be called at exit.
-        atexit.register(self.close_desktop)
+        # Register the desktop closure to be called at exit unless asked not not.
+        if close_on_exit:
+            atexit.register(self.close_desktop)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
When adding the action of closing AEDT through `atexit.register`, the case with `close_on_exit=False` was not handled.
This should fix this behavior.

Close #5273

@AlfVII Can you give a try at this PR to see if it fixes your problem ?