### PR TITLE
CI: Bump doc-style action version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check documentation style
-        uses: ansys/actions/doc-style@v6
+        uses: ansys/actions/doc-style@v8
         with:
          token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Update doc-style action to latest version in order to fix the new changes in errata-ai/vale-action@1262efa.
See https://github.com/ansys/actions/pull/614