### PR TITLE
CI: Bump ansys actions version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -81,6 +81,7 @@ jobs:
           dependencies: "graphviz texlive-latex-extra latexmk texlive-xetex texlive-fonts-extra"
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           sphinxopts: '-j auto --color -w build_errors.txt'
+          check-links: false
 
 # # =================================================================================================
 # # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check commit name
-        uses: ansys/actions/commit-style@v8
+        uses: ansys/actions/check-pr-title@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           use-upper-case: true

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Documentation build
         uses: ansys/actions/doc-build@v8
         with:
+          dependencies: "graphviz texlive-latex-extra latexmk texlive-xetex texlive-fonts-extra"
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          dependencies: 'graphviz texlive-latex-extra latexmk texlive-xetex texlive-fonts-extra'
 
 # # =================================================================================================
 # # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           dependencies: "graphviz texlive-latex-extra latexmk texlive-xetex texlive-fonts-extra"
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          sphinxopts: '-j auto --color -w build_errors.txt'
 
 # # =================================================================================================
 # # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check commit name
-        uses: ansys/actions/commit-style@v6
+        uses: ansys/actions/commit-style@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           use-upper-case: true
@@ -57,10 +57,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         target: ['all', 'installer']
-
     steps:
       - name: Build wheelhouse and perform smoke test
-        uses: ansys/actions/build-wheelhouse@v4
+        uses: ansys/actions/build-wheelhouse@v8
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           operating-system: ${{ matrix.os }}
@@ -71,67 +70,15 @@ jobs:
         run: |
           python -c "import ansys.aedt.core; from ansys.aedt.core import __version__"
 
-  # TODO: Update to ansys/actions/doc-build@v6 once we remove examples
   doc-build:
     name: Documentation build
     runs-on: ubuntu-latest
     needs: [doc-style]
-    steps:
-      - name: Install Git and checkout project
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Documentation build
+        uses: ansys/actions/doc-build@v8
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-
-      - name: Update pip
-        run: |
-          pip install --upgrade pip
-
-      - name: Install pyaedt and documentation dependencies
-        run: |
-          pip install .[doc]
-
-      - name: Retrieve PyAEDT version
-        id: version
-        run: |
-          echo "PYAEDT_VERSION=$(python -c 'from ansys.aedt.core import __version__; print(__version__)')" >> $GITHUB_OUTPUT
-          echo "PyAEDT version is: $(python -c "from ansys.aedt.core import __version__; print(__version__)")"
-
-      - name: Install doc build requirements
-        run: |
-          sudo apt update
-          sudo apt install graphviz texlive-latex-extra latexmk texlive-xetex texlive-fonts-extra -y
-
-      # TODO: Update this step once pyaedt-examples is ready
-      - name: Build HTML documentation
-        run: |
-          make -C doc clean
-          make -C doc html
-
-      # Verify that sphinx generates no warnings
-      - name: Check for warnings
-        run: |
-          python doc/print_errors.py
-
-      - name: Upload HTML documentation
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation-html
-          path: doc/_build/html
-          retention-days: 7
-
-      - name: Build PDF documentation
-        run: |
-          make -C doc pdf
-
-      - name: Upload PDF documentation
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation-pdf
-          path: doc/_build/latex/PyAEDT-Documentation-*.pdf
-          retention-days: 7
+          dependencies: 'graphviz texlive-latex-extra latexmk texlive-xetex texlive-fonts-extra'
 
 # # =================================================================================================
 # # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv    RUNNING ON SELF-HOSTED RUNNER    vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
@@ -392,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build library source and wheel artifacts
-        uses: ansys/actions/build-library@v4
+        uses: ansys/actions/build-library@v8
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
@@ -405,14 +352,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release to the public PyPI repository
-        uses: ansys/actions/release-pypi-public@v4
+        uses: ansys/actions/release-pypi-public@v8
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           twine-username: "__token__"
           twine-token: ${{ secrets.PYPI_TOKEN }}
 
       - name: Release to GitHub
-        uses: ansys/actions/release-github@v4
+        uses: ansys/actions/release-github@v8
         with:
           library-name: ${{ env.PACKAGE_NAME }}
 
@@ -423,40 +370,9 @@ jobs:
     needs: [release]
     steps:
       - name: Deploy the stable documentation
-        uses: ansys/actions/doc-deploy-stable@v5
+        uses: ansys/actions/doc-deploy-stable@v8
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          doc-artifact-name: 'documentation-html'
-
-  doc-index-stable:
-    name: Deploy stable docs index
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    needs: upload-release-doc
-    steps:
-      - name: Install Git and clone project
-        uses: actions/checkout@v4
-
-      - name: Install the package requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-
-      - name: Get the version to PyMeilisearch
-        run: |
-          VERSION=$(python -c "from ansys.aedt.core import __version__; print('.'.join(__version__.split('.')[:2]))")
-          VERSION_MEILI=$(python -c "from ansys.aedt.core import __version__; print('-'.join(__version__.split('.')[:2]))")
-          echo "Calculated VERSION: $VERSION"
-          echo "Calculated VERSION_MEILI: $VERSION_MEILI"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION_MEILI=$VERSION_MEILI" >> $GITHUB_ENV
-
-      - name: Deploy the latest documentation index
-        uses: ansys/actions/doc-deploy-index@v5
-        with:
-          cname: ${{ env.DOCUMENTATION_CNAME }}/version/${{ env.VERSION }}
-          index-name: pyaedt-v${{ env.VERSION_MEILI }}
-          host-url: ${{ env.MEILISEARCH_HOST_URL }}
-          api-key: ${{ env.MEILISEARCH_API_KEY }}
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -74,6 +74,7 @@ jobs:
     name: Documentation build
     runs-on: ubuntu-latest
     needs: [doc-style]
+    steps:
       - name: Documentation build
         uses: ansys/actions/doc-build@v8
         with:

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -23,6 +23,7 @@ jobs:
     name: Documentation build
     runs-on: [ self-hosted, Windows, pyaedt ]
     needs: [doc-style]
+    steps:
       - name: Documentation build
         uses: ansys/actions/doc-build@v8
         with:

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -22,87 +22,11 @@ jobs:
   doc-build:
     name: Documentation build
     runs-on: [ self-hosted, Windows, pyaedt ]
-    timeout-minutes: 720
-    steps:
-      - name: Install Git and checkout project
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
+    needs: [doc-style]
+      - name: Documentation build
+        uses: ansys/actions/doc-build@v8
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-
-      - name: Create virtual environment
-        run: |
-          python -m venv .venv
-          .venv\Scripts\Activate.ps1
-          python -m pip install pip -U
-          python -m pip install wheel setuptools -U
-          python -c "import sys; print(sys.executable)"
-
-      - name: Install pyaedt and documentation dependencies
-        run: |
-          .venv\Scripts\Activate.ps1
-          pip install .[doc]
-
-      - name: Retrieve PyAEDT version
-        id: version
-        run: |
-          .venv\Scripts\Activate.ps1
-          echo "PYAEDT_VERSION=$(python -c 'from ansys.aedt.core import __version__; print(__version__)')" >> $GITHUB_OUTPUT
-          echo "PyAEDT version is: $(python -c "from ansys.aedt.core import __version__; print(__version__)")"
-
-      - name: Install CI dependencies (e.g. vtk-osmesa)
-        run: |
-          .venv\Scripts\Activate.ps1
-          # Uninstall conflicting dependencies
-          pip uninstall --yes vtk
-          pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.2.20230527.dev0
-
-      # TODO: Update this step once pyaedt-examples is ready
-      # NOTE: Use environment variable to keep the doctree and avoid redundant build for PDF pages
-      - name: Build HTML documentation with examples
-        env:
-          SPHINXBUILD_KEEP_DOCTREEDIR: "1"
-        run: |
-          .venv\Scripts\Activate.ps1
-          .\doc\make.bat clean
-          .\doc\make.bat html
-
-      # TODO: Keeping this commented as reminder of https://github.com/ansys/pyaedt/issues/4296
-      # # Verify that sphinx generates no warnings
-      # - name: Check for warnings
-      #   run: |
-      #     .venv\Scripts\Activate.ps1
-      #     python doc/print_errors.py
-
-      # Use environment variable to remove the doctree after the build of PDF pages
-      - name: Build PDF documentation with examples
-        env:
-          SPHINXBUILD_KEEP_DOCTREEDIR: "0"
-        run: |
-          .venv\Scripts\Activate.ps1
-          .\doc\make.bat pdf
-
-      # - name: Add assets to HTML docs
-      #   run: |
-      #     zip -r documentation-html.zip ./doc/_build/html
-      #     mv documentation-html.zip ./doc/_build/html/_static/assets/download/
-      #     cp doc/_build/latex/PyAEDT-Documentation-*.pdf ./doc/_build/html/_static/assets/download/pyaedt.pdf
-
-      - name: Upload HTML documentation with examples artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation-html
-          path: doc/_build/html
-          retention-days: 7
-
-      - name: Upload PDF documentation without examples artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation-pdf
-          path: doc/_build/latex/PyAEDT-Documentation-*.pdf
-          retention-days: 7
 
   upload-dev-doc:
     name: Upload dev documentation
@@ -110,22 +34,9 @@ jobs:
     needs: doc-build
     steps:
       - name: Upload development documentation
-        uses: ansys/actions/doc-deploy-dev@v5
+        uses: ansys/actions/doc-deploy-dev@v8
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          doc-artifact-name: 'documentation-html'
-
-  doc-index-dev:
-    name: Deploy dev index docs
-    runs-on: ubuntu-latest
-    needs: upload-dev-doc
-    steps:
-      - name: Deploy the latest documentation index
-        uses: ansys/actions/doc-deploy-index@v5
-        with:
-          cname: ${{ env.DOCUMENTATION_CNAME }}/version/dev
-          index-name: pyaedt-vdev
-          host-url: ${{ env.MEILISEARCH_HOST_URL }}
-          api-key: ${{ env.MEILISEARCH_API_KEY }}
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -55,5 +55,5 @@ pdf: .install-deps
 	@echo "Building PDF pages."
 	@$(SPHINXBUILD) -M latex "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	cd $(BUILDDIR)/latex && latexmk -r latexmkrc -pdf *.tex -interaction=nonstopmode || true
-	(test -f $(BUILDDIR)/latex/PyAEDT-Documentation-*.pdf && echo pdf exists) || exit 1
+	(test -f $(BUILDDIR)/latex/pyaedt.pdf && echo pdf exists) || exit 1
 	@echo "Build finished. The PDF pages are in $(BUILDDIR)."

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -318,29 +318,11 @@ html_css_files = [
     'custom.css',
 ]
 
-
-# -- Options for HTMLHelp output ---------------------------------------------
-
-# Output file base name for HTML help builder.
-htmlhelp_basename = "pyaedtdoc"
-
 # -- Options for LaTeX output ------------------------------------------------
-# additional logos for the latex coverpage
+
+# Additional logos for the latex coverpage
 latex_additional_files = [watermark, ansys_logo_white, ansys_logo_white_cropped]
 
-# change the preamble of latex with customized title page
+# Change the preamble of latex with customized title page
 # variables are the title of pdf, watermark
 latex_elements = {"preamble": latex.generate_preamble(html_title)}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (
-        master_doc,
-        f"{project}-Documentation-{__version__}.tex",
-        f"{project} Documentation",
-        author,
-        "manual",
-    ),
-]


### PR DESCRIPTION
As title say.

We've been left behind with ansys/actions due to various reasons - the biggest one being the artifact compatibility issue.
Now that all the issues that slowed us down are solved, we can update our CICD !

Notable changes:

- To be compatible with `ansys/actions/doc-build` I'm removing the name of the pdf in `conf.py`. This should lead to the creation of a pdf named `pyaedt.pdf`. In the process we lose the version in the pdf file name but this is a requirement for the `doc-build` action. I don't think this is a problem though.
- Meilisearch is being deprecated so I dropped the indexing jobs. I'll update our documentation to remove meilisearch and leverage static search in another PR.