### PR TITLE
FIX: Clean objects name

### DIFF
--- a/_unittest/test_02_3D_modeler.py
+++ b/_unittest/test_02_3D_modeler.py
@@ -1190,3 +1190,12 @@ class TestClass:
         assert not self.aedtapp.modeler.create_conical_rings("Z", position, 20, 10, 0, 1)
         assert not self.aedtapp.modeler.create_conical_rings("Z", position, 20, 10, 20, 0)
         assert not self.aedtapp.modeler.create_conical_rings("Z", [0], 20, 10, 20, 0)
+
+    def test_clean_objects_name(self):
+        box_0 = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 10], name="Object_Part0")
+        box_1 = self.aedtapp.modeler.create_box([5, 5, 0], [1, 1, 1], name="Object_Part1")
+        self.aedtapp.modeler.unite([box_0, box_1], keep_originals=True)
+        self.aedtapp.modeler.clean_objects_name("Object")
+
+        assert self.aedtapp.modeler.get_matched_object_name("Part0")
+        assert self.aedtapp.modeler.get_matched_object_name("Part1")

--- a/src/ansys/aedt/core/modeler/cad/primitives.py
+++ b/src/ansys/aedt/core/modeler/cad/primitives.py
@@ -4017,17 +4017,17 @@ class GeometryModeler(Modeler):
 
         >>> oEditor.RenamePart
         """
-        # import os.path
-        # (CADPath, CADFilename) = os.path.split(CADFile)
-        # (CADName, CADExt) = os.path.splitext(CADFilename)
-        CADSuffix = main_part_name + "_"
-        objNames = self.oeditor.GetMatchedObjectName(CADSuffix + "*")
-        for name in objNames:
-            RenameArgs = {}
-            RenameArgs["NAME"] = "Rename Data"
-            RenameArgs["Old Name"] = name
-            RenameArgs["New Name"] = name.replace(CADSuffix, "")
-            self.oeditor.RenamePart(RenameArgs)
+        cad_suffix = main_part_name + "_"
+        names = self.oeditor.GetMatchedObjectName(cad_suffix + "*")
+        for name in names:
+            args = [
+                "NAME:Rename Data",
+                "Old Name:=",
+                name,
+                "New Name:=",
+                name.replace(cad_suffix, ""),
+            ]
+            self.oeditor.RenamePart(args)
         return True
 
     @pyaedt_function_handler(defname="name")


### PR DESCRIPTION
There was a problem in the implementation of `clean_objects_name`.
This PR fixes it and also add a test that was missing previously.