### PR TITLE
FIX: Wrong import in touchstone parser

### DIFF
--- a/src/ansys/aedt/core/visualization/advanced/touchstone_parser.py
+++ b/src/ansys/aedt/core/visualization/advanced/touchstone_parser.py
@@ -42,7 +42,7 @@ except ImportError:  # pragma: no cover
     np = None
 
 try:
-    import matplotlib as plt
+    import matplotlib.pyplot as plt
 except ImportError:  # pragma: no cover
     warnings.warn(
         "The Matplotlib module is required to run functionalities of TouchstoneData.\n"


### PR DESCRIPTION
Fix error in the refactoring of #5339

This is currently breaking the CICD of [pyaedt-examples](https://github.com/ansys/pyaedt-examples).