### PR TITLE
CI: Remove needs to doc-build

### DIFF
--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -22,7 +22,6 @@ jobs:
   doc-build:
     name: Documentation build
     runs-on: [ self-hosted, Windows, pyaedt ]
-    needs: [doc-style]
     steps:
       - name: Documentation build
         uses: ansys/actions/doc-build@v8


### PR DESCRIPTION
Fix error introduced while refactoring the CICD to use recent ansys/actions.