### PR TITLE
FIX: Remove f-string from IronPython script

### DIFF
--- a/doc/source/Resources/pyaedt_installer_from_aedt.py
+++ b/doc/source/Resources/pyaedt_installer_from_aedt.py
@@ -134,15 +134,19 @@ def run_pyinstaller_from_c_python(oDesktop):
         if version <= "231":
             f.write("from pyaedt.workflows.installer.pyaedt_installer import add_pyaedt_to_aedt\n")
             f.write(
-                f'add_pyaedt_to_aedt(aedt_version="{oDesktop.GetVersion()[:6]}", personallib=r"{oDesktop.GetPersonalLibDirectory()}")\n'
+                'add_pyaedt_to_aedt(aedt_version="{}", personallib=r"{}")\n'.format(
+                    oDesktop.GetVersion()[:6], oDesktop.GetPersonalLibDirectory()
+                )
             )
         else:
             f.write("from ansys.aedt.core.workflows.installer.pyaedt_installer import add_pyaedt_to_aedt\n")
             f.write(
-                f'add_pyaedt_to_aedt(aedt_version="{oDesktop.GetVersion()[:6]}", personal_lib=r"{oDesktop.GetPersonalLibDirectory()}")\n'
+                'add_pyaedt_to_aedt(aedt_version="{}", personal_lib=r"{}")\n'.format(
+                    oDesktop.GetVersion()[:6], oDesktop.GetPersonalLibDirectory()
+                )
             )
 
-    command = f'"{python_exe}" "{python_script}"'
+    command = r'"{}" "{}"'.format(python_exe, python_script)
     oDesktop.AddMessage("", "", 0, "Configuring PyAEDT panels in automation tab.")
     ret_code = os.system(command)
     if ret_code != 0:

--- a/doc/source/Resources/pyaedt_installer_from_aedt.py
+++ b/doc/source/Resources/pyaedt_installer_from_aedt.py
@@ -75,14 +75,15 @@ def run_pyinstaller_from_c_python(oDesktop):
 
     # Launch this script again from the CPython interpreter. This calls the ``install_pyaedt()`` method,
     # which creates a virtual environment and installs PyAEDT and its dependencies
-    command = [f"{python_exe}", f"{os.path.normpath(__file__)}", "--version=" + version]
+    command = ['"{}"'.format(python_exe), '"{}"'.format(os.path.normpath(__file__)), "--version=" + version]
+
     if is_student_version(oDesktop):
         command.append("--student")
     if is_linux:
-        command.extend([f'--edt_root="{edt_root}"', f'--python_version="{python_version}"'])
+        command.extend(['--edt_root="{}"'.format(edt_root), '--python_version="{}"'.format(python_version)])
 
     if wheelpyaedt:
-        command.extend([f'--wheel="{wheelpyaedt}"'])
+        command.extend(['--wheel="{}"'.format(wheelpyaedt)])
 
     oDesktop.AddMessage("", "", 0, "Installing PyAEDT.")
     if is_windows:
@@ -200,19 +201,24 @@ def install_pyaedt():
         venv_dir = os.path.join(os.environ["HOME"], VENV_DIR_PREFIX, python_version)
         python_exe = os.path.join(venv_dir, "bin", "python")
         pip_exe = os.path.join(venv_dir, "bin", "pip")
-        os.environ[f"ANSYSEM_ROOT{args.version}"] = args.edt_root
+        os.environ["ANSYSEM_ROOT{}".format(args.version)] = args.edt_root
         ld_library_path_dirs_to_add = [
-            f"{args.edt_root}/commonfiles/CPython/{args.python_version.replace('.', '_')}/linx64/Release/python/lib",
-            f"{args.edt_root}/common/mono/Linux64/lib64",
-            f"{args.edt_root}",
+            "{}/commonfiles/CPython/{}/linx64/Release/python/lib".format(
+                args.edt_root, args.python_version.replace(".", "_")
+            ),
+            "{}/common/mono/Linux64/lib64".format(args.edt_root),
+            "{}".format(args.edt_root),
         ]
         if args.version < "232":
-            ld_library_path_dirs_to_add.append(f"{args.edt_root}/Delcross")
+            ld_library_path_dirs_to_add.append("{}/Delcross".format(args.edt_root))
         os.environ["LD_LIBRARY_PATH"] = ":".join(ld_library_path_dirs_to_add) + ":" + os.getenv("LD_LIBRARY_PATH", "")
-        os.environ["TK_LIBRARY"] = (f"{args.edt_root}/commonfiles/CPython/{args.python_version.replace('.', '_')}"
-                                    f"/linx64/Release/python/lib/tk8.5")
-        os.environ["TCL_LIBRARY"] = (f"{args.edt_root}/commonfiles/CPython/{args.python_version.replace('.', '_')}"
-                                     f"/linx64/Release/python/lib/tcl8.5")
+        os.environ["TK_LIBRARY"] = "{}/commonfiles/CPython/{}/linx64/Release/python/lib/tk8.5".format(
+            args.edt_root, args.python_version.replace(".", "_")
+        )
+        os.environ["TCL_LIBRARY"] = "{}/commonfiles/CPython/{}/linx64/Release/python/lib/tcl8.5".format(
+            args.edt_root, args.python_version.replace(".", "_")
+        )
+
     response = disclaimer()
     if not response:
         exit(1)
@@ -220,9 +226,9 @@ def install_pyaedt():
     if not os.path.exists(venv_dir):
 
         if args.version == "231":
-            run_command(f'"{sys.executable}" -m venv "{venv_dir}" --system-site-packages')
+            run_command('"{}" -m venv "{}" --system-site-packages'.format(sys.executable, venv_dir))
         else:
-            run_command(f'"{sys.executable}" -m venv "{venv_dir}"')
+            run_command('"{}" -m venv "{}"'.format(sys.executable, venv_dir))
 
         if args.wheel and os.path.exists(args.wheel):
             wheel_pyaedt = args.wheel
@@ -242,31 +248,32 @@ def install_pyaedt():
                 unzipped_path = wheel_pyaedt
             if args.version <= "231":
                 run_command(
-                    f'"{pip_exe}" install --no-cache-dir --no-index --find-links={unzipped_path} pyaedt[all,dotnet]'
-                )
+                    '"{}" install --no-cache-dir --no-index --find-links={} pyaedt[all,dotnet]'.format(
+                        pip_exe, unzipped_path
+                    )                )
             else:
                 run_command(
-                    f'"{pip_exe}" install --no-cache-dir --no-index --find-links={unzipped_path} pyaedt[installer]'
+                    '"{}" install --no-cache-dir --no-index --find-links={} pyaedt[installer]'.format(
+                        pip_exe, unzipped_path
+                    )
                 )
 
         else:
-            run_command(f'"{python_exe}" -m pip install --upgrade pip')
-            run_command(f'"{pip_exe}" --default-timeout=1000 install wheel')
-            # run_command(
-            # '"{}" --default-timeout=1000 install git+https://github.com/ansys/pyaedt.git@main'.format(pip_exe))
+            run_command('"{}" -m pip install --upgrade pip'.format(python_exe))
+            run_command('"{}" --default-timeout=1000 install wheel'.format(pip_exe))
             if args.version <= "231":
-                run_command(f'"{pip_exe}" --default-timeout=1000 install pyaedt[all]=="0.9.0"')
-                run_command(f'"{pip_exe}" --default-timeout=1000 install jupyterlab')
-                run_command(f'"{pip_exe}" --default-timeout=1000 install ipython -U')
-                run_command(f'"{pip_exe}" --default-timeout=1000 install ipyvtklink')
+                run_command('"{}" --default-timeout=1000 install pyaedt[all]=="0.9.0"'.format(pip_exe))
+                run_command('"{}" --default-timeout=1000 install jupyterlab'.format(pip_exe))
+                run_command('"{}" --default-timeout=1000 install ipython -U'.format(pip_exe))
+                run_command('"{}" --default-timeout=1000 install ipyvtklink'.format(pip_exe))
             else:
-                run_command(f'"{pip_exe}" --default-timeout=1000 install pyaedt[installer]')
+                run_command('"{}" --default-timeout=1000 install pyaedt[installer]'.format(pip_exe))
 
         if args.version == "231":
-            run_command(f'"{pip_exe}" uninstall -y pywin32')
+            run_command('"{}" uninstall -y pywin32'.format(pip_exe))
 
     else:
-        run_command(f'"{pip_exe}" uninstall --yes pyaedt')
+        run_command('"{}" uninstall --yes pyaedt'.format(pip_exe))
 
         if args.wheel and os.path.exists(args.wheel):
             wheel_pyaedt = args.wheel
@@ -282,20 +289,24 @@ def install_pyaedt():
                 zip_ref.extractall(unzipped_path)
             if args.version <= "231":
                 run_command(
-                    f'"{pip_exe}" install --no-cache-dir --no-index --find-links={unzipped_path} pyaedt[all]=="0.9.0"'
+                    '"{}" install --no-cache-dir --no-index --find-links={} pyaedt[all]=="0.9.0"'.format(
+                        pip_exe, unzipped_path
+                    )
                 )
             else:
                 run_command(
-                    f'"{pip_exe}" install --no-cache-dir --no-index --find-links={unzipped_path} pyaedt[installer]'
+                    '"{}" install --no-cache-dir --no-index --find-links={} pyaedt[installer]'.format(
+                        pip_exe, unzipped_path
+                    )
                 )
         else:
             if args.version <= "231":
-                run_command(f'"{pip_exe}" --default-timeout=1000 install pyaedt[all]=="0.9.0"')
-                run_command(f'"{pip_exe}" --default-timeout=1000 install jupyterlab')
-                run_command(f'"{pip_exe}" --default-timeout=1000 install ipython -U')
-                run_command(f'"{pip_exe}" --default-timeout=1000 install ipyvtklink')
+                run_command('"{}" --default-timeout=1000 install pyaedt[all]=="0.9.0"'.format(pip_exe))
+                run_command('"{}" --default-timeout=1000 install jupyterlab'.format(pip_exe))
+                run_command('"{}" --default-timeout=1000 install ipython -U'.format(pip_exe))
+                run_command('"{}" --default-timeout=1000 install ipyvtklink'.format(pip_exe))
             else:
-                run_command(f'"{pip_exe}" --default-timeout=1000 install pyaedt[installer]')
+                run_command('"{}" --default-timeout=1000 install pyaedt[installer]'.format(pip_exe))
     sys.exit(0)
 
 
@@ -309,7 +320,7 @@ def is_student_version(oDesktop):
 
 def run_command(command):
     if is_windows:
-        command = f'"{command}"'
+        command = '"{}"'.format(command)
     ret_code = os.system(command)
     return ret_code
 


### PR DESCRIPTION
The script file `pyaedt_installer_from_aedt.py` is supposed to be executed in an IronPython environment and therefore is not compatible with f-string.