### PR TITLE
Add `material_appearance` property to `Modeler3D`

### DIFF
--- a/src/ansys/aedt/core/modeler/cad/object_3d.py
+++ b/src/ansys/aedt/core/modeler/cad/object_3d.py
@@ -98,6 +98,7 @@ class Object3d(object):
         self._surface_material = None
         self._color = None
         self._wireframe = None
+        self._material_appearance = None
         self._part_coordinate_system = None
         self._model = None
         self._m_groupName = None
@@ -1341,6 +1342,43 @@ class Object3d(object):
 
         self._change_property(vWireframe)
         self._wireframe = fWireframe
+
+    @property
+    def material_appearance(self):
+        """Material appearance property of the part.
+
+        Returns
+        -------
+        bool
+            ``True`` when material appearance is activated for the part, ``False`` otherwise.
+
+        References
+        ----------
+
+        >>> oEditor.GetPropertyValue
+        >>> oEditor.ChangeProperty
+
+        """
+        if self._material_appearance is not None:
+            return self._material_appearance
+        if "Material Appearance" in self.valid_properties:
+            material_appearance = self._oeditor.GetPropertyValue("Geometry3DAttributeTab", self._m_name, "Material Appearance")
+            if material_appearance == "true" or material_appearance == "True":
+                self._material_appearance = True
+            else:
+                self._material_appearance = False
+            return self._material_appearance
+
+    @material_appearance.setter
+    def material_appearance(self, material_appearance):
+        vMaterialAppearance = [
+            "NAME:Material Appearance",
+            "Value:=",
+            material_appearance,
+        ]
+
+        self._change_property(vMaterialAppearance)
+        self._material_appearance = material_appearance
 
     @pyaedt_function_handler()
     def history(self):

--- a/src/ansys/aedt/core/modeler/cad/object_3d.py
+++ b/src/ansys/aedt/core/modeler/cad/object_3d.py
@@ -1362,7 +1362,9 @@ class Object3d(object):
         if self._material_appearance is not None:
             return self._material_appearance
         if "Material Appearance" in self.valid_properties:
-            material_appearance = self._oeditor.GetPropertyValue("Geometry3DAttributeTab", self._m_name, "Material Appearance")
+            material_appearance = self._oeditor.GetPropertyValue(
+                "Geometry3DAttributeTab", self._m_name, "Material Appearance"
+            )
             if material_appearance == "true" or material_appearance == "True":
                 self._material_appearance = True
             else:

--- a/tests/system/general/test_07_Object3D.py
+++ b/tests/system/general/test_07_Object3D.py
@@ -241,6 +241,7 @@ class TestClass:
         assert new_object.solve_inside == initial_object.solve_inside
         assert new_object.model == initial_object.model
         assert new_object.display_wireframe == initial_object.display_wireframe
+        assert new_object.material_appearance == initial_object.material_appearance
         assert new_object.part_coordinate_system == initial_object.part_coordinate_system
         assert new_object.transparency == 0.76
         assert new_object.color == initial_object.color
@@ -248,7 +249,6 @@ class TestClass:
         assert len(new_object.vertices) == 8
         assert len(new_object.faces) == 6
         assert len(new_object.edges) == 12
-        assert new_object.display_wireframe == initial_object.display_wireframe
         new_object.name = "Properties_Box"
         assert not new_object.name == "Properties_Box"
 


### PR DESCRIPTION
**Changes**
- Add property `material_appearance` to the `Modeler3D` class
- Modify one test

**Detail**
- The implementation is the same as `display_wireframe`

**Questions**
- Does `update_geometry_property` in `GeometryModeler` need an update?
- It seems like `display_wireframe` does not have a standalone unit test so I didn't include one for `material_appearance`
