### PR TITLE
DOCS: Fix python code error in visualization report

### DIFF
--- a/doc/source/API/visualization/report.rst
+++ b/doc/source/API/visualization/report.rst
@@ -49,7 +49,7 @@ The following code shows how to use report modules in standalone mode.
     p1 = app.modeler.create_polyline(test_points)
     setup = app.create_setup()
 
-    report = Fields(app=app, report_category="Fields",
+    report = Fields(app=app.post, report_category="Fields",
                     setup_name=setup.name + " : LastAdaptive",
                     expressions="Mag_E")
     report.polyline = p1.name

--- a/src/ansys/aedt/core/visualization/report/field.py
+++ b/src/ansys/aedt/core/visualization/report/field.py
@@ -67,10 +67,13 @@ class AntennaParameters(Standard):
 
 
 class Fields(CommonReport):
-    """Provides for managing fields."""
+    """Handler to manage fields."""
 
-    def __init__(self, app, report_category, setup_name, expressions=None):
-        CommonReport.__init__(self, app, report_category, setup_name, expressions)
+    @pyaedt_function_handler(
+        app="post_app",
+    )
+    def __init__(self, post_app, report_category, setup_name, expressions=None):
+        CommonReport.__init__(self, post_app, report_category, setup_name, expressions)
         self.domain = "Sweep"
         self.primary_sweep = "Distance"
 

--- a/src/ansys/aedt/core/visualization/report/field.py
+++ b/src/ansys/aedt/core/visualization/report/field.py
@@ -28,6 +28,7 @@ This module contains these classes: `AntennaParameters`, `Fields`, `NearField`, 
 This module provides all functionalities for creating and editing reports.
 
 """
+from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.visualization.report.common import CommonReport
 from ansys.aedt.core.visualization.report.standard import Standard
 


### PR DESCRIPTION
Changes include:
- fixing the documentation error;
- refactoring the `Fields`'s `__init__` method to use `post_app` as input argument name instead of `app`.

The second point would have helped to understand that one must provide a post application and not an app like `Hfss`, ...