### PR TITLE
FIX: Duplicate function by @abhandare21 in #5438

### DIFF
--- a/src/ansys/aedt/core/modeler/modeler_pcb.py
+++ b/src/ansys/aedt/core/modeler/modeler_pcb.py
@@ -758,7 +758,7 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
         self.cleanup_objects()
         if isinstance(assignment, str):
             assignment = [assignment]
-        self.oeditor.Duplicate(["NAME:options", "count:=", count], ["NAME:elements", ",".join(assignment)], vector)
+        self.oeditor.Duplicate(["NAME:options", "count:=", count], ["NAME:elements"] + assignment, vector)
         return self.cleanup_objects()
 
     @pyaedt_function_handler(objects="assignment")


### PR DESCRIPTION
Updated the duplicate function in the modeler_pcb.py file line 761, to allow a list of items to be passed as argument for hfss3dlayout to duplicate.