### PR TITLE
DOCS: Correct variation_type data type in parametric setup documentation

### DIFF
--- a/src/ansys/aedt/core/modules/design_xploration.py
+++ b/src/ansys/aedt/core/modules/design_xploration.py
@@ -916,7 +916,7 @@ class SetupParam(CommonOptimetrics, object):
             Variation Step or Count depending on variation_type. Default is `100`.
         units : str, optional
             Variation units. Default is `None`.
-        variation_type : float or int
+        variation_type : str, optional
             Variation Type. Admitted values are `"SingleValue", `"LinearCount"`, `"LinearStep"`,
             `"DecadeCount"`, `"OctaveCount"`, `"ExponentialCount"`.
 

--- a/src/ansys/aedt/core/modules/design_xploration.py
+++ b/src/ansys/aedt/core/modules/design_xploration.py
@@ -1159,7 +1159,7 @@ class ParametricSetups(object):
             Variation End Point. This parameter is optional if a Single Value is defined.
         step : float or int
             Variation Step or Count depending on variation_type. The default is ``100``.
-        variation_type : float or int
+        variation_type : str, optional
             Variation Type. Admitted values are `"LinearCount"`, `"LinearStep"`, `"LogScale"`, `"SingleValue"`.
         solution : str, optional
             Type of the solution. The default is ``None``, in which case the default


### PR DESCRIPTION
## Description
The functions add() and add_variation() within the ParametricSetup and SetupParam classes expect to be overloaded with variation_type variable of type str. However, initially it was int or float. This generated a warning when passing this argument as shown in the image below

![image](https://github.com/user-attachments/assets/e9a27af0-420a-48d5-af9e-f864480cf065)

The change in the docstring removes these warnings 

![image](https://github.com/user-attachments/assets/24ed6210-ad00-432c-b541-e202d4657894)


## Issue linked
No issue linked to this

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
