### PR TITLE
FEAT: Add dictionary entries to set custom savefields

### DIFF
--- a/src/ansys/aedt/core/modules/setup_templates.py
+++ b/src/ansys/aedt/core/modules/setup_templates.py
@@ -168,6 +168,16 @@ HFSSSBR = dict(
 )
 """HFSS SBR+ setup properties and default values."""
 
+mw_subrange = dict(
+    {
+        "RangeType": "LinearStep",
+        "RangeStart": "500Hz",
+        "RangeEnd": "1kHz",
+        "RangeStep": "500Hz",
+    }
+)
+mw_subranges = dict({"Subrange": mw_subrange})
+
 MaxwellTransient = dict(
     {
         "Enabled": True,
@@ -191,6 +201,7 @@ MaxwellTransient = dict(
         "NumberSolveSteps": 1,
         "RangeStart": "0s",
         "RangeEnd": "0.1s",
+        "SweepRanges": mw_subranges,
     }
 )
 """Maxwell transient setup properties and default values."""


### PR DESCRIPTION
## Description
Added  entries in the transient dictionary for maxwell under setup_templates.py, to account for custom field saves of different types. This should be seen as a temporary solution. Perhaps this will be worked out as part of PR #5496 

![image](https://github.com/user-attachments/assets/e1bb0455-0c0c-4f46-8776-77296c2bb916)