### PR TITLE
FEAT: Rescale property in model units

### DIFF
--- a/src/ansys/aedt/core/modeler/cad/primitives.py
+++ b/src/ansys/aedt/core/modeler/cad/primitives.py
@@ -261,6 +261,7 @@ class GeometryModeler(Modeler):
         self._unclassified = []
         self._all_object_names = []
         self._model_units = None
+        self.rescale_model = False
         self._object_names_to_ids = {}
         self.objects = Objects(self, "o")
         self.user_defined_components = Objects(self, "u")
@@ -423,11 +424,23 @@ class GeometryModeler(Modeler):
     def model_units(self):
         """Model units as a string. For example, ``"mm"``.
 
+        This property allows you to get or set the model units. When setting the model units,
+        you can specify whether to rescale the model by adjusting the ``rescale_model`` attribute.
+
         References
         ----------
 
         >>> oEditor.GetModelUnits
         >>> oEditor.SetModelUnits
+
+        Examples
+        --------
+
+        >>> from ansys.aedt.core import hfss
+        >>> hfss = Hfss()
+        >>> hfss.modeler.model_units = "cm"
+        >>> hfss.modeler.rescale_model = True
+        >>> hfss.modeler.model_units = "mm"
         """
         if not self._model_units:
             self._model_units = self.oeditor.GetModelUnits()
@@ -436,7 +449,7 @@ class GeometryModeler(Modeler):
     @model_units.setter
     def model_units(self, units):
         assert units in AEDT_UNITS["Length"], f"Invalid units string {units}."
-        self.oeditor.SetModelUnits(["NAME:Units Parameter", "Units:=", units, "Rescale:=", False])
+        self.oeditor.SetModelUnits(["NAME:Units Parameter", "Units:=", units, "Rescale:=", self.rescale_model])
         self._model_units = units
 
     @property

--- a/tests/system/general/test_07_Object3D.py
+++ b/tests/system/general/test_07_Object3D.py
@@ -768,3 +768,11 @@ class TestClass:
         )
         assert not self.aedtapp.modeler.simplify_objects(assignment=None)
         assert not self.aedtapp.modeler.simplify_objects(assignment=1)
+
+    def test_30_rescale(self):
+        self.aedtapp.modeler.model_units = "meter"
+        box1 = self.aedtapp.modeler.create_box([0, 0, 0], [5, 10, 2], material="Copper")
+        assert box1.mass == 893300.0
+        self.aedtapp.modeler.rescale_model = True
+        self.aedtapp.modeler.model_units = "mm"
+        assert round(box1.mass, 5) == 0.00089


### PR DESCRIPTION
## Description
Model_units property allows you to get or set the model units. When setting the model units, you can specify whether to rescale the model by adjusting the ``rescale_model`` attribute.

## Issue linked
Close #5541 
Close #5533 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
