### PR TITLE
FIX: Improve create_report 

### DIFF
--- a/src/ansys/aedt/core/visualization/post/common.py
+++ b/src/ansys/aedt/core/visualization/post/common.py
@@ -1307,7 +1307,7 @@ class PostProcessorCommon(object):
             else:
                 report.matrix = context
         elif report_category == "Far Fields":
-            if not context and self._app._field_setups:
+            if not context and self._app.field_setups:
                 report.far_field_sphere = self._app.field_setups[0].name
             else:
                 if isinstance(context, dict):
@@ -1538,6 +1538,11 @@ class PostProcessorCommon(object):
         elif report_category == "Far Fields":
             if not context and self._app.field_setups:
                 report.far_field_sphere = self._app.field_setups[0].name
+                if "Theta" not in report.variations:
+                    report.variations["Theta"] = ["All"]
+                if "Phi" not in report.variations:
+                    report.variations["Phi"] = ["All"]
+                report.primary_sweep = "Theta"
             else:
                 if isinstance(context, dict):
                     if "Context" in context.keys() and "SourceContext" in context.keys():

--- a/src/ansys/aedt/core/visualization/post/post_common_3d.py
+++ b/src/ansys/aedt/core/visualization/post/post_common_3d.py
@@ -2233,7 +2233,7 @@ class PostProcessor3D(PostProcessorCommon):
         if not assignment:
             self._app.modeler.refresh_all_ids()
             non_model = self._app.modeler.non_model_objects[:]
-            assignment = [i for i in self._app.modeler.object_names if i not in non_model]
+            assignment = [i for i in self._app.modeler.object_names if i not in non_model and "PML_" not in i]
             if not air_objects:
                 assignment = [
                     i


### PR DESCRIPTION
create_report now automatically get the first Sphere if no argument is passes and set Theta and Phi to All in case they are not defined as variaton dictionary.
plot_field is automatically skipping PML objects.

## Description
create_report now automatically get the first Sphere if no argument is passes and set Theta and Phi to All in case they are not defined as variaton dictionary.
plot_field is automatically skipping PML objects.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
