### PR TITLE
REFACTOR: Loading dotnet runtime

### DIFF
--- a/doc/source/release_1_0.rst
+++ b/doc/source/release_1_0.rst
@@ -186,9 +186,9 @@ The following table list the name changes with the old and new paths:
 +----------------------------------------------------------------+--------------------------------------------------------------------------+
 
 Dotnet changes in Linux
----------------------
+-----------------------
 
-To improve compatibility with system libraries, the Python package `dotnetcore2` is being removed from PyAEDT's dotnet installation target.
+To improve compatibility with system libraries in Linux, the Python package `dotnetcore2` is being removed from PyAEDT's dotnet installation target.
 Indeed, the embedded version of `.NET` associated to `dotnetcore2` is old and has **incompatibilities** with recent versions of `openssl` such as the one installed by default in Ubuntu 22.04.
 
 The impact of this decision is that users need to install `.NET` themselves.

--- a/doc/source/release_1_0.rst
+++ b/doc/source/release_1_0.rst
@@ -185,6 +185,49 @@ The following table list the name changes with the old and new paths:
 | pyaedt\\modules\\SolveSweeps.py                                | src\\ansys\\aedt\\core\\modules\\solve_sweeps.py                         |
 +----------------------------------------------------------------+--------------------------------------------------------------------------+
 
+Dotnet changes in Linux
+---------------------
+
+To improve compatibility with system libraries, the Python package `dotnetcore2` is being removed from PyAEDT's dotnet installation target.
+Indeed, the embedded version of `.NET` associated to `dotnetcore2` is old and has **incompatibilities** with recent versions of `openssl` such as the one installed by default in Ubuntu 22.04.
+
+The impact of this decision is that users need to install `.NET` themselves.
+The installation process can be done following the official
+Microsoft documentation for `.NET` on Linux to ensure proper setup and compatibility. See
+`Register Microsoft package repository <https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#register-the-microsoft-package-repository>`_
+and `Install .NET <https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#install-net>`_.
+
+.. note::
+    Starting with Ubuntu 22.04, `.NET` is available in the official Ubuntu repository.
+    If you want to use the Microsoft package to install `.NET`, you can use the following
+    approach to *"demote"* the Ubuntu packages so that the Microsoft packages take precedence.
+
+    1. Ensure the removal of any existing `.NET` installation. In Ubuntu, this can be done with
+    the following command:
+
+    .. code::
+
+        sudo apt remove dotnet* aspnetcore* netstandard*
+
+    2. Create a preference file in `/etc/apt/preferences.d`, for example `microsoft-dotnet.pref`,
+    with the following content:
+
+    .. code::
+
+        Package: dotnet* aspnet* netstandard*
+        Pin: origin "archive.ubuntu.com"
+        Pin-Priority: -10
+
+        Package: dotnet* aspnet* netstandard*
+        Pin: origin "security.ubuntu.com"
+        Pin-Priority: -10
+
+    3. Perform an update and install of the version you want, for example .NET 6.0 or 8.0
+
+    .. code::
+
+        sudo apt update && sudo apt install -y dotnet-sdk-6.0
+
 Other changes in release 1.0
 ============================
 

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -24,7 +24,7 @@ DesignXploration
 docstring
 [Dd]ocstrings
 doppler
-dotnet
+[Dd]otnet
 EDB
 EDT
 efields
@@ -58,6 +58,7 @@ netlist
 Nexxim
 numpy
 numpydoc
+openssl
 [Oo]ptimetrics
 padstack
 padstacks

--- a/src/ansys/aedt/core/__init__.py
+++ b/src/ansys/aedt/core/__init__.py
@@ -37,6 +37,13 @@ PYTHON_VERSION_WARNING = (
     "take full advantage of the latest features and improvements, we strongly "
     "recommend updating the Python version being used."
 )
+DOTNET_LINUX_WARNING = (
+    "Due to compatibility issues between .NET Core and libssl on some Linux versions, "
+    "for example Ubuntu 22.04, we are going to stop depending on `dotnetcore2`."
+    "Instead of using this package which embeds .NET Core 3, users will be required to "
+    "install .NET themselves. For more information, see "
+    "https://aedt.docs.pyansys.com/version/stable/release_1_0.html#dotnet-changes-in-linux"
+)
 
 
 def deprecation_warning():

--- a/src/ansys/aedt/core/generic/clr_module.py
+++ b/src/ansys/aedt/core/generic/clr_module.py
@@ -23,50 +23,91 @@
 # SOFTWARE.
 
 import os
+from pathlib import Path
 import pkgutil
 import sys
 import warnings
 
+import ansys.aedt.core
 from ansys.aedt.core.aedt_logger import pyaedt_logger as logger
 
+existing_showwarning = warnings.showwarning
+
+
+def custom_show_warning(message, category, filename, lineno, file=None, line=None):
+    """Custom warning used to remove <stdin>:loc: pattern."""
+    print(f"{category.__name__}: {message}")
+
+
+warnings.showwarning = custom_show_warning
+
 modules = [tup[1] for tup in pkgutil.iter_modules()]
-pyaedt_path = os.path.dirname(os.path.dirname(__file__))
 cpython = "IronPython" not in sys.version and ".NETFramework" not in sys.version
 is_linux = os.name == "posix"
 is_windows = not is_linux
 is_clr = False
-sys.path.append(os.path.join(pyaedt_path, "dlls", "PDFReport"))
-if is_linux and cpython:  # pragma: no cover
-    try:
-        if os.environ.get("DOTNET_ROOT") is None:
-            runtime = None
-            try:
-                import dotnet
+pyaedt_path = Path(ansys.aedt.core.__file__).parent
 
-                runtime = os.path.join(os.path.dirname(dotnet.__path__))
-            except Exception:
-                import dotnetcore2
+if is_linux and cpython:
+    from pythonnet import load
 
-                runtime = os.path.join(os.path.dirname(dotnetcore2.__file__), "bin")
-            finally:
-                os.environ["DOTNET_ROOT"] = runtime
+    dotnet_root = None
+    runtime_config = None
+    # Use system .NET core runtime or fall back to dotnetcore2
+    if os.environ.get("DOTNET_ROOT") is None:
+        try:
+            from clr_loader import get_coreclr
 
-        from pythonnet import load
+            runtime = get_coreclr()
+            load(runtime)
+            os.environ["DOTNET_ROOT"] = runtime.dotnet_root.as_posix()
+            is_clr = True
+        # TODO: Fall backing to dotnetcore2 should be removed in a near future.
+        except Exception:
+            warnings.warn(
+                "Unable to set .NET root and locate the runtime configuration file. "
+                "Falling back to using dotnetcore2."
+            )
+            warnings.warn(ansys.aedt.core.DOTNET_LINUX_WARNING)
 
-        json_file = os.path.abspath(os.path.join(pyaedt_path, "misc", "pyaedt.runtimeconfig.json"))
-        load("coreclr", runtime_config=json_file, dotnet_root=os.environ["DOTNET_ROOT"])
-        print("DotNet Core correctly loaded.")
-        if "mono" not in os.getenv("LD_LIBRARY_PATH", ""):
-            warnings.warn("LD_LIBRARY_PATH needs to be setup to use pyaedt.")
-            warnings.warn("export ANSYSEM_ROOT232=/path/to/AnsysEM/v232/Linux64")
-            msg = "export LD_LIBRARY_PATH="
-            msg += "$ANSYSEM_ROOT232/common/mono/Linux64/lib64:$LD_LIBRARY_PATH"
-            msg += "If PyAEDT will run on AEDT<2023.2 then $ANSYSEM_ROOT222/Delcross should be added to LD_LIBRARY_PATH"
+            import dotnetcore2
+
+            dotnet_root = Path(dotnetcore2.__file__).parent / "bin"
+            runtime_config = pyaedt_path / "misc" / "pyaedt.runtimeconfig.json"
+    # Use specified .NET root folder
+    else:
+        dotnet_root = Path(os.environ["DOTNET_ROOT"])
+        # Patch the case where DOTNET_ROOT leads to dotnetcore2.
+        # TODO: Remove once dotnetcore2 is deprecated
+        if dotnet_root.parent.name == "dotnetcore2":
+            runtime_config = pyaedt_path / "misc" / "pyaedt.runtimeconfig.json"
+        else:
+            from clr_loader import find_runtimes
+
+            candidates = [rt for rt in find_runtimes() if rt.name == "Microsoft.NETCore.App"]
+            candidates.sort(key=lambda spec: spec.version, reverse=True)
+            if not candidates:
+                raise RuntimeError(
+                    "Configuration file could not be found from DOTNET_ROOT. "
+                    "Please ensure that .NET SDK is correctly installed or "
+                    "that DOTNET_ROOT is correctly set."
+                )
+            runtime_config = candidates[0]
+    # Use specific .NET core runtime
+    if dotnet_root is not None and runtime_config is not None:
+        try:
+            load("coreclr", runtime_config=str(runtime_config), dotnet_root=str(dotnet_root))
+            os.environ["DOTNET_ROOT"] = dotnet_root.as_posix()
+            if "mono" not in os.getenv("LD_LIBRARY_PATH", ""):
+                warnings.warn("LD_LIBRARY_PATH needs to be setup to use pyaedt.")
+                warnings.warn("export ANSYSEM_ROOT242=/path/to/AnsysEM/v242/Linux64")
+                msg = "export LD_LIBRARY_PATH="
+                msg += "$ANSYSEM_ROOT242/common/mono/Linux64/lib64:$LD_LIBRARY_PATH"
+                warnings.warn(msg)
+            is_clr = True
+        except ImportError:
+            msg = "pythonnet or dotnetcore not installed. PyAEDT will work only in client mode."
             warnings.warn(msg)
-        is_clr = True
-    except ImportError:
-        msg = "pythonnet or dotnetcore not installed. Pyaedt will work only in client mode."
-        warnings.warn(msg)
 else:
     try:
         from pythonnet import load
@@ -77,9 +118,8 @@ else:
     except Exception:
         logger.error("An error occurred while loading clr.")
 
-
-try:  # work around a number formatting bug in the EDB API for non-English locales
-    # described in #1980
+# Work around a number formatting bug in the EDB API for non-English locales, see #1980
+try:
     import clr as _clr  # isort:skip
     from System.Globalization import CultureInfo as _CultureInfo
 
@@ -93,15 +133,10 @@ try:  # work around a number formatting bug in the EDB API for non-English local
     from System.Collections.Generic import List
 
     edb_initialized = True
-
 except ImportError:  # pragma: no cover
     if is_windows:
-        warnings.warn(
-            "The clr is missing. Install PythonNET or use an IronPython version if you want to use the EDB module."
-        )
+        warnings.warn("The clr is missing.")
         edb_initialized = False
-    elif sys.version[0] == 3 and sys.version[1] < 7:
-        warnings.warn("EDB requires Linux Python 3.7 or later.")
     _clr = None
     String = None
     Double = None
@@ -111,6 +146,7 @@ except ImportError:  # pragma: no cover
     Dictionary = None
     Array = None
     edb_initialized = False
+
 if "win32com" in modules:
     try:
         import win32com.client as win32_client

--- a/src/ansys/aedt/core/generic/clr_module.py
+++ b/src/ansys/aedt/core/generic/clr_module.py
@@ -36,7 +36,7 @@ existing_showwarning = warnings.showwarning
 
 def custom_show_warning(message, category, filename, lineno, file=None, line=None):
     """Custom warning used to remove <stdin>:loc: pattern."""
-    print(f"{category.__name__}: {message}")
+    print(f"{category.__name__}: {message}", file=file or sys.stderr)
 
 
 warnings.showwarning = custom_show_warning

--- a/src/ansys/aedt/core/generic/clr_module.py
+++ b/src/ansys/aedt/core/generic/clr_module.py
@@ -155,3 +155,5 @@ if "win32com" in modules:
             import win32com.client as win32_client
         except ImportError:
             win32_client = None
+
+warnings.showwarning = existing_showwarning

--- a/tests/unit/test_clr_module.py
+++ b/tests/unit/test_clr_module.py
@@ -108,7 +108,6 @@ def test_use_dotnet_root_env_variable_success_dotnetcore2(mock_warn, mock_load, 
     assert cm.is_clr
     assert DOTNETCORE2_BIN == os.environ["DOTNET_ROOT"]
     assert all(DOTNET_LINUX_WARNING not in call.args for call in mock_warn.call_args_list)
-    exit([call for call in mock_warn.call_args_list])
 
 
 @pytest.mark.skipif(os.name != "posix", reason="test for linux behavior")

--- a/tests/unit/test_clr_module.py
+++ b/tests/unit/test_clr_module.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from ansys.aedt.core import DOTNET_LINUX_WARNING
+import pytest
+
+DOTNET_ROOT = "dummy/root/path"
+DOTNET_ROOT_PATH = Path(DOTNET_ROOT)
+DOTNETCORE2_FILE = "dummy/dotnetcore2/file"
+DOTNETCORE2_BIN = "dummy/dotnetcore2/bin"
+PYAEDT_FILE = "dummy/pyaedt/file"
+
+
+@pytest.fixture
+def clean_environment():
+    initial_sys_modules = sys.modules.copy()
+    initial_os_environ = os.environ.copy()
+
+    if "ansys.aedt.core.generic.clr_module" in sys.modules:
+        del sys.modules["ansys.aedt.core.genericclr_module"]
+    if "DOTNET_ROOT" in os.environ:
+        del os.environ["DOTNET_ROOT"]
+
+    yield
+
+    sys.modules.clear()
+    sys.modules.update(initial_sys_modules)
+    os.environ.clear()
+    os.environ.update(initial_os_environ)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="test for linux behavior")
+@patch("pythonnet.load")
+@patch("clr_loader.get_coreclr")
+def test_use_system_dotnet(mock_get_coreclr, mock_load, clean_environment):
+    mock_runtime = MagicMock()
+    mock_runtime.dotnet_root = DOTNET_ROOT_PATH
+    mock_get_coreclr.return_value = mock_runtime
+
+    import ansys.aedt.core.generic.clr_module as cm
+
+    assert cm.is_clr
+    assert DOTNET_ROOT_PATH.as_posix() == os.environ["DOTNET_ROOT"]
+    del os.environ["DOTNET_ROOT"]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="test for linux behavior")
+@patch("dotnetcore2.__file__", new=DOTNETCORE2_FILE)
+@patch("pythonnet.load")
+@patch("clr_loader.get_coreclr", side_effect=Exception("Dummy exception"))
+def test_use_dotnetcore2(mock_get_coreclr, mock_load, clean_environment, capsys):
+    import ansys.aedt.core.generic.clr_module as cm
+
+    captured = capsys.readouterr()
+
+    assert cm.is_clr
+    assert DOTNETCORE2_BIN == os.environ["DOTNET_ROOT"]
+    assert DOTNET_LINUX_WARNING in captured.out
+
+
+@pytest.mark.skipif(os.name != "posix", reason="test for linux behavior")
+@patch("dotnetcore2.__file__", new=DOTNETCORE2_FILE)
+@patch("pythonnet.load")
+@patch("clr_loader.find_runtimes", return_value=[])
+def test_use_dotnet_root_env_variable_failure(mock_find_runtimes, mock_load, clean_environment, capsys):
+    os.environ["DOTNET_ROOT"] = DOTNET_ROOT
+
+    with pytest.raises(RuntimeError):
+        import ansys.aedt.core.generic.clr_module  # noqa: F401
+
+
+@pytest.mark.skipif(os.name != "posix", reason="test for linux behavior")
+@patch("dotnetcore2.__file__", new=DOTNETCORE2_FILE)
+@patch("pythonnet.load")
+def test_use_dotnet_root_env_variable_success_dotnetcore2(mock_load, clean_environment, capsys):
+    os.environ["DOTNET_ROOT"] = DOTNETCORE2_BIN
+
+    import ansys.aedt.core.generic.clr_module as cm
+
+    captured = capsys.readouterr()
+
+    assert cm.is_clr
+    assert DOTNETCORE2_BIN == os.environ["DOTNET_ROOT"]
+    assert DOTNET_LINUX_WARNING not in captured.out
+
+
+@pytest.mark.skipif(os.name != "posix", reason="test for linux behavior")
+@patch("dotnetcore2.__file__", new=DOTNETCORE2_FILE)
+@patch("pythonnet.load")
+@patch("clr_loader.find_runtimes")
+def test_use_dotnet_root_env_variable_success(mock_find_runtimes, mock_load, clean_environment, capsys):
+    os.environ["DOTNET_ROOT"] = DOTNET_ROOT
+    mock_runtime = MagicMock()
+    mock_runtime.name = "Microsoft.NETCore.App"
+    mock_find_runtimes.return_value = [mock_runtime]
+
+    import ansys.aedt.core.generic.clr_module  # noqa: F401
+
+    assert os.environ["DOTNET_ROOT"]


### PR DESCRIPTION
## Description
To improve compatibility with system libraries in Linux, the Python package `dotnetcore2` should be removed from PyAEDT's dotnet installation target. Indeed, the embedded version of `.NET` associated to `dotnetcore2` is old and has **incompatibilities** with recent versions of `openssl` such as the one installed by default in Ubuntu 22.04.

This PR propose to add this modification to the breaking changes of release v1.0 and, in the mean time, to allow users to:
- use a .NET runtime that they have installed instead of the one embedded in `dotnetcore2`
- fallback to the `dotnetcore2` approach if no .NET runtime is detected / provided through environment variable (DOTNET_ROOT).

## Issue linked
See #5554

---

> [!NOTE]  
Tests implementation differs from pyedb since pyaedt has a `filterwarnings` option for pytest.

---

> [!WARNING]  
**DO NOT MERGE until feedback is provided**
