### PR TITLE
FIX: Allow non graphical mode for Import GDSII in 3D

### DIFF
--- a/src/ansys/aedt/core/application/analysis_3d.py
+++ b/src/ansys/aedt/core/application/analysis_3d.py
@@ -1333,7 +1333,7 @@ class FieldAnalysis3D(Analysis, object):
         >>> oEditor.ImportDXF
 
         """
-        if self.desktop_class.non_graphical and self.desktop_class.aedt_version_id < "2024.2":
+        if self.desktop_class.non_graphical and self.desktop_class.aedt_version_id < "2024.2":  # pragma: no cover
             self.logger.error("Method is supported only in graphical mode.")
             return False
         dxf_layers = self.get_dxf_layers(file_path)
@@ -1376,7 +1376,7 @@ class FieldAnalysis3D(Analysis, object):
         return True
 
     @pyaedt_function_handler(gds_file="input_file", gds_number="mapping_layers", unit="units")
-    def import_gds_3d(self, input_file, mapping_layers, units="um", import_method=1):  # pragma: no cover
+    def import_gds_3d(self, input_file: str, mapping_layers: dict, units: str = "um", import_method: int = 1) -> bool:
         """Import a GDSII file.
 
         Parameters
@@ -1385,7 +1385,7 @@ class FieldAnalysis3D(Analysis, object):
             Path to the GDS file.
         mapping_layers : dict
             Dictionary keys are GDS layer numbers, and the value is a tuple with the thickness and elevation.
-        units : string, optional
+        units : str, optional
             Length unit values. The default is ``"um"``.
         import_method : integer, optional
             GDSII import method. The default is ``1``. Options are:
@@ -1414,7 +1414,7 @@ class FieldAnalysis3D(Analysis, object):
 
         """
 
-        if self.desktop_class.non_graphical:
+        if self.desktop_class.non_graphical and self.desktop_class.aedt_version_id < "2024.1":  # pragma: no cover
             self.logger.error("Method is supported only in graphical mode.")
             return False
         if not os.path.exists(input_file):

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -1698,13 +1698,17 @@ class TestClass:
         assert aedtapp.solution_type == "Transient Composite"
         aedtapp.close_project(save=False)
 
-    @pytest.mark.skipif(config["NonGraphical"], reason="Test fails on build machine")
     def test_68_import_gds_3d(self):
         self.aedtapp.insert_design("gds_import_H3D")
         gds_file = os.path.join(TESTS_GENERAL_PATH, "example_models", "cad", "GDS", "gds1.gds")
         assert self.aedtapp.import_gds_3d(gds_file, {7: (100, 10), 9: (110, 5)})
+        assert len(self.aedtapp.modeler.solid_names) == 3
+        assert len(self.aedtapp.modeler.sheet_names) == 0
         assert self.aedtapp.import_gds_3d(gds_file, {7: (0, 0), 9: (0, 0)})
+        assert len(self.aedtapp.modeler.sheet_names) == 3
         assert self.aedtapp.import_gds_3d(gds_file, {7: (100e-3, 10e-3), 9: (110e-3, 5e-3)}, "mm", 0)
+        assert len(self.aedtapp.modeler.solid_names) == 6
+        self.aedtapp.save_project(r"C:\Users\slopez\Downloads\test.aedt")
         assert not self.aedtapp.import_gds_3d(gds_file, {})
         gds_file = os.path.join(TESTS_GENERAL_PATH, "example_models", "cad", "GDS", "gds1not.gds")
         assert not self.aedtapp.import_gds_3d(gds_file, {7: (100, 10), 9: (110, 5)})

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -1708,7 +1708,6 @@ class TestClass:
         assert len(self.aedtapp.modeler.sheet_names) == 3
         assert self.aedtapp.import_gds_3d(gds_file, {7: (100e-3, 10e-3), 9: (110e-3, 5e-3)}, "mm", 0)
         assert len(self.aedtapp.modeler.solid_names) == 6
-        self.aedtapp.save_project(r"C:\Users\slopez\Downloads\test.aedt")
         assert not self.aedtapp.import_gds_3d(gds_file, {})
         gds_file = os.path.join(TESTS_GENERAL_PATH, "example_models", "cad", "GDS", "gds1not.gds")
         assert not self.aedtapp.import_gds_3d(gds_file, {7: (100, 10), 9: (110, 5)})


### PR DESCRIPTION
## Description
From 2024R1, AEDT API allows the import of GDSII in non-graphical mode.

## Issue linked
Close #5567 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
