### PR TITLE
FIX: Temporary avoid attrs v24.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
     "tomli-w",
     "rpyc>=6.0.0,<6.1",
     "pyyaml",
-    "defusedxml>=0.7,<8.0"
+    "defusedxml>=0.7,<8.0",
+    "attrs!=24.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description
Temporary solution for the packaging issue in CICD. This PR should be reverted at some point once `attrs` gets a new release with license available on PyPI.

## Issue linked
Here is the issue associated to our CICD failure  https://github.com/python-attrs/attrs/issues/1386
