### PR TITLE
REFACTOR: Deprecate props and use properties

### DIFF
--- a/src/ansys/aedt/core/modeler/cad/elements_3d.py
+++ b/src/ansys/aedt/core/modeler/cad/elements_3d.py
@@ -24,6 +24,8 @@
 
 from __future__ import absolute_import
 
+import warnings
+
 from ansys.aedt.core.generic.general_methods import _dim_arg
 from ansys.aedt.core.generic.general_methods import clamp
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
@@ -1434,6 +1436,17 @@ class BinaryTreeNode:
             if name == "CreatePolyline:1":
                 self.segments = self.children[name].children
             del self.children[name]
+
+    @property
+    def props(self):
+        """Properties data.
+
+        Returns
+        -------
+        :class:``ansys.aedt.coree.modeler.cad.elements_3d.HistoryProps``
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
 
     @property
     def properties(self):

--- a/src/ansys/aedt/core/modeler/cad/modeler.py
+++ b/src/ansys/aedt/core/modeler/cad/modeler.py
@@ -30,7 +30,9 @@ This modules provides functionalities for the 3D Modeler, 2D Modeler,
 3D Layout Modeler, and Circuit Modeler.
 """
 
-from __future__ import absolute_import  # noreorder
+from __future__ import absolute_import
+
+import warnings  # noreorder
 
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.general_methods import PropsManager
@@ -439,11 +441,22 @@ class FaceCoordinateSystem(BaseCoordinateSystem, object):
 
     @property
     def props(self):
-        """Properties of the coordinate system.
+        """Coordinate system properties.
 
         Returns
         -------
-        :class:`ansys.aedt.core.modeler.Modeler.CSProps`
+        :class:`ansys.aedt.core.modeler.cad.modeler.CsProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """Coordinate system properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modeler.cad.modeler.CsProps`
         """
         if self._props or settings.aedt_version <= "2022.2" or self.name is None:
             return self._props
@@ -733,11 +746,22 @@ class CoordinateSystem(BaseCoordinateSystem, object):
 
     @property
     def props(self):
+        """Coordinate system properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modeler.cad.modeler.CsProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
         """Coordinate System Properties.
 
         Returns
         -------
-        :class:`ansys.aedt.core.modeler.Modeler.CSProps`
+        :class:`ansys.aedt.core.modeler.cad.modeler.CsProps`
         """
         if self._props or settings.aedt_version <= "2022.2" or self.name is None:
             return self._props
@@ -1269,11 +1293,22 @@ class ObjectCoordinateSystem(BaseCoordinateSystem, object):
 
     @property
     def props(self):
-        """Properties of the coordinate system.
+        """Coordinate system properties.
 
         Returns
         -------
-        :class:`ansys.aedt.core.modeler.Modeler.CSProps`
+        :class:`ansys.aedt.core.modeler.cad.modeler.CsProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """Coordinate system properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modeler.cad.modeler.CsProps`
         """
         if self._props or settings.aedt_version <= "2022.2" or self.name is None:
             return self._props

--- a/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
@@ -25,6 +25,7 @@
 import math
 import os
 import secrets
+import warnings
 
 from ansys.aedt.core.application.variables import decompose_variable_value
 from ansys.aedt.core.generic.constants import AEDT_UNITS
@@ -1268,7 +1269,13 @@ class ComponentInfo(object):
 
     @property
     def props(self):
-        """Retrieve the component properties."""
+        """Component properties."""
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """Component properties."""
         if not self._props:
             self._props = load_keyword_in_aedt_file(self.file_name, self.name)
         return self._props

--- a/src/ansys/aedt/core/modeler/circuits/primitives_emit.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_emit.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 
 from collections import defaultdict
+import warnings
 
 from ansys.aedt.core.emit_core import emit_constants as emit_consts
 import ansys.aedt.core.generic.constants as consts
@@ -1023,16 +1024,25 @@ class EmitComponentPropNode(object):
 
     @property
     def props(self):
-        """Returns a dictionary of all the properties for this node.
-
-        Parameters
-        ----------
-        None
+        """Node properties
 
         Returns
         -------
         Dict
-            Dictionary of all the properties for this node."""
+            Dictionary of all the properties for this node.
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """Node properties
+
+        Returns
+        -------
+        Dict
+            Dictionary of all the properties for this node.
+        """
         prop_list = self.odesign.GetComponentNodeProperties(self.parent_component.name, self.node_name)
         props = dict(p.split("=", 1) for p in prop_list)
         return props

--- a/src/ansys/aedt/core/modules/boundary/common.py
+++ b/src/ansys/aedt/core/modules/boundary/common.py
@@ -26,6 +26,8 @@
 This module contains these classes: ``BoundaryCommon`` and ``BoundaryObject``.
 """
 
+import warnings
+
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.general_methods import PropsManager
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
@@ -271,7 +273,18 @@ class BoundaryObject(BoundaryCommon, BinaryTreeNode):
 
         Returns
         -------
-        :class:BoundaryProps
+        :class:`ansys.aedt.core.modules.boundary.common.BoundaryProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """Boundary data.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.boundary.common.BoundaryProps`
         """
         if self.__props:
             return self.__props

--- a/src/ansys/aedt/core/modules/boundary/hfss_boundary.py
+++ b/src/ansys/aedt/core/modules/boundary/hfss_boundary.py
@@ -22,6 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import warnings
+
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.general_methods import _dim_arg
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
@@ -58,6 +60,23 @@ class FieldSetup(BoundaryCommon, BinaryTreeNode):
 
     @property
     def props(self):
+        """AEDT boundary component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.boundary.common.BoundaryProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """AEDT boundary component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.boundary.common.BoundaryProps`
+        """
         if not self.__props and self._app.design_properties:
             if (
                 self.type == "FarFieldSphere"

--- a/src/ansys/aedt/core/modules/boundary/icepak_boundary.py
+++ b/src/ansys/aedt/core/modules/boundary/icepak_boundary.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 from abc import abstractmethod
 import copy
+import warnings
 
 from ansys.aedt.core.application.variables import decompose_variable_value
 from ansys.aedt.core.generic.general_methods import generate_unique_name
@@ -58,7 +59,23 @@ class BoundaryDictionary:
 
     @property
     def props(self):
-        """Dictionary that defines all the boundary condition properties."""
+        """Dictionary that defines all the boundary condition properties.
+
+        Returns
+        -------
+        dict
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """Dictionary that defines all the boundary condition properties.
+
+        Returns
+        -------
+        dict
+        """
         return {
             "Type": self.assignment_type,
             "Function": self.function_type,
@@ -1056,8 +1073,21 @@ class NetworkObject(BoundaryObject):
 
         @property
         def props(self):
+            """Link properties.
+
+            Returns
+            -------
+            list
+                First two elements of the list are the node names that the link connects,
+                the third element is the link type while the fourth contains the value
+                associated with the link.
             """
-            Get link properties.
+            warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+            return self.properties
+
+        @property
+        def properties(self):
+            """Link properties.
 
             Returns
             -------
@@ -1116,7 +1146,19 @@ class NetworkObject(BoundaryObject):
 
         @property
         def props(self):
-            """Get properties of the node.
+            """Node properties.
+
+            Returns
+            -------
+            dict
+                Node properties.
+            """
+            warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+            return self.properties
+
+        @property
+        def properties(self):
+            """Node properties.
 
             Returns
             -------
@@ -1127,7 +1169,19 @@ class NetworkObject(BoundaryObject):
 
         @props.setter
         def props(self, props):
-            """Set properties of the node.
+            """Node properties.
+
+            Parameters
+            ----------
+            props : dict
+                Node properties.
+            """
+            warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+            self.properties = props
+
+        @properties.setter
+        def properties(self, props):
+            """Node properties.
 
             Parameters
             ----------

--- a/src/ansys/aedt/core/modules/boundary/layout_boundary.py
+++ b/src/ansys/aedt/core/modules/boundary/layout_boundary.py
@@ -22,6 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import warnings
+
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.data_handlers import random_string
 from ansys.aedt.core.generic.general_methods import GrpcApiError
@@ -111,6 +113,17 @@ class NativeComponentObject(BoundaryCommon, BinaryTreeNode):
 
     @property
     def props(self):
+        """AEDT boundary component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.boundary.common.BoundaryProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
         return self.__props
 
     @property
@@ -331,7 +344,18 @@ class BoundaryObject3dLayout(BoundaryCommon, BinaryTreeNode):
 
         Returns
         -------
-        :class:BoundaryProps
+        :class:`ansys.aedt.core.modules.boundary.common.BoundaryProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """Excitation data.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.boundary.common.BoundaryProps`
         """
         if self.__props:
             return self.__props

--- a/src/ansys/aedt/core/modules/boundary/maxwell_boundary.py
+++ b/src/ansys/aedt/core/modules/boundary/maxwell_boundary.py
@@ -22,6 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import warnings
+
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
@@ -108,6 +110,17 @@ class MaxwellParameters(BoundaryCommon, BinaryTreeNode):
 
     @property
     def props(self):
+        """Maxwell parameter data.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.boundary.common.BoundaryProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
         """Maxwell parameter data.
 
         Returns

--- a/src/ansys/aedt/core/modules/mesh.py
+++ b/src/ansys/aedt/core/modules/mesh.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import  # noreorder
 
 import os
 import shutil
+import warnings
 
 from ansys.aedt.core.application.design_solutions import model_names
 from ansys.aedt.core.generic.data_handlers import _dict2arg
@@ -139,6 +140,23 @@ class MeshOperation(BinaryTreeNode):
 
     @property
     def props(self):
+        """AEDT mesh component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.mesh.MeshProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """AEDT mesh component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.mesh.MeshProps`
+        """
         if not self._legacy_props:
             props = {}
             for k, v in self.properties.items():

--- a/src/ansys/aedt/core/modules/solve_setup.py
+++ b/src/ansys/aedt/core/modules/solve_setup.py
@@ -208,6 +208,23 @@ class CommonSetup(PropsManager, BinaryTreeNode):
 
     @property
     def props(self):
+        """AEDT boundary component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.solve_sweeps.SetupProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """AEDT boundary component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.solve_sweeps.SetupProps`
+        """
         if self._legacy_props:
             return self._legacy_props
         if self._is_new_setup:
@@ -231,6 +248,13 @@ class CommonSetup(PropsManager, BinaryTreeNode):
 
     @props.setter
     def props(self, value):
+        """AEDT boundary component internal properties."""
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        self.properties = value
+
+    @properties.setter
+    def properties(self, value):
+        """AEDT boundary component internal properties."""
         self._legacy_props = SetupProps(self, value)
 
     @property
@@ -1113,6 +1137,23 @@ class SetupCircuit(CommonSetup):
 
     @property
     def props(self):
+        """AEDT boundary component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.solve_sweeps.SetupProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """AEDT boundary component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.solve_sweeps.SetupProps`
+        """
         if self._legacy_props:
             return self._legacy_props
         if self._is_new_setup:
@@ -1826,6 +1867,23 @@ class Setup3DLayout(CommonSetup):
 
     @property
     def props(self):
+        """AEDT boundary component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.solve_sweeps.SetupProps`
+        """
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        return self.properties
+
+    @property
+    def properties(self):
+        """AEDT boundary component internal properties.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.solve_sweeps.SetupProps`
+        """
         if self._legacy_props:
             return self._legacy_props
         if self._is_new_setup:
@@ -1847,6 +1905,13 @@ class Setup3DLayout(CommonSetup):
 
     @props.setter
     def props(self, value):
+        """AEDT boundary component internal properties."""
+        warnings.warn("This method is deprecated. Use properties instead.", DeprecationWarning)
+        self.properties = value
+
+    @properties.setter
+    def properties(self, value):
+        """AEDT boundary component internal properties."""
         self._legacy_props = SetupProps(self, value)
 
     @property


### PR DESCRIPTION
## Description
Follow up of #5488 where a part of the changes broke an example, see https://github.com/ansys/pyaedt-examples/issues/287
Note that the changes from `props` to `properties` make total sense so I applied the same logic on other classes.
Among changes, I also added documentation improvements.

## Issue linked
https://github.com/ansys/pyaedt-examples/issues/287
