### PR TITLE
aligns elevation and thickness parameter order in documentation with code for `import_gds_3d`

### DIFF
--- a/src/ansys/aedt/core/application/analysis_3d.py
+++ b/src/ansys/aedt/core/application/analysis_3d.py
@@ -1377,7 +1377,7 @@ class FieldAnalysis3D(Analysis, object):
         input_file : str
             Path to the GDS file.
         mapping_layers : dict
-            Dictionary keys are GDS layer numbers, and the value is a tuple with the thickness and elevation.
+            Dictionary keys are GDS layer numbers, and the value is a tuple with the elevation and thickness.
         units : str, optional
             Length unit values. The default is ``"um"``.
         import_method : integer, optional


### PR DESCRIPTION
## Description

elevation and thickness order in `import_gds_3d` is interchanged with might be misleading. I aligned the order to the order in the [code](https://github.com/ansys/pyaedt/blob/84a7b79702c2c45a48cc5501a20ebb741eeb1119/src/ansys/aedt/core/application/analysis_3d.py#L1445). 

## Issue linked

N/A

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
