### PR TITLE
DOCS: Update ParametricSetups docstring

### DIFF
--- a/src/ansys/aedt/core/modules/design_xploration.py
+++ b/src/ansys/aedt/core/modules/design_xploration.py
@@ -1162,10 +1162,13 @@ class ParametricSetups(object):
             Variation Start Point if a variation is defined or Single Value.
         end_point : float or int, optional
             Variation End Point. This parameter is optional if a Single Value is defined.
-        step : float or int
-            Variation Step or Count depending on variation_type. The default is ``100``.
+        step : float, int, or str
+            Variation Step or Count depending on variation_type. The default is ``100``
+            for the "LinearCount" variation_type. If a string is passed as an argument, it
+            must be a valid expression in the given context. For example, "0.1mm" may be passed
+            for a step size when the variation_type is "LinearStep".
         variation_type : str, optional
-            Variation Type. Admitted values are `"LinearCount"`, `"LinearStep"`, `"LogScale"`, `"SingleValue"`.
+            Variation Type. Permitted values are `"LinearCount"`, `"LinearStep"`, `"LogScale"`, `"SingleValue"`.
         solution : str, optional
             Type of the solution. The default is ``None``, in which case the default
             solution is used.


### PR DESCRIPTION
## Description

The ParametricSetup docstring was updated to allow strings as passed
parameters in the correct context.
## Issue linked
Close Issue #5616

## Checklist

This is a documentation issue.

