### PR TITLE
FEAT: Add min version decorator

### DIFF
--- a/src/ansys/aedt/core/application/analysis_3d.py
+++ b/src/ansys/aedt/core/application/analysis_3d.py
@@ -1144,6 +1144,7 @@ class FieldAnalysis3D(Analysis, object):
         return True
 
     @pyaedt_function_handler(object_name="assignment")
+    @min_aedt_version("2023.2")
     def identify_touching_conductors(self, assignment=None):
         # type: (str) -> dict
         """Identify all touching components and group in a dictionary.
@@ -1160,7 +1161,7 @@ class FieldAnalysis3D(Analysis, object):
         dict
 
         """
-        if settings.aedt_version >= "2023.2" and self.design_type == "HFSS":  # pragma: no cover
+        if self.design_type == "HFSS":  # pragma: no cover
             nets_aedt = self.oboundary.IdentifyNets(True)
             nets = {}
             for net in nets_aedt[1:]:

--- a/src/ansys/aedt/core/application/analysis_3d.py
+++ b/src/ansys/aedt/core/application/analysis_3d.py
@@ -27,6 +27,7 @@ import ntpath
 import os
 
 from ansys.aedt.core.application.analysis import Analysis
+from ansys.aedt.core.generic.checks import min_aedt_version
 from ansys.aedt.core.generic.configurations import Configurations
 from ansys.aedt.core.generic.constants import unit_converter
 from ansys.aedt.core.generic.general_methods import generate_unique_name
@@ -224,6 +225,7 @@ class FieldAnalysis3D(Analysis, object):
         return components_dict
 
     @pyaedt_function_handler(objects="assignment", export_path="output_file")
+    @min_aedt_version("2021.2")
     def plot(
         self,
         assignment=None,
@@ -280,23 +282,20 @@ class FieldAnalysis3D(Analysis, object):
         :class:`ansys.aedt.core.generic.plot.ModelPlotter`
             Model Object.
         """
-        if self._aedt_version < "2021.2":
-            self.logger.warning("Plot is supported from AEDT 2021 R2.")
-        else:
-            return self.post.plot_model_obj(
-                objects=assignment,
-                show=show,
-                export_path=output_file,
-                plot_as_separate_objects=plot_as_separate_objects,
-                plot_air_objects=plot_air_objects,
-                force_opacity_value=force_opacity_value,
-                clean_files=clean_files,
-                view=view,
-                show_legend=show_legend,
-                dark_mode=dark_mode,
-                show_bounding=show_bounding,
-                show_grid=show_grid,
-            )
+        return self.post.plot_model_obj(
+            objects=assignment,
+            show=show,
+            export_path=output_file,
+            plot_as_separate_objects=plot_as_separate_objects,
+            plot_air_objects=plot_air_objects,
+            force_opacity_value=force_opacity_value,
+            clean_files=clean_files,
+            view=view,
+            show_legend=show_legend,
+            dark_mode=dark_mode,
+            show_bounding=show_bounding,
+            show_grid=show_grid,
+        )
 
     @pyaedt_function_handler(setup_name="setup", variation_string="variations")
     def export_mesh_stats(self, setup, variations="", mesh_path=None):
@@ -1161,9 +1160,6 @@ class FieldAnalysis3D(Analysis, object):
         dict
 
         """
-        if settings.aedt_version < "2023.2":  # pragma: no cover
-            self.logger.error("This method requires CPython and PyVista.")
-            return {}
         if settings.aedt_version >= "2023.2" and self.design_type == "HFSS":  # pragma: no cover
             nets_aedt = self.oboundary.IdentifyNets(True)
             nets = {}

--- a/src/ansys/aedt/core/application/design.py
+++ b/src/ansys/aedt/core/application/design.py
@@ -68,7 +68,7 @@ from ansys.aedt.core.generic.aedt_versions import aedt_versions
 from ansys.aedt.core.generic.constants import AEDT_UNITS
 from ansys.aedt.core.generic.constants import unit_system
 from ansys.aedt.core.generic.data_handlers import variation_string_to_dict
-from ansys.aedt.core.generic.general_methods import GrpcApiError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import check_and_download_file
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import inner_project_settings

--- a/src/ansys/aedt/core/application/variables.py
+++ b/src/ansys/aedt/core/application/variables.py
@@ -50,7 +50,7 @@ from ansys.aedt.core.generic.constants import AEDT_UNITS
 from ansys.aedt.core.generic.constants import SI_UNITS
 from ansys.aedt.core.generic.constants import _resolve_unit_system
 from ansys.aedt.core.generic.constants import unit_system
-from ansys.aedt.core.generic.general_methods import GrpcApiError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import check_numeric_equivalence
 from ansys.aedt.core.generic.general_methods import is_array
 from ansys.aedt.core.generic.general_methods import is_number

--- a/src/ansys/aedt/core/emit_core/couplings.py
+++ b/src/ansys/aedt/core/emit_core/couplings.py
@@ -27,7 +27,7 @@ This module contains these classes: `CouplingsEmit`.
 This module provides for interacting with EMIT Analysis and Results windows.
 """
 
-import warnings
+from ansys.aedt.core.generic.checks import min_aedt_version
 
 
 class CouplingsEmit(object):
@@ -156,8 +156,11 @@ class CouplingsEmit(object):
             self._odesign.UpdateLink(coupling_name)
 
     @property
+    @min_aedt_version("2022.2")
     def linkable_design_names(self):
         """List the available link names.
+
+        This property is only available in AEDT version 2022.2 or higher.
 
         Parameters
         ----------
@@ -174,12 +177,7 @@ class CouplingsEmit(object):
         >>> app = Emit("Apache with multiple links")
         >>> links = app.couplings.linkable_design_names
         """
-        desktop_version = self._desktop.GetVersion()[0:6]
-        if desktop_version >= "2022.2":
-            return self._odesign.GetAvailableLinkNames()
-        else:
-            warnings.warn("The function linkable_design_names() requires AEDT 2022 R2 or later.")
-            return []
+        return self._odesign.GetAvailableLinkNames()
 
     @property
     def cad_nodes(self):

--- a/src/ansys/aedt/core/generic/checks.py
+++ b/src/ansys/aedt/core/generic/checks.py
@@ -67,11 +67,11 @@ def min_aedt_version(min_version: str):
 
     def aedt_version_decorator(method):
         def wrapper(self, *args, **kwargs):
-            odesktop = fetch_odesktop_from_common_attributes_names(self)
-            if odesktop is None:
-                odesktop = fetch_odesktop_from_private_app_attribute(self)
-            if odesktop is None:
-                odesktop = fetch_odesktop_from_desktop_class(self)
+            odesktop = (
+                fetch_odesktop_from_common_attributes_names(self)
+                or fetch_odesktop_from_private_app_attribute(self)
+                or fetch_odesktop_from_desktop_class(self)
+            )
             if odesktop is None:
                 raise AEDTRuntimeError("The AEDT desktop object is not available.")
 

--- a/src/ansys/aedt/core/generic/checks.py
+++ b/src/ansys/aedt/core/generic/checks.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Provides functions for performing common checks."""
+
+from ansys.aedt.core.generic.errors import AEDTRuntimeError
+
+
+def min_aedt_version(min_version: str):
+    """Compare a minimum required version to the current AEDT version.
+
+    This decorator should only be used on methods where the associated object can reach the desktop instance.
+    Otherwise, there is no way to check version compatibility and an error is raised.
+
+    Parameters
+    ----------
+    min_version: str
+        Minimum AEDT version required by the method.
+        The value should follow the format YEAR.RELEASE, for example '2024.2'.
+
+    Raises
+    ------
+
+    AEDTRuntimeError
+        If the method version is higher than the AEDT version.
+    """
+
+    def aedt_version_decorator(method):
+        def wrapper(self, *args, **kwargs):
+            attributes_to_check = ["odesktop", "_odesktop", "_desktop"]
+            # Browse attributes and retrieve the first non-null value
+            available_attributes = [attr for attr in attributes_to_check if hasattr(self, attr)]
+            if not available_attributes:
+                raise AEDTRuntimeError("The desktop is not available.")
+            odesktop = next(
+                (getattr(self, attr) for attr in available_attributes if getattr(self, attr) is not None), None
+            )
+            if odesktop is not None:
+                desktop_version = odesktop.GetVersion()
+                if desktop_version < min_version:
+                    raise AEDTRuntimeError(
+                        f"The method '{method.__name__}' requires a minimum Ansys release version of "
+                        + f"{min_version}, but the current version used is {desktop_version}."
+                    )
+                else:
+                    return method(self, *args, **kwargs)
+
+        return wrapper
+
+    return aedt_version_decorator

--- a/src/ansys/aedt/core/generic/configurations.py
+++ b/src/ansys/aedt/core/generic/configurations.py
@@ -32,7 +32,7 @@ import ansys.aedt.core
 from ansys.aedt.core import __version__
 from ansys.aedt.core.application.variables import decompose_variable_value
 from ansys.aedt.core.generic.data_handlers import _arg2dict
-from ansys.aedt.core.generic.general_methods import GrpcApiError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import generate_unique_folder_name
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import open_file

--- a/src/ansys/aedt/core/generic/errors.py
+++ b/src/ansys/aedt/core/generic/errors.py
@@ -28,16 +28,10 @@
 class GrpcApiError(RuntimeError):
     """Exception raised for errors encountered while interacting with the gRPC API."""
 
-    pass
-
 
 class MethodNotSupportedError(RuntimeError):
     """Exception raised when attempting to call a method that is not supported."""
 
-    pass
-
 
 class AEDTRuntimeError(RuntimeError):
     """Exception raised for errors occurring during the runtime execution of AEDT scripts."""
-
-    pass

--- a/src/ansys/aedt/core/generic/errors.py
+++ b/src/ansys/aedt/core/generic/errors.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Provide PyAEDT errors."""
+
+
+class GrpcApiError(RuntimeError):
+    """Exception raised for errors encountered while interacting with the gRPC API."""
+
+    pass
+
+
+class MethodNotSupportedError(RuntimeError):
+    """Exception raised when attempting to call a method that is not supported."""
+
+    pass
+
+
+class AEDTRuntimeError(RuntimeError):
+    """Exception raised for errors occurring during the runtime execution of AEDT scripts."""
+
+    pass

--- a/src/ansys/aedt/core/generic/general_methods.py
+++ b/src/ansys/aedt/core/generic/general_methods.py
@@ -47,6 +47,8 @@ import traceback
 from ansys.aedt.core.aedt_logger import pyaedt_logger
 from ansys.aedt.core.generic.aedt_versions import aedt_versions
 from ansys.aedt.core.generic.constants import CSS4_COLORS
+from ansys.aedt.core.generic.errors import GrpcApiError
+from ansys.aedt.core.generic.errors import MethodNotSupportedError
 from ansys.aedt.core.generic.settings import inner_project_settings  # noqa: F401
 from ansys.aedt.core.generic.settings import settings
 import psutil
@@ -65,18 +67,6 @@ inclusion_list = [
     "ImportGerber",
     "EditSources",
 ]
-
-
-class GrpcApiError(Exception):
-    """ """
-
-    pass
-
-
-class MethodNotSupportedError(Exception):
-    """ """
-
-    pass
 
 
 def _write_mes(mes_text):

--- a/src/ansys/aedt/core/generic/grpc_plugin_dll_class.py
+++ b/src/ansys/aedt/core/generic/grpc_plugin_dll_class.py
@@ -34,7 +34,7 @@ import socket
 import time
 import types
 
-from ansys.aedt.core.generic.general_methods import GrpcApiError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import _retry_ntimes
 from ansys.aedt.core.generic.general_methods import inclusion_list
 from ansys.aedt.core.generic.general_methods import settings

--- a/src/ansys/aedt/core/hfss3dlayout.py
+++ b/src/ansys/aedt/core/hfss3dlayout.py
@@ -34,6 +34,7 @@ import re
 
 from ansys.aedt.core.application.analysis_3d_layout import FieldAnalysis3DLayout
 from ansys.aedt.core.application.analysis_hf import ScatteringMethods
+from ansys.aedt.core.generic.checks import min_aedt_version
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import open_file
 from ansys.aedt.core.generic.general_methods import parse_excitation_file
@@ -916,6 +917,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout, ScatteringMethods):
         return True
 
     @pyaedt_function_handler()
+    @min_aedt_version("2025.1")
     def set_export_touchstone(
         self,
         file_format="TouchStone1.0",
@@ -996,9 +998,6 @@ class Hfss3dLayout(FieldAnalysis3DLayout, ScatteringMethods):
 
 
         """
-        if settings.aedt_version < "2025.1":
-            self.logger.warning("Touchstone export setup aborted. This method is available from AEDT 2025.1.")
-            return False
         preferences = "Planar EM\\"
         design_name = self.design_name
 

--- a/src/ansys/aedt/core/icepak.py
+++ b/src/ansys/aedt/core/icepak.py
@@ -36,7 +36,7 @@ from ansys.aedt.core.application.analysis_icepak import FieldAnalysisIcepak
 from ansys.aedt.core.generic.data_handlers import _arg2dict
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.data_handlers import random_string
-from ansys.aedt.core.generic.general_methods import GrpcApiError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import open_file
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler

--- a/src/ansys/aedt/core/modeler/cad/component_array.py
+++ b/src/ansys/aedt/core/modeler/cad/component_array.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import
 import os
 import re
 
+from ansys.aedt.core.generic.checks import min_aedt_version
 from ansys.aedt.core.generic.constants import AEDT_UNITS
 from ansys.aedt.core.generic.general_methods import _uname
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
@@ -368,6 +369,7 @@ class ComponentArray(object):
         self.__app.component_array_names = list(self.__app.get_oo_name(self.__app.odesign, "Model"))
 
     @pyaedt_function_handler(array_path="output_file")
+    @min_aedt_version("2024.1")
     def export_array_info(self, output_file=None):  # pragma: no cover
         """Export array information to a CSV file.
 
@@ -379,12 +381,7 @@ class ComponentArray(object):
         References
         ----------
         >>> oModule.ExportArray
-
         """
-        if self.__app.settings.aedt_version < "2024.1":  # pragma: no cover
-            self.logger.warning(f"This feature is not available in {str(self.__app.settings.aedt_version)}.")
-            return False
-
         if not output_file:  # pragma: no cover
             output_file = os.path.join(self.__app.toolkit_directory, "array_info.csv")
         self.__app.omodelsetup.ExportArray(self.name, output_file)

--- a/src/ansys/aedt/core/modeler/cad/object_3d.py
+++ b/src/ansys/aedt/core/modeler/cad/object_3d.py
@@ -37,6 +37,7 @@ from __future__ import absolute_import  # noreorder
 import os
 import re
 
+from ansys.aedt.core.generic.checks import min_aedt_version
 from ansys.aedt.core.generic.constants import AEDT_UNITS
 from ansys.aedt.core.generic.general_methods import _to_boolean
 from ansys.aedt.core.generic.general_methods import _uname
@@ -253,6 +254,7 @@ class Object3d(object):
         return self._primitives._modeler._app._odesign
 
     @pyaedt_function_handler()
+    @min_aedt_version("2021.2")
     def plot(self, show=True):
         """Plot model with PyVista.
 
@@ -270,18 +272,17 @@ class Object3d(object):
         -----
         Works from AEDT 2021.2 in CPython only. PyVista has to be installed.
         """
-        if self._primitives._app._aedt_version >= "2021.2":
-            return self._primitives._app.post.plot_model_obj(
-                objects=[self.name],
-                plot_as_separate_objects=True,
-                plot_air_objects=True,
-                show=show,
-            )
+        return self._primitives._app.post.plot_model_obj(
+            objects=[self.name],
+            plot_as_separate_objects=True,
+            plot_air_objects=True,
+            show=show,
+        )
 
     @pyaedt_function_handler(file_path="output_file")
+    @min_aedt_version("2021.2")
     def export_image(self, output_file=None):
         """Export the current object to a specified file path.
-
 
         .. note::
            Works from AEDT 2021.2 in CPython only. PyVista has to be installed.
@@ -298,19 +299,17 @@ class Object3d(object):
         str
             File path.
         """
-        if self._primitives._app._aedt_version >= "2021.2":
-            if not output_file:
-                output_file = os.path.join(self._primitives._app.working_directory, self.name + ".png")
-            model_obj = self._primitives._app.post.plot_model_obj(
-                objects=[self.name],
-                show=False,
-                export_path=output_file,
-                plot_as_separate_objects=True,
-                clean_files=True,
-            )
-            if model_obj:
-                return model_obj.image_file
-        return False
+        if not output_file:
+            output_file = os.path.join(self._primitives._app.working_directory, self.name + ".png")
+        model_obj = self._primitives._app.post.plot_model_obj(
+            objects=[self.name],
+            show=False,
+            export_path=output_file,
+            plot_as_separate_objects=True,
+            clean_files=True,
+        )
+        if model_obj:
+            return model_obj.image_file
 
     @pyaedt_function_handler()
     def touching_conductors(self):

--- a/src/ansys/aedt/core/modeler/modeler_3d.py
+++ b/src/ansys/aedt/core/modeler/modeler_3d.py
@@ -31,7 +31,7 @@ import os.path
 import warnings
 
 from ansys.aedt.core.application.variables import generate_validation_errors
-from ansys.aedt.core.generic.general_methods import GrpcApiError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import open_file
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler

--- a/src/ansys/aedt/core/modules/boundary/layout_boundary.py
+++ b/src/ansys/aedt/core/modules/boundary/layout_boundary.py
@@ -24,7 +24,7 @@
 
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.data_handlers import random_string
-from ansys.aedt.core.generic.general_methods import GrpcApiError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.modeler.cad.elements_3d import BinaryTreeNode
 from ansys.aedt.core.modules.boundary.common import BoundaryCommon

--- a/src/ansys/aedt/core/modules/mesh.py
+++ b/src/ansys/aedt/core/modules/mesh.py
@@ -31,7 +31,7 @@ import shutil
 
 from ansys.aedt.core.application.design_solutions import model_names
 from ansys.aedt.core.generic.data_handlers import _dict2arg
-from ansys.aedt.core.generic.general_methods import MethodNotSupportedError
+from ansys.aedt.core.generic.errors import MethodNotSupportedError
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.generic.general_methods import settings

--- a/src/ansys/aedt/core/modules/mesh_icepak.py
+++ b/src/ansys/aedt/core/modules/mesh_icepak.py
@@ -26,7 +26,7 @@ import os.path
 import warnings
 
 from ansys.aedt.core.generic.data_handlers import _dict2arg
-from ansys.aedt.core.generic.general_methods import GrpcApiError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import _dim_arg
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler

--- a/src/ansys/aedt/core/visualization/post/field_data.py
+++ b/src/ansys/aedt/core/visualization/post/field_data.py
@@ -34,7 +34,7 @@ import warnings
 from ansys.aedt.core.generic.constants import AllowedMarkers
 from ansys.aedt.core.generic.constants import EnumUnits
 from ansys.aedt.core.generic.data_handlers import _dict2arg
-from ansys.aedt.core.generic.general_methods import GrpcApiError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import check_and_download_file
 from ansys.aedt.core.generic.general_methods import open_file
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler

--- a/src/ansys/aedt/core/visualization/post/post_icepak.py
+++ b/src/ansys/aedt/core/visualization/post/post_icepak.py
@@ -323,18 +323,17 @@ class PostProcessorIcepak(PostProcessor3D):
         """
         if variations is None:
             variations = {}
-        else:  # pragma: no cover
-            if self._app.monitor.face_monitors.get(monitor, None):
-                field_type = "Surface"
-            elif self._app.monitor.point_monitors.get(monitor, None):
-                field_type = "Volume"
-            else:
-                raise AttributeError(f"Monitor {monitor} is not found in the design.")
-            fs = self.create_field_summary()
-            fs.add_calculation(
-                "Monitor", field_type, monitor, quantity, side=side, ref_temperature=ref_temperature, time=time
-            )
-            return self._parse_field_summary_content(fs, setup_name, variations, quantity)
+        if self._app.monitor.face_monitors.get(monitor, None):
+            field_type = "Surface"
+        elif self._app.monitor.point_monitors.get(monitor, None):
+            field_type = "Volume"
+        else:
+            raise AttributeError(f"Monitor {monitor} is not found in the design.")
+        fs = self.create_field_summary()
+        fs.add_calculation(
+            "Monitor", field_type, monitor, quantity, side=side, ref_temperature=ref_temperature, time=time
+        )
+        return self._parse_field_summary_content(fs, setup_name, variations, quantity)
 
     @pyaedt_function_handler(design_variation="variations")
     def evaluate_object_quantity(

--- a/src/ansys/aedt/core/visualization/post/post_icepak.py
+++ b/src/ansys/aedt/core/visualization/post/post_icepak.py
@@ -34,10 +34,10 @@ import csv
 import os
 import re
 
+from ansys.aedt.core.generic.checks import min_aedt_version
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import open_file
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
-from ansys.aedt.core.generic.settings import settings
 from ansys.aedt.core.visualization.post.field_summary import FieldSummary
 from ansys.aedt.core.visualization.post.field_summary import TOTAL_QUANTITIES
 from ansys.aedt.core.visualization.post.post_common_3d import PostProcessor3D
@@ -283,6 +283,7 @@ class PostProcessorIcepak(PostProcessor3D):
         return self._parse_field_summary_content(fs, setup_name, variations, quantity)
 
     @pyaedt_function_handler(monitor_name="monitor", quantity_name="quantity", design_variation="variations")
+    @min_aedt_version("2024.1")
     def evaluate_monitor_quantity(
         self, monitor, quantity, side="Default", setup_name=None, variations=None, ref_temperature="", time="0s"
     ):
@@ -322,8 +323,6 @@ class PostProcessorIcepak(PostProcessor3D):
         """
         if variations is None:
             variations = {}
-        if settings.aedt_version < "2024.1":
-            raise NotImplementedError("Monitors are not supported in field summary in versions earlier than 2024 R1.")
         else:  # pragma: no cover
             if self._app.monitor.face_monitors.get(monitor, None):
                 field_type = "Surface"

--- a/tests/system/solvers/test_00_analyze.py
+++ b/tests/system/solvers/test_00_analyze.py
@@ -33,6 +33,7 @@ from ansys.aedt.core import Hfss3dLayout
 from ansys.aedt.core import Icepak
 from ansys.aedt.core import Maxwell3d
 from ansys.aedt.core import Rmxprt
+from ansys.aedt.core.generic.errors import AEDTRuntimeError
 from ansys.aedt.core.generic.settings import is_linux
 from ansys.aedt.core.visualization.post.spisim import SpiSim
 import pytest
@@ -316,7 +317,7 @@ class TestClass:
         out = self.icepak_app.post.evaluate_boundary_quantity(opening.name, "Ux")
         assert out["Mean"]
         if self.icepak_app.settings.aedt_version < "2024.1":
-            with pytest.raises(NotImplementedError):
+            with pytest.raises(AEDTRuntimeError):
                 self.icepak_app.post.evaluate_monitor_quantity("test_monitor2", "Temperature")
         else:
             out = self.icepak_app.post.evaluate_monitor_quantity("test_monitor2", "Temperature")
@@ -409,7 +410,8 @@ class TestClass:
         if desktop_version > "2024.2":
             assert self.hfss3dl_solve.set_export_touchstone()
         else:
-            assert not self.hfss3dl_solve.set_export_touchstone()
+            with pytest.raises(AEDTRuntimeError):
+                self.hfss3dl_solve.set_export_touchstone()
         assert self.hfss3dl_solve.analyze_setup("Setup1", cores=4, blocking=False)
         assert self.hfss3dl_solve.are_there_simulations_running
         assert self.hfss3dl_solve.stop_simulations()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -352,5 +352,5 @@ def test_min_aedt_version_raise_error_on_non_decorable_object():
 
     dummy = Dummy()
 
-    with pytest.raises(AEDTRuntimeError, match="The desktop is not available."):
+    with pytest.raises(AEDTRuntimeError, match="The AEDT desktop object is not available."):
         dummy.dummy_method()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -47,6 +47,10 @@ SETTINGS_RELEASE_ON_EXCEPTION = settings.release_on_exception
 SETTINGS_ENABLE_ERROR_HANDLER = settings.enable_error_handler
 ERROR_MESSAGE = "Dummy message."
 TOML_DATA = {"key_0": "dummy", "key_1": 12, "key_2": [1, 2], "key_3": {"key_4": 42}}
+CURRENT_YEAR = current_year = time.localtime().tm_year
+CURRENT_YEAR_VERSION = f"{CURRENT_YEAR}.2"
+NEXT_YEAR_VERSION = f"{CURRENT_YEAR + 1}.2"
+PREVIOUS_YEAR_VERSION = f"{CURRENT_YEAR - 1}.2"
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -269,12 +273,6 @@ def test_write_toml(tmp_path):
     _create_toml_file(TOML_DATA, file_path)
 
     assert file_path.exists()
-
-
-CURRENT_YEAR = current_year = time.localtime().tm_year
-CURRENT_YEAR_VERSION = f"{CURRENT_YEAR}.2"
-NEXT_YEAR_VERSION = f"{CURRENT_YEAR + 1}.2"
-PREVIOUS_YEAR_VERSION = f"{CURRENT_YEAR - 1}.2"
 
 
 def test_min_aedt_version_success():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -275,12 +275,45 @@ def test_write_toml(tmp_path):
     assert file_path.exists()
 
 
-def test_min_aedt_version_success():
+def test_min_aedt_version_success_with_common_attributes_names():
     class Dummy:
-        """Dummy class to test min version."""
+        """Dummy class to test min version with common attribute."""
 
         odesktop = MagicMock()
         odesktop.GetVersion.return_value = CURRENT_YEAR_VERSION
+
+        @min_aedt_version(PREVIOUS_YEAR_VERSION)
+        def old_method(self):
+            pass
+
+    dummy = Dummy()
+    dummy.old_method()
+
+
+def test_min_aedt_version_success_with_app_private_attribute():
+    class Dummy:
+        """Dummy class to test min version with __app attribute."""
+
+        odesktop = MagicMock()
+        odesktop.GetVersion.return_value = CURRENT_YEAR_VERSION
+        __app = odesktop
+
+        @min_aedt_version(PREVIOUS_YEAR_VERSION)
+        def old_method(self):
+            pass
+
+    dummy = Dummy()
+    dummy.old_method()
+
+
+def test_min_aedt_version_success_with_desktop_class():
+    class Dummy:
+        """Dummy class to test min version with __app attribute."""
+
+        odesktop = MagicMock()
+        odesktop.GetVersion.return_value = CURRENT_YEAR_VERSION
+        desktop_class = MagicMock()
+        desktop_class.odesktop = odesktop
 
         @min_aedt_version(PREVIOUS_YEAR_VERSION)
         def old_method(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -289,7 +289,6 @@ def test_min_aedt_version_success():
             pass
 
     dummy = Dummy()
-
     dummy.old_method()
 
 


### PR DESCRIPTION
## Description
This feature adds the ability to decorate a method with a check on AEDT version.
This way, check the version inside the method is no longer required and one can see right away that there is a limitation on the method.

The decorator should be compatible in many classes of PyAEDT. However, there is a limitation which requires the decorated object to be able to access the AEDT desktop.
Current ways to achieve such check is to leverage any existing attribute among `odesktop`, `_odesktop` and `_desktop`.

## Issue linked
Associated to #5504 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).

## Note

The test are performed on a mock object to simplify things but I also tested it on a fake Desktop and it worked just fine, here is the class I used to test with real AEDT object

```python
class DummyDesktop(Desktop):
    """Dummy class to test min version."""

    def __new__(cls, *args, **kwargs):
        instance = super(Desktop, cls).__new__(cls, *args, **kwargs)
        return instance

    def __init__(self):
        super().__init__()

    @min_aedt_version(PREVIOUS_YEAR_VERSION)
    def old_method(self):
        pass

    @min_aedt_version(NEXT_YEAR_VERSION)
    def future_method(self):
        pass
```
