### PR TITLE
FIX: Move onetwork_data_explorer to AedtObjects

### DIFF
--- a/src/ansys/aedt/core/application/aedt_objects.py
+++ b/src/ansys/aedt/core/application/aedt_objects.py
@@ -81,6 +81,7 @@ class AedtObjects(object):
         self._o_symbol_manager = None
         self._opadstackmanager = None
         self._oradfield = None
+        self._onetwork_data_explorer = None
 
     @property
     def oradfield(self):
@@ -429,3 +430,15 @@ class AedtObjects(object):
         if not self._o_model_manager and self.odefinition_manager:
             self._o_model_manager = self.odefinition_manager.GetManager("Model")
         return self._o_model_manager
+
+    @property
+    def onetwork_data_explorer(self):
+        """Network data explorer module.
+
+        References
+        ----------
+        >>> oDesktop.GetTool("NdExplorer")
+        """
+        if not self._onetwork_data_explorer:
+            self._onetwork_data_explorer = self._odesktop.GetTool("NdExplorer")
+        return self._onetwork_data_explorer

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -192,7 +192,6 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods):
             remove_lock=remove_lock,
         )
         ScatteringMethods.__init__(self, self)
-        self.onetwork_data_explorer = self._desktop.GetTool("NdExplorer")
 
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -232,7 +232,6 @@ class Hfss(FieldAnalysis3D, ScatteringMethods):
             remove_lock=remove_lock,
         )
         ScatteringMethods.__init__(self, self)
-        self.onetwork_data_explorer = self.odesktop.GetTool("NdExplorer")
         self._field_setups = []
         self.component_array = {}
         self.component_array_names = list(self.get_oo_name(self.odesign, "Model"))

--- a/src/ansys/aedt/core/hfss3dlayout.py
+++ b/src/ansys/aedt/core/hfss3dlayout.py
@@ -187,7 +187,6 @@ class Hfss3dLayout(FieldAnalysis3DLayout, ScatteringMethods):
             remove_lock=remove_lock,
         )
         ScatteringMethods.__init__(self, self)
-        self.onetwork_data_explorer = self.odesktop.GetTool("NdExplorer")
 
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)


### PR DESCRIPTION
## Description
Move onetwork_data_explorer to general AEDT objects instead of initializing it on every application.

## Issue linked
Close #5637 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
