### PR TITLE
FEAT: Added support for 25R1 EMI Receiver component RBW and RBW Factor feat…

### DIFF
--- a/src/ansys/aedt/core/visualization/report/emi.py
+++ b/src/ansys/aedt/core/visualization/report/emi.py
@@ -115,7 +115,7 @@ class EMIReceiver(CommonReport):
         str
             RBW Factor setting.
         """
-        return self._legacy_props["context"].get("RBW_factpr", None)
+        return self._legacy_props["context"].get("RBW_factor", None)
 
     @rbw_factor.setter
     def rbw_factor(self, value):

--- a/src/ansys/aedt/core/visualization/report/emi.py
+++ b/src/ansys/aedt/core/visualization/report/emi.py
@@ -29,6 +29,7 @@ This module provides all functionalities for creating and editing reports.
 
 """
 
+
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.visualization.report.common import CommonReport
@@ -53,6 +54,8 @@ class EMIReceiver(CommonReport):
         self._emission = "CE"
         self.overlap_rate = 95
         self.band = "0"
+        self.rbw = "0"
+        self.rbw_factor = "0"
         self.primary_sweep = "Freq"
 
     @property
@@ -87,6 +90,36 @@ class EMIReceiver(CommonReport):
     @band.setter
     def band(self, value):
         self._legacy_props["context"]["band"] = value
+
+    @property
+    def rbw(self):
+        """RBW attached to the EMI receiver.
+
+        Returns
+        -------
+        str
+            RBW setting.
+        """
+        return self._legacy_props["context"].get("RBW", None)
+
+    @rbw.setter
+    def rbw(self, value):
+        self._legacy_props["context"]["RBW"] = value
+
+    @property
+    def rbw_factor(self):
+        """RBW Factor attached to the EMI receiver.
+
+        Returns
+        -------
+        str
+            RBW Factor setting.
+        """
+        return self._legacy_props["context"].get("RBW_factpr", None)
+
+    @rbw_factor.setter
+    def rbw_factor(self, value):
+        self._legacy_props["context"]["RBW_factor"] = value
 
     @property
     def emission(self):
@@ -188,7 +221,10 @@ class EMIReceiver(CommonReport):
                 str(self.overlap_rate),
                 "RBW",
                 False,
-                "9000Hz",
+                str(self.rbw),
+                "RBWFactor",
+                False,
+                str(self.rbw_factor),
                 "SIG",
                 False,
                 "0",

--- a/tests/system/general/test_12_PostProcessing.py
+++ b/tests/system/general/test_12_PostProcessing.py
@@ -762,6 +762,8 @@ class TestClass:
         emi_receiver_test.analyze()
         new_report = emi_receiver_test.post.reports_by_category.emi_receiver()
         new_report.band = "2"
+        new_report.rbw = "2"
+        new_report.rbw_factor = "0"
         new_report.emission = "RE"
         new_report.time_start = "1ns"
         new_report.time_stop = "2us"


### PR DESCRIPTION
## Description
This PR adds support for 25R1 EMI Receiver component RBW and RBW Factor settings.

## Issue linked
Issue #5585

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved by the PR if any.
- [X] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
