### PR TITLE
FIX: default intrinsics

### DIFF
--- a/src/ansys/aedt/core/modules/solve_setup.py
+++ b/src/ansys/aedt/core/modules/solve_setup.py
@@ -139,28 +139,32 @@ class CommonSetup(PropsManager, BinaryTreeNode):
         dict
             Dictionary which keys are typically Freq, Phase or Time.
         """
-        intr = {}
+        intrinsics = {}
         if "HFSS 3D Layout" in self._app.design_type:  # pragma no cover
             try:
-                intr["Freq"] = (
+                intrinsics["Freq"] = (
                     self._app.modeler.edb.setups[self.name]
                     .adaptive_settings.adaptive_frequency_data_list[0]
                     .adaptive_frequency
                 )
-                intr["Phase"] = "0deg"
-                return intr
+                intrinsics["Phase"] = "0deg"
+                return intrinsics
             except Exception:
                 settings.logger.debug("Failed to retrieve adaptive frequency.")
-        for i in self._app.design_solutions.intrinsics:
-            if i == "Freq" and "Frequency" in self.props:
-                intr[i] = self.props["Frequency"]
-            elif i == "Freq" and "Solution Freq" in self.properties:
-                intr[i] = self.properties["Solution Freq"]
-            elif i == "Phase":
-                intr[i] = "0deg"
-            elif i == "Time":
-                intr[i] = "0s"
-        return intr
+        intrinsic_map = {"Freq": ["Frequency", "Solution Freq"], "Phase": "0deg", "Time": "0s"}
+
+        for intrinsic, props in intrinsic_map.items():
+            if isinstance(props, list):
+                for prop in props:
+                    if prop in self.props:
+                        intrinsics[intrinsic] = self.props[prop]
+                        break
+                    elif prop in self.properties:
+                        intrinsics[intrinsic] = self.properties[prop]
+                        break
+            else:
+                intrinsics[intrinsic] = props
+        return intrinsics
 
     def __repr__(self):
         return "SetupName " + self.name + " with " + str(len(self.sweeps)) + " Sweeps"

--- a/src/ansys/aedt/core/modules/solve_setup.py
+++ b/src/ansys/aedt/core/modules/solve_setup.py
@@ -154,6 +154,8 @@ class CommonSetup(PropsManager, BinaryTreeNode):
         for i in self._app.design_solutions.intrinsics:
             if i == "Freq" and "Frequency" in self.props:
                 intr[i] = self.props["Frequency"]
+            elif i == "Freq" and "Solution Freq" in self.properties:
+                intr[i] = self.properties["Solution Freq"]
             elif i == "Phase":
                 intr[i] = "0deg"
             elif i == "Time":

--- a/src/ansys/aedt/core/modules/solve_setup.py
+++ b/src/ansys/aedt/core/modules/solve_setup.py
@@ -151,19 +151,17 @@ class CommonSetup(PropsManager, BinaryTreeNode):
                 return intrinsics
             except Exception:
                 settings.logger.debug("Failed to retrieve adaptive frequency.")
-        intrinsic_map = {"Freq": ["Frequency", "Solution Freq"], "Phase": "0deg", "Time": "0s"}
 
-        for intrinsic, props in intrinsic_map.items():
-            if isinstance(props, list):
-                for prop in props:
-                    if prop in self.props:
-                        intrinsics[intrinsic] = self.props[prop]
-                        break
-                    elif prop in self.properties:
-                        intrinsics[intrinsic] = self.properties[prop]
-                        break
-            else:
-                intrinsics[intrinsic] = props
+        for i in self._app.design_solutions.intrinsics:
+            if i == "Freq":
+                if "Frequency" in self.props:
+                    intrinsics[i] = self.props["Frequency"]
+                elif "Solution Freq" in self.properties:
+                    intrinsics[i] = self.properties["Solution Freq"]
+            elif i == "Phase":
+                intrinsics[i] = "0deg"
+            elif i == "Time":
+                intrinsics[i] = "0s"
         return intrinsics
 
     def __repr__(self):


### PR DESCRIPTION
## Description
**This default intrinsics weren't correctly populated for HFSS design since the latest refactoring of the GetDataModel PR.
Hence a new check for frequency was needed in properties.**

## Issue linked
**Closes #5650**

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
