### PR TITLE
FIX: Use Get3DComponentDefinitionNames to obtain 3DComponent instances

### DIFF
--- a/src/ansys/aedt/core/modules/boundary/layout_boundary.py
+++ b/src/ansys/aedt/core/modules/boundary/layout_boundary.py
@@ -118,7 +118,9 @@ class NativeComponentObject(BoundaryCommon, BinaryTreeNode):
 
         """
         child_object = None
-        for el in self._app.oeditor.GetChildNames("ComponentDefinition"):
+        component_definition = self._app.oeditor.Get3DComponentDefinitionNames()
+
+        for el in component_definition:
             design_childs = self._app.get_oo_object(self._app.oeditor, el).GetChildNames()
             if self._name in design_childs:
                 child_object = self._app.get_oo_object(self._app.oeditor, f"{el}\\{self._name}")

--- a/src/ansys/aedt/core/modules/mesh_icepak.py
+++ b/src/ansys/aedt/core/modules/mesh_icepak.py
@@ -933,12 +933,12 @@ class MeshRegion(MeshRegionCommon):
                     for sr in sub_regions:
                         p1 = []
                         p2 = []
-                        if "Part Names" in self._app.modeler[sr].history().props:
-                            p1 = self._app.modeler[sr].history().props.get("Part Names", None)
+                        if "Part Names" in self._app.modeler[sr].history().properties:
+                            p1 = self._app.modeler[sr].history().properties.get("Part Names", None)
                             if not isinstance(p1, list):
                                 p1 = [p1]
-                        elif "Submodel Names" in self._app.modeler[sr].history().props:
-                            p2 = self._app.modeler[sr].history().props.get("Submodel Names", None)
+                        elif "Submodel Names" in self._app.modeler[sr].history().properties:
+                            p2 = self._app.modeler[sr].history().properties.get("Submodel Names", None)
                             if not isinstance(p2, list):
                                 p2 = [p2]
                         p1 += p2


### PR DESCRIPTION
## Description
Fix issue with 2024R1. API method was not supported.

## Issue linked
Close #5653 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
