### PR TITLE
FIX: Convert near field list name order

### DIFF
--- a/src/ansys/aedt/core/visualization/advanced/misc.py
+++ b/src/ansys/aedt/core/visualization/advanced/misc.py
@@ -154,14 +154,15 @@ def convert_nearfield_data(dat_folder, frequency=6, invert_phase_for_lower_faces
     index = 1
     for el in list(file_keys):
         for k in range(index, index + len(components[el].x)):
-            row = []
-            row.append(k)
-            row.append(components[el].x[k - index])
-            row.append(components[el].y[k - index])
-            row.append(components[el].z[k - index])
+            row = [k, components[el].x[k - index], components[el].y[k - index], components[el].z[k - index]]
             for field in ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]:
-                row.append(components[el].re[field][k - index])
-                row.append(components[el].im[field][k - index])
+                field_index = k - index
+                if len(components[el].re[field]) <= field_index:
+                    row.append(0)
+                    row.append(0)
+                else:
+                    row.append(components[el].re[field][field_index])
+                    row.append(components[el].im[field][field_index])
             full_data.append(row)
         index += len(components[el].x)
 


### PR DESCRIPTION
## Description
Depeding on OS, the file list order could change, and the files could contain different size data. With this PR, if the field does not contain information, it is filled with a 0 value, because it means that there is no field value at this field component.

## Issue linked
Close #5664 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
