### PR TITLE
FIX: Load numpy lazily

### DIFF
--- a/src/ansys/aedt/core/q3d.py
+++ b/src/ansys/aedt/core/q3d.py
@@ -42,15 +42,6 @@ from ansys.aedt.core.modules.boundary.common import BoundaryObject
 from ansys.aedt.core.modules.boundary.q3d_boundary import Matrix
 from ansys.aedt.core.modules.setup_templates import SetupKeys
 
-try:
-    import numpy as np
-except ImportError:  # pragma: no cover
-    warnings.warn(
-        "The NumPy module is required to use functionalities provided by the module ansys.edt.core.q3d.\n"
-        "Install with \n\npip install numpy"
-    )
-    np = None
-
 
 class QExtractor(FieldAnalysis3D, object):
     """Extracts a 2D or 3D field analysis.
@@ -1944,6 +1935,8 @@ class Q3d(QExtractor, object):
             ``True`` when successful, ``False`` when failed.
         """
         try:
+            import numpy as np
+
             if not insulator_threshold:
                 insulator_threshold = 10000
             if not perfect_conductor_threshold:
@@ -1962,6 +1955,11 @@ class Q3d(QExtractor, object):
 
             self.oboundary.SetMaterialThresholds(insulator_threshold, perfect_conductor_threshold, magnetic_threshold)
             return True
+        except ImportError:  # pragma: no cover
+            warnings.warn(
+                "The NumPy module is required to use functionalities provided by the module ansys.edt.core.q3d.\n"
+                "Install with \n\npip install numpy"
+            )
         except Exception:
             return False
 


### PR DESCRIPTION
## Description
Running some PyAEDT tests in Linux with `numpy>=2.Y` leads to errors when a test requires to load a Desktop and then uses `PyEDB` and tries to load .NET Core.

This changes will ensure that if one uses `ansys.aedt.core`, `numpy` is not loaded by default before the Desktop.
Otherwise, there is a side effect and .NET Core can't be loaded...

This should be further investigated.

## Issue linked

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
