### PR TITLE
BUILD: Avoid new attrs release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "rpyc>=6.0.0,<6.1",
     "pyyaml",
     "defusedxml>=0.7,<8.0",
-    "attrs!=24.3.0",
+    "attrs<24.3.0",
     "referencing<0.36.0",
 ]
 


### PR DESCRIPTION
## Description
The tool used to check license is not yet able to work with PEP 639, I just proposed a PR to fix that (https://github.com/raimon49/pip-licenses/pull/226) but in the mean time we must avoid the latests versions of `attrs`.

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
