### PR TITLE
FIX: Use GPRC API by default in Jupyter template

### DIFF
--- a/src/ansys/aedt/core/workflows/installer/jupyter_template.ipynb
+++ b/src/ansys/aedt/core/workflows/installer/jupyter_template.ipynb
@@ -39,7 +39,7 @@
     "if version > \"2023.1\":\n",
     "        from ansys.aedt.core import *\n",
     "        import ansys.aedt.core\n",
-    "        ansys.aedt.core.settings.use_grpc_api=False\n",
+    "        ansys.aedt.core.settings.use_grpc_api=True\n",
     "else:\n",
     "        from pyaedt import *\n",
     "        import pyaedt\n",


### PR DESCRIPTION
## Description
Use GRPC by default in Jupyter template

## Issue linked
Close #5685 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
