### PR TITLE
DOCS: Add docstring for Page in create_component

### DIFF
--- a/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
@@ -780,6 +780,8 @@ class CircuitComponents(object):
             The default is ``False``.
         global_netlist_list : list, optional
             The default is ``None``, in which case an empty list is passed.
+        page: int, optional
+            Schematics page number. The default value is ``1``.
 
         Returns
         -------

--- a/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
@@ -781,7 +781,7 @@ class CircuitComponents(object):
         global_netlist_list : list, optional
             The default is ``None``, in which case an empty list is passed.
         page: int, optional
-            Schematics page number. The default value is ``1``.
+            Schematic page number. The default value is ``1``.
 
         Returns
         -------


### PR DESCRIPTION
Adding documentation to create_component method within circuit_primitives.py 

Issue #5722 