### PR TITLE
FIX: layout editor from circuit designer is loaded when layouteditor is called

### DIFF
--- a/src/ansys/aedt/core/application/aedt_objects.py
+++ b/src/ansys/aedt/core/application/aedt_objects.py
@@ -414,7 +414,7 @@ class AedtObjects(object):
         >>> oDesign.SetActiveEditor("Layout")
         """
         if not self._layouteditor and self.design_type in ["Circuit Design"]:
-            self._layouteditor = self._odesign.SetActiveEditor("Layout")
+            self._layouteditor = self._odesign.GetEditor("Layout")
         return self._layouteditor
 
     @property


### PR DESCRIPTION
## Description
Changed the behaviour with GetEditor method to remain in schematic

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
