### PR TITLE
FIX: add set_touchstone_model to Hfss3dLayout

### DIFF
--- a/src/ansys/aedt/core/modeler/modeler_pcb.py
+++ b/src/ansys/aedt/core/modeler/modeler_pcb.py
@@ -940,6 +940,314 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
         return True
 
     @pyaedt_function_handler()
+    def set_touchstone_model(self, assignment, input_file, model_name=None):
+        """Assign a Touchstone model to a component.
+
+        Parameters
+        ----------
+        assignment : str
+            Name of the component.
+        input_file : str, optional
+            Full path to the model file. The default is ``None``.
+        model_name : str, optional
+            Name of the model. The default is ``None``, in which case the model name is the file name without an
+            extension.
+
+
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+
+        Examples
+        --------
+
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> h3d = Hfss3dLayout("myproject")
+        >>> h3d.modeler.set_touchstone_model(assignment="C1",input_file="comp.s2p")
+
+        """
+
+        if not model_name:
+            model_name = os.path.splitext(os.path.basename(input_file))[0]
+            if "." in model_name:
+                model_name = model_name.replace(".", "_")
+        if model_name in list(self.o_model_manager.GetNames()):
+            model_name = generate_unique_name(model_name, n=2)
+        num_terminal = int(os.path.splitext(input_file)[1].lower().strip(".sp"))
+
+        port_names = []
+        with open_file(input_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith(("!", "#", "")):
+                    if "Port" in line and "=" in line and "Impedance" not in line:
+                        port_names.append(line.split("=")[-1].strip().replace(" ", "_").strip("[]"))
+                else:
+                    break
+        image_subcircuit_path = ""
+        bmp_file_name = ""
+
+        if not port_names:
+            port_names = ["Port" + str(i + 1) for i in range(num_terminal)]
+        arg = [
+            "NAME:" + model_name,
+            "Name:=",
+            model_name,
+            "ModTime:=",
+            0,
+            "Library:=",
+            "",
+            "LibLocation:=",
+            "Project",
+            "ModelType:=",
+            "nport",
+            "Description:=",
+            "",
+            "ImageFile:=",
+            image_subcircuit_path,
+            "SymbolPinConfiguration:=",
+            0,
+            ["NAME:PortInfoBlk"],
+            ["NAME:PortOrderBlk"],
+            "filename:=",
+            input_file,
+            "numberofports:=",
+            num_terminal,
+            "sssfilename:=",
+            "",
+            "sssmodel:=",
+            False,
+            "PortNames:=",
+            port_names,
+            "domain:=",
+            "frequency",
+            "datamode:=",
+            "Link",
+            "devicename:=",
+            "",
+            "SolutionName:=",
+            "",
+            "displayformat:=",
+            "MagnitudePhase",
+            "datatype:=",
+            "SMatrix",
+            [
+                "NAME:DesignerCustomization",
+                "DCOption:=",
+                0,
+                "InterpOption:=",
+                0,
+                "ExtrapOption:=",
+                1,
+                "Convolution:=",
+                0,
+                "Passivity:=",
+                0,
+                "Reciprocal:=",
+                False,
+                "ModelOption:=",
+                "",
+                "DataType:=",
+                1,
+            ],
+            [
+                "NAME:NexximCustomization",
+                "DCOption:=",
+                3,
+                "InterpOption:=",
+                1,
+                "ExtrapOption:=",
+                3,
+                "Convolution:=",
+                0,
+                "Passivity:=",
+                0,
+                "Reciprocal:=",
+                False,
+                "ModelOption:=",
+                "",
+                "DataType:=",
+                2,
+            ],
+            [
+                "NAME:HSpiceCustomization",
+                "DCOption:=",
+                1,
+                "InterpOption:=",
+                2,
+                "ExtrapOption:=",
+                3,
+                "Convolution:=",
+                0,
+                "Passivity:=",
+                0,
+                "Reciprocal:=",
+                False,
+                "ModelOption:=",
+                "",
+                "DataType:=",
+                3,
+            ],
+            "NoiseModelOption:=",
+            "External",
+        ]
+        self.o_model_manager.Add(arg)
+        arg = [
+            "NAME:" + model_name,
+            "Info:=",
+            [
+                "Type:=",
+                10,
+                "NumTerminals:=",
+                num_terminal,
+                "DataSource:=",
+                "",
+                "ModifiedOn:=",
+                1618569625,
+                "Manufacturer:=",
+                "",
+                "Symbol:=",
+                "",
+                "ModelNames:=",
+                "",
+                "Footprint:=",
+                "",
+                "Description:=",
+                "",
+                "InfoTopic:=",
+                "",
+                "InfoHelpFile:=",
+                "",
+                "IconFile:=",
+                bmp_file_name,
+                "Library:=",
+                "",
+                "OriginalLocation:=",
+                "Project",
+                "IEEE:=",
+                "",
+                "Author:=",
+                "",
+                "OriginalAuthor:=",
+                "",
+                "CreationDate:=",
+                1618569625,
+                "ExampleFile:=",
+                "",
+                "HiddenComponent:=",
+                0,
+                "CircuitEnv:=",
+                0,
+                "GroupID:=",
+                0,
+            ],
+            "CircuitEnv:=",
+            0,
+            "Refbase:=",
+            "S",
+            "NumParts:=",
+            1,
+            "ModSinceLib:=",
+            False,
+        ]
+        for i in range(num_terminal):
+            arg.append("Terminal:=")
+            arg.append([port_names[i], port_names[i], "A", False, i, 1, "", "Electrical", "0"])
+        arg.append("CompExtID:=")
+        arg.append(5)
+        arg.append(
+            [
+                "NAME:Parameters",
+                "MenuProp:=",
+                ["CoSimulator", "SD", "", "Default", 0],
+                "ButtonProp:=",
+                ["CosimDefinition", "SD", "", "Edit", "Edit", 40501, "ButtonPropClientData:=", []],
+            ]
+        )
+        arg.append(
+            [
+                "NAME:CosimDefinitions",
+                [
+                    "NAME:CosimDefinition",
+                    "CosimulatorType:=",
+                    102,
+                    "CosimDefName:=",
+                    "Default",
+                    "IsDefinition:=",
+                    True,
+                    "Connect:=",
+                    True,
+                    "ModelDefinitionName:=",
+                    model_name,
+                    "ShowRefPin2:=",
+                    2,
+                    "LenPropName:=",
+                    "",
+                ],
+                "DefaultCosim:=",
+                "Default",
+            ]
+        )
+
+        self.o_component_manager.Add(arg)
+        self.o_component_manager.AddSolverOnDemandModel(
+            self.components[assignment].part,
+            [
+                "NAME:CosimDefinition",
+                "CosimulatorType:=",
+                102,
+                "CosimDefName:=",
+                model_name,
+                "IsDefinition:=",
+                True,
+                "Connect:=",
+                True,
+                "ModelDefinitionName:=",
+                model_name,
+                "ShowRefPin2:=",
+                2,
+                "LenPropName:=",
+                "",
+            ],
+        )
+        self.oeditor.ChangeProperty(
+            [
+                "NAME:AllTabs",
+                [
+                    "NAME:BaseElementTab",
+                    ["NAME:PropServers", assignment],
+                    [
+                        "NAME:ChangedProps",
+                        [
+                            "NAME:Model Info",
+                            [
+                                "NAME:Model",
+                                "RLCProp:=",
+                                [
+                                    "CompPropEnabled:=",
+                                    True,
+                                    "Pid:=",
+                                    -1,
+                                    "Pmo:=",
+                                    "0",
+                                    "CompPropType:=",
+                                    0,
+                                    "PinPairRLC:=",
+                                    ["RLCModelType:=", 1, "CosimDefintion:=", model_name],
+                                ],
+                                "CompType:=",
+                                3,
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        )
+
+        return model_name
+
+    @pyaedt_function_handler()
     def clip_plane(self):
         """Create a clip plane in the layout.
 

--- a/src/ansys/aedt/core/modules/setup_templates.py
+++ b/src/ansys/aedt/core/modules/setup_templates.py
@@ -338,7 +338,6 @@ DCBiasedEddyCurrent = dict(
         "SmoothBHCurve": False,
         "Frequency": "60Hz",
         "HasSweepSetup": False,
-        "SweepRanges": subranges,
         "UseHighOrderShapeFunc": False,
         "UseMuLink": False,
         "DCPercentRefinement": 30,

--- a/tests/system/general/test_01_3dlayout_edb.py
+++ b/tests/system/general/test_01_3dlayout_edb.py
@@ -222,7 +222,11 @@ class TestClass:
         ports = aedtapp.create_ports_on_component_by_nets("U1", "DDR4_DQS0_P")
         assert aedtapp.modeler.change_property(f"Excitations:{ports[0].name}", "Impedance", "49ohm", "EM Design")
 
-    def test_06_assign_spice_model(self, aedtapp):
+    def test_06_assign_touchstone_model(self, aedtapp):
+        model_path = os.path.join(TESTS_GENERAL_PATH, "example_models", "TEDB", "GRM32_DC0V_25degC_series.s2p")
+        assert aedtapp.modeler.set_touchstone_model(assignment="C217", input_file=model_path, model_name="Test1")
+
+    def test_07_assign_spice_model(self, aedtapp):
         model_path = os.path.join(TESTS_GENERAL_PATH, "example_models", test_subfolder, "GRM32ER72A225KA35_25C_0V.sp")
         assert aedtapp.modeler.set_spice_model(
             assignment="C1", input_file=model_path, subcircuit_name="GRM32ER72A225KA35_25C_0V"


### PR DESCRIPTION
## Description

Added a new method called set_touchstone model in HFSS 3D Layout to assign a touchstone to a component in the layout. Still missing the possibility to assign a pin mapping to the terminals. Those advanced functionalities are available anyway in PyEDB.

## Issue linked
Close #4363
Close #4391

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
