### PR TITLE
REFACTOR: Design initialization in PyAEDT APP 

### DIFF
--- a/src/ansys/aedt/core/application/aedt_objects.py
+++ b/src/ansys/aedt/core/application/aedt_objects.py
@@ -390,13 +390,18 @@ class AedtObjects(object):
         ----------
         >>> oEditor = oDesign.SetActiveEditor("SchematicEditor")"""
         if not self._oeditor and self._odesign:
-            if self.design_type in ["Circuit Design", "Twin Builder", "Maxwell Circuit", "EMIT"]:
+            if self.design_type in ["Circuit Design"]:
+                self._oeditor = self._odesign.GetEditor("SchematicEditor")
+                if is_linux and settings.aedt_version == "2024.1":  # pragma: no cover
+                    time.sleep(1)
+                    self.desktop_class.close_windows()
+            if self.design_type in ["Twin Builder", "Maxwell Circuit", "EMIT"]:
                 self._oeditor = self._odesign.SetActiveEditor("SchematicEditor")
                 if is_linux and settings.aedt_version == "2024.1":  # pragma: no cover
                     time.sleep(1)
                     self.desktop_class.close_windows()
             elif self.design_type in ["HFSS 3D Layout Design", "HFSS3DLayout"]:
-                self._oeditor = self._odesign.SetActiveEditor("Layout")
+                self._oeditor = self._odesign.GetEditor("Layout")
             elif self.design_type in ["RMxprt", "RMxprtSolution"]:
                 self._oeditor = self._odesign.SetActiveEditor("Machine")
             elif self.design_type in ["Circuit Netlist"]:

--- a/src/ansys/aedt/core/application/aedt_objects.py
+++ b/src/ansys/aedt/core/application/aedt_objects.py
@@ -395,7 +395,7 @@ class AedtObjects(object):
                 if is_linux and settings.aedt_version == "2024.1":  # pragma: no cover
                     time.sleep(1)
                     self.desktop_class.close_windows()
-            if self.design_type in ["Twin Builder", "Maxwell Circuit", "EMIT"]:
+            elif self.design_type in ["Twin Builder", "Maxwell Circuit", "EMIT"]:
                 self._oeditor = self._odesign.SetActiveEditor("SchematicEditor")
                 if is_linux and settings.aedt_version == "2024.1":  # pragma: no cover
                     time.sleep(1)

--- a/src/ansys/aedt/core/application/design.py
+++ b/src/ansys/aedt/core/application/design.py
@@ -1124,11 +1124,19 @@ class Design(AedtObjects):
                         valids.append(name)
                     elif self._temp_solution_type in des.GetSolutionType():
                         valids.append(name)
-            if len(valids) != 1:
-                warning_msg = "No consistent unique design is present. Inserting a new design."
-            else:
+            if len(valids) > 1:
+                des_name = self.oproject.GetActiveDesign().GetName()
+                if des_name in valids:
+                    activedes = self.oproject.GetActiveDesign().GetName()
+                else:
+                    activedes = valids[0]
+                warning_msg = f"Active Design set to {valids[0]}"
+            elif len(valids) == 1:
                 activedes = valids[0]
                 warning_msg = f"Active Design set to {valids[0]}"
+            else:
+                warning_msg = "No consistent unique design is present. Inserting a new design."
+
         # legacy support for version < 2021.2
         elif self.design_list:  # pragma: no cover
             self._odesign = self._oproject.GetDesign(self.design_list[0])
@@ -4091,6 +4099,7 @@ class Design(AedtObjects):
                     raise ValueError(f"Specified design is not of type {self._design_type}.")
             elif self._design_type not in {"RMxprtSolution", "ModelCreation"}:
                 raise ValueError(f"Specified design is not of type {self._design_type}.")
+
             return True
         elif ":" in des_name:
             try:

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -773,6 +773,8 @@ class Desktop(object):
         if is_linux and settings.aedt_version == "2024.1" and design_type == "Circuit Design":  # pragma: no cover
             time.sleep(1)
             self.close_windows()
+        warning_msg = f"Active Design set to {active_design.GetName()}"
+        settings.logger.info(warning_msg)
         return active_design
 
     @pyaedt_function_handler()

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -1570,7 +1570,9 @@ class TestClass:
         ),
     )
     def test_64_import_dxf(self, dxf_file: str, object_count: int, self_stitch_tolerance: float):
-        design_name = self.aedtapp.insert_design("test_64_import_dxf")
+        from pyedb.generic.general_methods import generate_unique_name
+
+        design_name = self.aedtapp.insert_design(generate_unique_name("test_64_import_dxf"))
         self.aedtapp.set_active_design(design_name)
         dxf_layers = self.aedtapp.get_dxf_layers(dxf_file)
         assert isinstance(dxf_layers, list)


### PR DESCRIPTION
## Description
When initializing an application without defining a design name actually is taking the existing design only if the number of designs into the projects are only 1. We are changing this behaviour. If design name is not provided:

- It checks for active design if is of the type we are looking for and eventually set it to active
- If not if it takes the first alphabetically ordered design and makes it active.
## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
