### PR TITLE
REFACTOR: Use Mixin to create boundary

### DIFF
--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -31,7 +31,6 @@ import math
 import os
 from pathlib import Path
 import tempfile
-from typing import TYPE_CHECKING
 import warnings
 
 from ansys.aedt.core.application.analysis_3d import FieldAnalysis3D
@@ -53,13 +52,11 @@ from ansys.aedt.core.modeler import cad
 from ansys.aedt.core.modeler.cad.component_array import ComponentArray
 from ansys.aedt.core.modeler.cad.components_3d import UserDefinedComponent
 from ansys.aedt.core.modeler.geometry_operators import GeometryOperators
+from ansys.aedt.core.modules.boundary.common import BoundaryObject
 from ansys.aedt.core.modules.boundary.hfss_boundary import FarFieldSetup
 from ansys.aedt.core.modules.boundary.hfss_boundary import NearFieldSetup
 from ansys.aedt.core.modules.boundary.layout_boundary import NativeComponentObject
 from ansys.aedt.core.modules.setup_templates import SetupKeys
-
-if TYPE_CHECKING:  # pragma: no cover
-    from ansys.aedt.core.modules.boundary.common import BoundaryObject
 
 
 class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -492,7 +492,8 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
                         self.odesign.ChangeProperty(properties)
                     except Exception:  # pragma: no cover
                         self.logger.warning(f"Failed to rename terminal {terminal}.")
-                self._create_boundary(terminal_name, props_terminal, "Terminal")
+                bound = BoundaryObject(self, terminal_name, props_terminal, "Terminal")
+                self._boundaries[terminal_name] = bound
 
             if iswaveport:
                 boundary.type = "Wave Port"

--- a/src/ansys/aedt/core/icepak.py
+++ b/src/ansys/aedt/core/icepak.py
@@ -4994,7 +4994,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
 
         if not boundary_name:
             boundary_name = generate_unique_name("AdiabaticPlate")
-        bound = self._create_boundary(boundary_name, props, "AdiabaticPlate")
+        bound = self._create_boundary(boundary_name, props, "Adiabatic Plate")
         return bound
 
     @pyaedt_function_handler()

--- a/src/ansys/aedt/core/icepak.py
+++ b/src/ansys/aedt/core/icepak.py
@@ -38,17 +38,16 @@ from ansys.aedt.core.generic.data_handlers import _arg2dict
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.data_handlers import random_string
 from ansys.aedt.core.generic.errors import AEDTRuntimeError
-from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import open_file
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.generic.settings import is_linux
 from ansys.aedt.core.generic.settings import settings
+from ansys.aedt.core.mixins import CreateBoundaryMixin
 from ansys.aedt.core.modeler.cad.components_3d import UserDefinedComponent
 from ansys.aedt.core.modeler.cad.elements_3d import FacePrimitive
 from ansys.aedt.core.modeler.geometry_operators import GeometryOperators
 from ansys.aedt.core.modeler.geometry_operators import GeometryOperators as go
-from ansys.aedt.core.modules.boundary.common import BoundaryObject
 from ansys.aedt.core.modules.boundary.icepak_boundary import BoundaryDictionary
 from ansys.aedt.core.modules.boundary.icepak_boundary import ExponentialDictionary
 from ansys.aedt.core.modules.boundary.icepak_boundary import LinearDictionary
@@ -57,13 +56,12 @@ from ansys.aedt.core.modules.boundary.icepak_boundary import PieceWiseLinearDict
 from ansys.aedt.core.modules.boundary.icepak_boundary import PowerLawDictionary
 from ansys.aedt.core.modules.boundary.icepak_boundary import SinusoidalDictionary
 from ansys.aedt.core.modules.boundary.icepak_boundary import SquareWaveDictionary
-from ansys.aedt.core.modules.boundary.icepak_boundary import _create_boundary
 from ansys.aedt.core.modules.boundary.layout_boundary import NativeComponentObject
 from ansys.aedt.core.modules.boundary.layout_boundary import NativeComponentPCB
 from ansys.aedt.core.modules.setup_templates import SetupKeys
 
 
-class Icepak(FieldAnalysisIcepak):
+class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
     """Provides the Icepak application interface.
 
     This class allows you to connect to an existing Icepak design or create a
@@ -301,12 +299,8 @@ class Icepak(FieldAnalysisIcepak):
 
         props["X"] = x_curve
         props["Y"] = y_curve
-        bound = BoundaryObject(self, boundary_name, props, "Grille")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            self.logger.info("Grille Assigned")
-            return bound
-        return None
+        bound = self._create_boundary(boundary_name, props, "Grille")
+        return bound
 
     @pyaedt_function_handler()
     def assign_openings(self, air_faces):
@@ -347,12 +341,8 @@ class Icepak(FieldAnalysisIcepak):
         props["External Rad. Temperature"] = "AmbientRadTemp"
         props["Inlet Type"] = "Pressure"
         props["Total Pressure"] = "AmbientPressure"
-        bound = BoundaryObject(self, boundary_name, props, "Opening")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            self.logger.info("Opening Assigned")
-            return bound
-        return None
+        bound = self._create_boundary(boundary_name, props, "Opening")
+        return bound
 
     @pyaedt_function_handler(setup_name="setup")
     def assign_2way_coupling(
@@ -528,12 +518,8 @@ class Icepak(FieldAnalysisIcepak):
         else:
             boundary_name = generate_unique_name("Block")
 
-        bound = BoundaryObject(self, boundary_name, props, "Block")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            self.logger.info(f"Block on {object_name} with {input_power} power created correctly.")
-            return bound
-        return None
+        bound = self._create_boundary(boundary_name, props, "Block")
+        return bound
 
     @pyaedt_function_handler()
     def create_conduting_plate(
@@ -647,8 +633,8 @@ class Icepak(FieldAnalysisIcepak):
             }
 
         props["Shell Conduction"] = shell_conduction
-        bound = BoundaryObject(self, bc_name, props, "Conducting Plate")
-        return _create_boundary(bound)
+        bound = self._create_boundary(bc_name, props, "Conducting Plate")
+        return bound
 
     @pyaedt_function_handler()
     def create_source_power(
@@ -734,8 +720,8 @@ class Icepak(FieldAnalysisIcepak):
         props["Surface Heat"] = surface_heat
         props["Temperature"] = temperature
         props["Radiation"] = {"Radiate": radiate}
-        bound = BoundaryObject(self, source_name, props, "SourceIcepak")
-        return _create_boundary(bound)
+        bound = self._create_boundary(source_name, props, "SourceIcepak")
+        return bound
 
     @pyaedt_function_handler()
     def create_network_block(
@@ -840,12 +826,8 @@ class Icepak(FieldAnalysisIcepak):
                 "Link2": ["Face" + str(fcrjb), "Internal", "R", str(rjb) + "cel_per_w"],
             }
             props["SchematicData"] = {}
-            bound = BoundaryObject(self, boundary_name, props, "Network")
-            if bound.create():
-                self._boundaries[bound.name] = bound
-                self.modeler[object_name].solve_inside = False
-                return bound
-            return None
+            bound = self._create_boundary(boundary_name, props, "Network")
+            return bound
 
     @pyaedt_function_handler()
     def create_network_blocks(
@@ -1840,12 +1822,8 @@ class Icepak(FieldAnalysisIcepak):
         props["SurfaceOnly"] = surfaces
 
         name = generate_unique_name("EMLoss")
-        bound = BoundaryObject(self, name, props, "EMLoss")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            self.logger.info("EM losses mapped from design: %s.", design)
-            return bound
-        return False
+        bound = self._create_boundary(name, props, "EMLoss")
+        return bound
 
     @pyaedt_function_handler()
     def eval_surface_quantity_from_field_summary(
@@ -3444,12 +3422,8 @@ class Icepak(FieldAnalysisIcepak):
         }
 
         self.modeler.primitives[object_name].material_name = "Ceramic_material"
-        boundary = BoundaryObject(self, object_name, props, "Network")
-        if boundary.create():
-            self._boundaries[boundary.name] = boundary
-            self.modeler.primitives[object_name].solve_inside = False
-            return boundary
-        return None
+        bound = self._create_boundary(object_name, props, "Network")
+        return bound
 
     @pyaedt_function_handler(htc_dataset="htc")
     def assign_stationary_wall(
@@ -3678,8 +3652,8 @@ class Icepak(FieldAnalysisIcepak):
         props["External Surface Radiation"] = ext_surf_rad
         props["External Material"] = ext_surf_rad_material
         props["External Radiation View Factor"] = ext_surf_rad_view_factor
-        bound = BoundaryObject(self, name, props, "Stationary Wall")
-        return _create_boundary(bound)
+        bound = self._create_boundary(name, props, "Stationary Wall")
+        return bound
 
     @pyaedt_function_handler()
     def assign_stationary_wall_with_heat_flux(
@@ -4143,12 +4117,8 @@ class Icepak(FieldAnalysisIcepak):
             else:
                 props[quantity] = value
 
-        bound = BoundaryObject(self, boundary_name, props, "SourceIcepak")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        else:
-            return None
+        bound = self._create_boundary(boundary_name, props, "SourceIcepak")
+        return bound
 
     @pyaedt_function_handler()
     def create_network_object(self, name=None, props=None, create=False):
@@ -4371,8 +4341,8 @@ class Icepak(FieldAnalysisIcepak):
         if not boundary_name:
             boundary_name = generate_unique_name("Block")
 
-        bound = BoundaryObject(self, boundary_name, props, "Block")
-        return _create_boundary(bound)
+        bound = self._create_boundary(boundary_name, props, "Block")
+        return bound
 
     @pyaedt_function_handler
     def assign_hollow_block(
@@ -4490,8 +4460,8 @@ class Icepak(FieldAnalysisIcepak):
         if not boundary_name:
             boundary_name = generate_unique_name("Block")
 
-        bound = BoundaryObject(self, boundary_name, props, "Block")
-        return _create_boundary(bound)
+        bound = self._create_boundary(boundary_name, props, "Block")
+        return bound
 
     @pyaedt_function_handler(timestep="time_step")
     def get_fans_operating_point(self, export_file=None, setup_name=None, time_step=None, design_variation=None):
@@ -4694,13 +4664,8 @@ class Icepak(FieldAnalysisIcepak):
 
         if not boundary_name:
             boundary_name = generate_unique_name("Opening")
-
-        bound = BoundaryObject(self, boundary_name, props, "Opening")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        else:
-            return None
+        bound = self._create_boundary(boundary_name, props, "Opening")
+        return bound
 
     @pyaedt_function_handler()
     def assign_pressure_free_opening(
@@ -4960,8 +4925,8 @@ class Icepak(FieldAnalysisIcepak):
         else:
             props["Objects"] = geometry
 
-        bound = BoundaryObject(self, boundary_name, props, "Symmetry Wall")
-        return _create_boundary(bound)
+        bound = self._create_boundary(boundary_name, props, "Symmetry Wall")
+        return bound
 
     @pyaedt_function_handler()
     def assign_adiabatic_plate(self, assignment, high_radiation_dict=None, low_radiation_dict=None, boundary_name=None):
@@ -5029,16 +4994,8 @@ class Icepak(FieldAnalysisIcepak):
 
         if not boundary_name:
             boundary_name = generate_unique_name("AdiabaticPlate")
-
-        bound = BoundaryObject(self, boundary_name, props, "Adiabatic Plate")
-        try:
-            if bound.create():
-                self._boundaries[bound.name] = bound
-                return bound
-            else:  # pragma: no cover
-                raise SystemExit
-        except (GrpcApiError, SystemExit):  # pragma: no cover
-            return None
+        bound = self._create_boundary(boundary_name, props, "AdiabaticPlate")
+        return bound
 
     @pyaedt_function_handler()
     def assign_resistance(
@@ -5207,16 +5164,8 @@ class Icepak(FieldAnalysisIcepak):
 
         if not boundary_name:
             boundary_name = generate_unique_name("Resistance")
-
-        bound = BoundaryObject(self, boundary_name, props, "Resistance")
-        try:
-            if bound.create():
-                self._boundaries[bound.name] = bound
-                return bound
-            else:  # pragma: no cover
-                raise SystemExit
-        except (GrpcApiError, SystemExit):  # pragma: no cover
-            return None
+        bound = self._create_boundary(boundary_name, props, "Resistance")
+        return bound
 
     @pyaedt_function_handler()
     def assign_power_law_resistance(
@@ -5610,8 +5559,8 @@ class Icepak(FieldAnalysisIcepak):
         if not boundary_name:
             boundary_name = generate_unique_name("Recirculating")
 
-        bound = BoundaryObject(self, boundary_name, props, "Recirculating")
-        return _create_boundary(bound)
+        bound = self._create_boundary(boundary_name, props, "Recirculating")
+        return bound
 
     @pyaedt_function_handler()
     def assign_blower_type1(
@@ -5807,8 +5756,8 @@ class Icepak(FieldAnalysisIcepak):
         props["Y"] = [str(pt) for pt in fan_curve_pressure]
         if not boundary_name:
             boundary_name = generate_unique_name("Blower")
-        bound = BoundaryObject(self, boundary_name, props, "Blower")
-        return _create_boundary(bound)
+        bound = self._create_boundary(boundary_name, props, "Blower")
+        return bound
 
     @pyaedt_function_handler()
     def assign_conducting_plate(
@@ -5927,8 +5876,8 @@ class Icepak(FieldAnalysisIcepak):
         props["Shell Conduction"] = shell_conduction
         if not boundary_name:
             boundary_name = generate_unique_name("Plate")
-        bound = BoundaryObject(self, boundary_name, props, "Conducting Plate")
-        return _create_boundary(bound)
+        bound = self._create_boundary(boundary_name, props, "Conducting Plate")
+        return bound
 
     def assign_conducting_plate_with_thickness(
         self,

--- a/src/ansys/aedt/core/maxwell.py
+++ b/src/ansys/aedt/core/maxwell.py
@@ -43,14 +43,14 @@ from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.generic.general_methods import read_configuration_file
 from ansys.aedt.core.generic.general_methods import write_configuration_file
 from ansys.aedt.core.generic.settings import settings
+from ansys.aedt.core.mixins import CreateBoundaryMixin
 from ansys.aedt.core.modeler.cad.elements_3d import FacePrimitive
 from ansys.aedt.core.modeler.geometry_operators import GeometryOperators
-from ansys.aedt.core.modules.boundary.common import BoundaryObject
 from ansys.aedt.core.modules.boundary.maxwell_boundary import MaxwellParameters
 from ansys.aedt.core.modules.setup_templates import SetupKeys
 
 
-class Maxwell(object):
+class Maxwell(CreateBoundaryMixin):
     def __init__(self):
         pass
 
@@ -431,7 +431,7 @@ class Maxwell(object):
                         prop = dict({"GroupName": element, "NumberOfBranches": branches[cont], "Sources": source_list})
                         props["MatrixGroup"]["MatrixGroup"].append(prop)
                         cont += 1
-            return self._create_boundary_object(matrix_name, props, "Matrix")
+            return self._create_boundary(matrix_name, props, "Matrix")
         else:
             raise AEDTRuntimeError("Solution type does not have matrix parameters")
 
@@ -753,7 +753,7 @@ class Maxwell(object):
                 props = dict({"Objects": assignment, "Current": amplitude, "IsPositive": swap_direction})
             else:
                 raise ValueError("Input must be a 2D object.")
-        return self._create_boundary_object(name, props, "Current")
+        return self._create_boundary(name, props, "Current")
 
     @pyaedt_function_handler(band_object="assignment")
     def assign_translate_motion(
@@ -850,7 +850,7 @@ class Maxwell(object):
                 "Objects": object_list,
             }
         )
-        return self._create_boundary_object(motion_name, props, "Band")
+        return self._create_boundary(motion_name, props, "Band")
 
     @pyaedt_function_handler(band_object="assignment")
     def assign_rotate_motion(
@@ -945,7 +945,7 @@ class Maxwell(object):
                 "Objects": object_list,
             }
         )
-        return self._create_boundary_object(motion_name, props, "Band")
+        return self._create_boundary(motion_name, props, "Band")
 
     @pyaedt_function_handler(face_list="assignment")
     def assign_voltage(self, assignment, amplitude=1, name=None):
@@ -1010,7 +1010,7 @@ class Maxwell(object):
                 key = "Edges" if is_maxwell_2d else "Faces"
                 props[key].append(element)
 
-        return self._create_boundary_object(name, props, "Voltage")
+        return self._create_boundary(name, props, "Voltage")
 
     @pyaedt_function_handler(face_list="assignment")
     def assign_voltage_drop(self, assignment, amplitude=1, swap_direction=False, name=None):
@@ -1047,7 +1047,7 @@ class Maxwell(object):
         assignment = self.modeler.convert_to_selections(assignment, True)
 
         props = dict({"Faces": assignment, "Voltage Drop": amplitude, "Point out of terminal": swap_direction})
-        return self._create_boundary_object(name, props, "VoltageDrop")
+        return self._create_boundary(name, props, "VoltageDrop")
 
     @pyaedt_function_handler()
     def assign_floating(self, assignment, charge_value=0, name=None):
@@ -1120,7 +1120,7 @@ class Maxwell(object):
         if not name:
             name = generate_unique_name("Floating")
 
-        return self._create_boundary_object(name, props, "Floating")
+        return self._create_boundary(name, props, "Floating")
 
     @pyaedt_function_handler(coil_terminals="assignment", current_value="current", res="resistance", ind="inductance")
     def assign_winding(
@@ -1190,7 +1190,7 @@ class Maxwell(object):
                 "Phase": self.modeler._arg_with_dim(phase, "deg"),
             }
         )
-        bound = self._create_boundary_object(name, props, "Winding")
+        bound = self._create_boundary(name, props, "Winding")
         if bound:
             if assignment is None:
                 assignment = []
@@ -1293,7 +1293,7 @@ class Maxwell(object):
             else:
                 raise AEDTRuntimeError("Face Selection is not allowed in Maxwell 2D. Provide a 2D object.")
 
-        return self._create_boundary_object(name, props, bound_type)
+        return self._create_boundary(name, props, bound_type)
 
     @pyaedt_function_handler(input_object="assignment", reference_cs="coordinate_system")
     def assign_force(self, assignment, coordinate_system="Global", is_virtual=True, force_name=None):
@@ -1371,7 +1371,7 @@ class Maxwell(object):
                     "Objects": assignment,
                 }
             )
-        return self._create_boundary_object(force_name, prop, "Force")
+        return self._create_boundary(force_name, prop, "Force")
 
     @pyaedt_function_handler(input_object="assignment", reference_cs="coordinate_system")
     def assign_torque(
@@ -1438,7 +1438,7 @@ class Maxwell(object):
                     "Objects": assignment,
                 }
             )
-        return self._create_boundary_object(torque_name, prop, "Torque")
+        return self._create_boundary(torque_name, prop, "Torque")
 
     @pyaedt_function_handler()
     def solve_inside(self, name, activate=True):
@@ -1561,7 +1561,7 @@ class Maxwell(object):
                 prop = dict({"Name": symmetry_name, "Faces": assignment, "IsOdd": is_odd})
         else:
             raise ValueError("At least one edge must be provided.")
-        return self._create_boundary_object(symmetry_name, prop, "Symmetry")
+        return self._create_boundary(symmetry_name, prop, "Symmetry")
 
     @pyaedt_function_handler(
         entities="assignment",
@@ -1692,7 +1692,7 @@ class Maxwell(object):
                     bound_name = current_density_name
                     bound_type = "CurrentDensity"
 
-            return self._create_boundary_object(bound_name, bound_props, bound_type)
+            return self._create_boundary(bound_name, bound_props, bound_type)
         except Exception:
             raise AEDTRuntimeError("Couldn't assign current density to desired list of objects.")
 
@@ -1746,7 +1746,7 @@ class Maxwell(object):
                 props["Objects"].append(sel)
             elif isinstance(sel, int):
                 props["Faces"].append(sel)
-        return self._create_boundary_object(radiation, props, "Radiation")
+        return self._create_boundary(radiation, props, "Radiation")
 
     @pyaedt_function_handler(objects="assignment")
     def enable_harmonic_force(
@@ -2135,16 +2135,21 @@ class Maxwell(object):
         setup.update()
         return setup
 
-    def _create_boundary_object(self, name, props, boundary_type):
-        if boundary_type in ["Force", "Torque", "Matrix", "LayoutForce"]:
-            bound = MaxwellParameters(self, name, props, boundary_type)
-        else:
-            bound = BoundaryObject(self, name, props, boundary_type)
-        if bound.create():
-            self.logger.info(f"Boundary {name} has been correctly created.")
+    @pyaedt_function_handler
+    # NOTE: Extend Mixin behaviour to handle Maxwell parameters
+    def _create_boundary(self, name, props, boundary_type):
+        # Non Maxwell parameters cases
+        if boundary_type not in ("Force", "Torque", "Matrix", "LayoutForce"):
+            return super()._create_boundary(name, props, boundary_type)
+
+        # Maxwell parameters cases
+        bound = MaxwellParameters(self, name, props, boundary_type)
+        result = bound.create()
+        if result:
             self._boundaries[bound.name] = bound
+            self.logger.info(f"Boundary {boundary_type} {name} has been created.")
             return bound
-        raise AEDTRuntimeError(f"Boundary {name} was not created.")
+        raise AEDTRuntimeError(f"Failed to create boundary {boundary_type} {name}")
 
 
 class Maxwell3d(Maxwell, FieldAnalysis3D, object):
@@ -2336,7 +2341,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
                 props["Objects"].append(sel)
             elif isinstance(sel, int):
                 props["Faces"].append(sel)
-        return self._create_boundary_object(insulation, props, "Insulating")
+        return self._create_boundary(insulation, props, "Insulating")
 
     @pyaedt_function_handler(geometry_selection="assignment", impedance_name="impedance")
     def assign_impedance(
@@ -2417,7 +2422,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
             props["UseMaterial"] = False
             props["Permeability"] = permeability
             props["Conductivity"] = conductivity
-        return self._create_boundary_object(impedance, props, "Impedance")
+        return self._create_boundary(impedance, props, "Impedance")
 
     @pyaedt_function_handler(entities="assignment")
     def assign_current_density_terminal(self, assignment, current_density_name=None):
@@ -2463,7 +2468,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
                 bound_name = current_density_name
                 bound_type = "CurrentDensityTerminal"
 
-            boundary = self._create_boundary_object(bound_name, props, bound_type)
+            boundary = self._create_boundary(bound_name, props, bound_type)
             if boundary:
                 return True
         except GrpcApiError as e:
@@ -2573,7 +2578,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
             master_props = dict(
                 {"Faces": independent, "CoordSysVector": u_master_vector_coordinates, "ReverseV": reverse_master}
             )
-            master = self._create_boundary_object(bound_name_m, master_props, "Independent")
+            master = self._create_boundary(bound_name_m, master_props, "Independent")
             if master:
                 u_slave_vector_coordinates = dict(
                     {
@@ -2592,7 +2597,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
                         "RelationIsSame": same_as_master,
                     }
                 )
-                slave = self._create_boundary_object(bound_name_s, slave_props, "Dependent")
+                slave = self._create_boundary(bound_name_s, slave_props, "Dependent")
                 if slave:
                     return master, slave
         except GrpcApiError as e:
@@ -2644,7 +2649,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         props = {"NAME": flux_name, "Faces": []}
         for sel in assignment:
             props["Faces"].append(sel)
-        return self._create_boundary_object(flux_name, props, "FluxTangential")
+        return self._create_boundary(flux_name, props, "FluxTangential")
 
     @pyaedt_function_handler(nets_layers_mapping="net_layers", reference_cs="coordinate_system")
     def assign_layout_force(
@@ -2719,7 +2724,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
                 "NetsAndLayersChoices": dict({component_name: dict({"NetLayerSetMap": nets_layers_props})}),
             }
         )
-        return self._create_boundary_object(force_name, props, "LayoutForce")
+        return self._create_boundary(force_name, props, "LayoutForce")
 
     @pyaedt_function_handler(faces="assignment")
     def assign_tangential_h_field(
@@ -2803,7 +2808,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
 
         props["CoordSysVector"] = dict({"Coordinate System": coordinate_system, "Origin": origin, "UPos": u_pos})
         props["ReverseV"] = reverse
-        return self._create_boundary_object(bound_name, props, "Tangential H Field")
+        return self._create_boundary(bound_name, props, "Tangential H Field")
 
     @pyaedt_function_handler(faces="assignment", bound_name="boundary")
     def assign_zero_tangential_h_field(self, assignment, boundary=None):
@@ -2837,7 +2842,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
                 "Faces": assignment,
             }
         )
-        return self._create_boundary_object(boundary, props, "Zero Tangential H Field")
+        return self._create_boundary(boundary, props, "Zero Tangential H Field")
 
     @pyaedt_function_handler()
     def assign_resistive_sheet(
@@ -2965,7 +2970,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
             props["CathodeParC"] = cathode_c
             props["CathodeParD"] = cathode_d
 
-        return self._create_boundary_object(name, props, "ResistiveSheet")
+        return self._create_boundary(name, props, "ResistiveSheet")
 
 
 class Maxwell2d(Maxwell, FieldAnalysis3D, object):
@@ -3237,7 +3242,7 @@ class Maxwell2d(Maxwell, FieldAnalysis3D, object):
             boundary = generate_unique_name("Balloon")
 
         props = dict({"Edges": assignment})
-        return self._create_boundary_object(boundary, props, "Balloon")
+        return self._create_boundary(boundary, props, "Balloon")
 
     @pyaedt_function_handler(input_edge="assignment", vectorvalue="vector_value", bound_name="boundary")
     def assign_vector_potential(self, assignment, vector_value=0, boundary=None):
@@ -3284,7 +3289,7 @@ class Maxwell2d(Maxwell, FieldAnalysis3D, object):
         else:
             props2 = dict({"Edges": assignment, "Value": str(vector_value), "CoordinateSystem": ""})
 
-        return self._create_boundary_object(boundary, props2, "Vector Potential")
+        return self._create_boundary(boundary, props2, "Vector Potential")
 
     @pyaedt_function_handler(master_edge="independent", slave_edge="dependent", bound_name="boundary")
     def assign_master_slave(
@@ -3329,7 +3334,7 @@ class Maxwell2d(Maxwell, FieldAnalysis3D, object):
                 bound_name_m = boundary
                 bound_name_s = boundary + "_dep"
             master_props = dict({"Edges": independent, "ReverseV": reverse_master})
-            master = self._create_boundary_object(bound_name_m, master_props, "Independent")
+            master = self._create_boundary(bound_name_m, master_props, "Independent")
             if master:
                 slave_props = dict(
                     {
@@ -3339,7 +3344,7 @@ class Maxwell2d(Maxwell, FieldAnalysis3D, object):
                         "SameAsMaster": same_as_master,
                     }
                 )
-                slave = self._create_boundary_object(bound_name_s, slave_props, "Dependent")
+                slave = self._create_boundary(bound_name_s, slave_props, "Dependent")
                 if slave:
                     return master, slave
         except GrpcApiError as e:
@@ -3389,4 +3394,4 @@ class Maxwell2d(Maxwell, FieldAnalysis3D, object):
                 "InductanceValue": self.modeler._arg_with_dim(inductance, "H"),
             }
         )
-        return self._create_boundary_object(boundary, props, "EndConnection")
+        return self._create_boundary(boundary, props, "EndConnection")

--- a/src/ansys/aedt/core/mechanical.py
+++ b/src/ansys/aedt/core/mechanical.py
@@ -31,11 +31,11 @@ from ansys.aedt.core.generic.constants import SOLUTIONS
 from ansys.aedt.core.generic.errors import AEDTRuntimeError
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
-from ansys.aedt.core.modules.boundary.common import BoundaryObject
+from ansys.aedt.core.mixins import CreateBoundaryMixin
 from ansys.aedt.core.modules.setup_templates import SetupKeys
 
 
-class Mechanical(FieldAnalysis3D, object):
+class Mechanical(FieldAnalysis3D, CreateBoundaryMixin):
     """Provides the Mechanical application interface.
 
     Parameters
@@ -270,12 +270,7 @@ class Mechanical(FieldAnalysis3D, object):
             props["SurfaceOnly"] = surfaces
 
         name = generate_unique_name("EMLoss")
-        bound = BoundaryObject(self, name, props, "EMLoss")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            self.logger.info("EM losses mapped from design %s.", design)
-            return bound
-        return False
+        return self._create_boundary(name, props, "EMLoss")
 
     @pyaedt_function_handler(
         designname="design",
@@ -364,13 +359,7 @@ class Mechanical(FieldAnalysis3D, object):
         }
 
         name = generate_unique_name("ThermalLink")
-        bound = BoundaryObject(self, name, props, "ThermalCondition")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            self.logger.info("Thermal conditions are mapped from design %s.", design)
-            return bound
-
-        return True
+        return self._create_boundary(name, props, "ThermalCondition")
 
     @pyaedt_function_handler(objects_list="assignment", boundary_name="name")
     def assign_uniform_convection(
@@ -424,11 +413,7 @@ class Mechanical(FieldAnalysis3D, object):
 
         if not name:
             name = generate_unique_name("Convection")
-        bound = BoundaryObject(self, name, props, "Convection")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(name, props, "Convection")
 
     @pyaedt_function_handler(objects_list="assignment", boundary_name="name")
     def assign_uniform_temperature(self, assignment, temperature="AmbientTemp", name=""):
@@ -471,11 +456,7 @@ class Mechanical(FieldAnalysis3D, object):
 
         if not name:
             name = generate_unique_name("Temp")
-        bound = BoundaryObject(self, name, props, "Temperature")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(name, props, "Temperature")
 
     @pyaedt_function_handler(objects_list="assignment", boundary_name="name")
     def assign_frictionless_support(self, assignment, name=""):
@@ -514,11 +495,7 @@ class Mechanical(FieldAnalysis3D, object):
 
         if not name:
             name = generate_unique_name("Temp")
-        bound = BoundaryObject(self, name, props, "Frictionless")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(name, props, "Frictionless")
 
     @pyaedt_function_handler(objects_list="assignment", boundary_name="name")
     def assign_fixed_support(self, assignment, name=""):
@@ -555,11 +532,7 @@ class Mechanical(FieldAnalysis3D, object):
 
         if not name:
             name = generate_unique_name("Temp")
-        bound = BoundaryObject(self, name, props, "FixedSupport")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(name, props, "FixedSupport")
 
     @property
     def existing_analysis_sweeps(self):
@@ -623,12 +596,7 @@ class Mechanical(FieldAnalysis3D, object):
 
         if not name:
             name = generate_unique_name("HeatFlux")
-
-        bound = BoundaryObject(self, name, props, "HeatFlux")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(name, props, "HeatFlux")
 
     @pyaedt_function_handler(objects_list="assignment", boundary_name="name")
     def assign_heat_generation(self, assignment, value, name=""):
@@ -665,12 +633,7 @@ class Mechanical(FieldAnalysis3D, object):
 
         if not name:
             name = generate_unique_name("HeatGeneration")
-
-        bound = BoundaryObject(self, name, props, "HeatGeneration")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(name, props, "HeatGeneration")
 
     @pyaedt_function_handler()
     def assign_2way_coupling(self, setup=None, number_of_iterations=2):

--- a/src/ansys/aedt/core/mixins.py
+++ b/src/ansys/aedt/core/mixins.py
@@ -70,10 +70,11 @@ class CreateBoundaryMixin:
         """
         try:
             bound = BoundaryObject(self, name, props, boundary_type)
-            result = bound.create()
-            if result:
-                self._boundaries[bound.name] = bound
-                self.logger.info(f"Boundary {boundary_type} {name} has been created.")
-                return bound
+            if not bound.create():
+                raise AEDTRuntimeError(f"Failed to create boundary {boundary_type} {name}")
+
+            self._boundaries[bound.name] = bound
+            self.logger.info(f"Boundary {boundary_type} {name} has been created.")
+            return bound
         except GrpcApiError as e:
             raise AEDTRuntimeError(f"Failed to create boundary {boundary_type} {name}") from e

--- a/src/ansys/aedt/core/mixins.py
+++ b/src/ansys/aedt/core/mixins.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 
 from ansys.aedt.core.generic.errors import AEDTRuntimeError
+from ansys.aedt.core.generic.errors import GrpcApiError
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.modules.boundary.common import BoundaryObject
 
@@ -67,11 +68,12 @@ class CreateBoundaryMixin:
             Boundary object.
 
         """
-
-        bound = BoundaryObject(self, name, props, boundary_type)
-        result = bound.create()
-        if result:
-            self._boundaries[bound.name] = bound
-            self.logger.info(f"Boundary {boundary_type} {name} has been created.")
-            return bound
-        raise AEDTRuntimeError(f"Failed to create boundary {boundary_type} {name}")
+        try:
+            bound = BoundaryObject(self, name, props, boundary_type)
+            result = bound.create()
+            if result:
+                self._boundaries[bound.name] = bound
+                self.logger.info(f"Boundary {boundary_type} {name} has been created.")
+                return bound
+        except GrpcApiError as e:
+            raise AEDTRuntimeError(f"Failed to create boundary {boundary_type} {name}") from e

--- a/src/ansys/aedt/core/mixins.py
+++ b/src/ansys/aedt/core/mixins.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from ansys.aedt.core.generic.errors import AEDTRuntimeError
+from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
+from ansys.aedt.core.modules.boundary.common import BoundaryObject
+
+
+class CreateBoundaryMixin:
+    """Mixin that provides methods to apply boundary conditions.
+
+    This mixin is designed to be used in classes that require boundary condition.
+    Methods provided by this mixin should be implemented or extended by subclasses
+    to define specific boundary condition behaviors.
+
+    For example:
+        ```python
+        class MyClass(CreateBoundaryMixin):
+
+            def _create_boundary(self):
+                # Use default behavior
+                if boundary_type not in ("SpecificString"):
+                    return super()._create_boundary(name, props, boundary_type)
+                # Custom implementation to create boundary conditions
+                else:
+                    pass
+        ```
+    """
+
+    @pyaedt_function_handler()
+    def _create_boundary(self, name, props, boundary_type):
+        """Create a boundary.
+
+        Parameters
+        ----------
+        name : str
+            Name of the boundary.
+        props : list or dict
+            List of properties for the boundary.
+        boundary_type :
+            Type of the boundary.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.boundary.common.BoundaryObject`
+            Boundary object.
+
+        """
+
+        bound = BoundaryObject(self, name, props, boundary_type)
+        result = bound.create()
+        if result:
+            self._boundaries[bound.name] = bound
+            self.logger.info(f"Boundary {boundary_type} {name} has been created.")
+            return bound
+        raise AEDTRuntimeError(f"Failed to create boundary {boundary_type} {name}")

--- a/src/ansys/aedt/core/mixins.py
+++ b/src/ansys/aedt/core/mixins.py
@@ -35,18 +35,18 @@ class CreateBoundaryMixin:
     Methods provided by this mixin should be implemented or extended by subclasses
     to define specific boundary condition behaviors.
 
-    For example:
-        ```python
-        class MyClass(CreateBoundaryMixin):
+    Example
+    -------
+    A class can use the default behavior or use a custom implementation.
 
-            def _create_boundary(self):
-                # Use default behavior
-                if boundary_type not in ("SpecificString"):
-                    return super()._create_boundary(name, props, boundary_type)
-                # Custom implementation to create boundary conditions
-                else:
-                    pass
-        ```
+    >>> class MyClass(CreateBoundaryMixin):
+    >>>     def _create_boundary(self):
+    >>>         # Use default behavior
+    >>>         if boundary_type not in ("SpecificString"):
+    >>>             return super()._create_boundary(name, props, boundary_type)
+    >>>         # Custom implementation to create boundary conditions
+    >>>         else:
+    >>>             pass
     """
 
     @pyaedt_function_handler()

--- a/src/ansys/aedt/core/modules/boundary/icepak_boundary.py
+++ b/src/ansys/aedt/core/modules/boundary/icepak_boundary.py
@@ -255,17 +255,6 @@ class PieceWiseLinearDictionary(BoundaryDictionary):
         return self.dataset.name
 
 
-def _create_boundary(bound):
-    try:
-        if bound.create():
-            bound._app._boundaries[bound.name] = bound
-            return bound
-        else:  # pragma : no cover
-            raise Exception
-    except Exception:  # pragma: no cover
-        return None
-
-
 class NetworkObject(BoundaryObject):
     """Manages networks in Icepak projects."""
 

--- a/src/ansys/aedt/core/q3d.py
+++ b/src/ansys/aedt/core/q3d.py
@@ -37,6 +37,7 @@ from ansys.aedt.core.generic.constants import MATRIXOPERATIONSQ3D
 from ansys.aedt.core.generic.general_methods import generate_unique_name
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.generic.settings import settings
+from ansys.aedt.core.mixins import CreateBoundaryMixin
 from ansys.aedt.core.modeler.geometry_operators import GeometryOperators as go
 from ansys.aedt.core.modules.boundary.common import BoundaryObject
 from ansys.aedt.core.modules.boundary.q3d_boundary import Matrix
@@ -1210,7 +1211,7 @@ class QExtractor(FieldAnalysis3D, object):
                 return False
 
 
-class Q3d(QExtractor, object):
+class Q3d(QExtractor, CreateBoundaryMixin):
     """Provides the Q3D app interface.
 
     This class allows you to create an instance of Q3D and link to an
@@ -1535,11 +1536,8 @@ class Q3d(QExtractor, object):
             type_bound = "GroundNet"
         elif net_type.lower() == "floating":
             type_bound = "FloatingNet"
-        bound = BoundaryObject(self, net_name, props, type_bound)
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+
+        return self._create_boundary(net_name, props, type_bound)
 
     @pyaedt_function_handler(objects="assignment", axisdir="direction")
     def source(self, assignment=None, direction=0, name=None, net_name=None, terminal_type="voltage"):
@@ -1636,11 +1634,7 @@ class Q3d(QExtractor, object):
         props["TerminalType"] = terminal_str
         if net_name:
             props["Net"] = net_name
-        bound = BoundaryObject(self, name, props, exc_type)
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(name, props, exc_type)
 
     @pyaedt_function_handler(
         object_name="assignment",
@@ -1693,10 +1687,7 @@ class Q3d(QExtractor, object):
             net_name = assignment
         if a:
             props = dict({"Faces": [a], "ParentBndID": assignment, "TerminalType": "ConstantVoltage", "Net": net_name})
-            bound = BoundaryObject(self, name, props, "Sink")
-            if bound.create():
-                self._boundaries[bound.name] = bound
-                return bound
+            return self._create_boundary(name, props, "Sink")
         return False
 
     @pyaedt_function_handler(sheetname="assignment", objectname="object_name", netname="net_name", sinkname="sink_name")
@@ -1755,11 +1746,7 @@ class Q3d(QExtractor, object):
         if net_name:
             props["Net"] = net_name
 
-        bound = BoundaryObject(self, sink_name, props, "Sink")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(sink_name, props, "Sink")
 
     @pyaedt_function_handler()
     def create_frequency_sweep(self, setupname, units=None, freqstart=0, freqstop=1, freqstep=None, sweepname=None):
@@ -2051,11 +2038,7 @@ class Q3d(QExtractor, object):
             thickness = str(thickness) + self.modeler.model_units
         props = dict({"Objects": new_ass, "Material": material, "Thickness": thickness})
 
-        bound = BoundaryObject(self, name, props, "ThinConductor")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False  # pragma: no cover
+        return self._create_boundary(name, props, "ThinConductor")
 
     @pyaedt_function_handler()
     def get_mutual_coupling(
@@ -2199,7 +2182,7 @@ class Q3d(QExtractor, object):
         return data
 
 
-class Q2d(QExtractor, object):
+class Q2d(QExtractor, CreateBoundaryMixin):
     """Provides the Q2D app interface.
 
     This class allows you to create an instance of Q2D and link to an
@@ -2453,11 +2436,7 @@ class Q2d(QExtractor, object):
 
         props = dict({"Objects": obj_names, "SolveOption": solve_option, "Thickness": str(thickness) + units})
 
-        bound = BoundaryObject(self, name, props, conductor_type)
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(name, props, conductor_type)
 
     @pyaedt_function_handler(edges="assignment", unit="units")
     def assign_huray_finitecond_to_edges(self, assignment, radius, ratio, units="um", name=""):
@@ -2495,11 +2474,7 @@ class Q2d(QExtractor, object):
 
         props = dict({"Edges": a, "UseCoating": False, "Radius": ra, "Ratio": str(ratio)})
 
-        bound = BoundaryObject(self, name, props, "Finite Conductivity")
-        if bound.create():
-            self._boundaries[bound.name] = bound
-            return bound
-        return False
+        return self._create_boundary(name, props, "Finite Conductivity")
 
     @pyaedt_function_handler()
     def auto_assign_conductors(self):

--- a/tests/system/general/test_27_Maxwell2D.py
+++ b/tests/system/general/test_27_Maxwell2D.py
@@ -206,7 +206,7 @@ class TestClass:
         )
         assert mas.name == "my_bound"
         assert slave.name == "my_bound_dep"
-        with pytest.raises(AEDTRuntimeError, match="Slave boundary could not be created."):
+        with pytest.raises(AEDTRuntimeError, match=r"Failed to create boundary Dependent Dependent_[A-Za-z0-9]*$"):
             aedtapp.assign_master_slave(
                 aedtapp.modeler["Rectangle1"].edges[0].id,
                 aedtapp.modeler["Rectangle1"].edges[1].id,

--- a/tests/system/general/test_28_Maxwell3D.py
+++ b/tests/system/general/test_28_Maxwell3D.py
@@ -676,9 +676,10 @@ class TestClass:
 
     def test_assign_current_density_terminal(self, m3d_app):
         box = m3d_app.modeler.create_box([50, 0, 50], [294, 294, 19], name="box")
-        assert m3d_app.assign_current_density_terminal(box.faces[0], "current_density_t_1")
-        with pytest.raises(AEDTRuntimeError, match="Current density terminal could not be assigned."):
-            m3d_app.assign_current_density_terminal(box.faces[0], "current_density_t_1")
+        density_name = "current_density_t_1"
+        assert m3d_app.assign_current_density_terminal(box.faces[0], density_name)
+        with pytest.raises(AEDTRuntimeError, match=f"Failed to create boundary CurrentDensityTerminal {density_name}"):
+            m3d_app.assign_current_density_terminal(box.faces[0], density_name)
         assert m3d_app.assign_current_density_terminal([box.faces[0], box.faces[1]], "current_density_t_2")
         m3d_app.solution_type = SOLUTIONS.Maxwell3d.Transient
         with pytest.raises(

--- a/tests/system/general/test_98_Icepak.py
+++ b/tests/system/general/test_98_Icepak.py
@@ -646,8 +646,12 @@ class TestClass:
             voltage_current_choice="Current",
             voltage_current_value={"Type": "Transient", "Function": "Sinusoidal", "Values": ["0A", 1, 1, "1s"]},
         )
-        assert ipk.create_source_power(ipk.modeler["boxSource"].top_face_z.id, input_power="2W", source_name="s01")
-        assert not ipk.create_source_power(ipk.modeler["boxSource"].top_face_z.id, input_power="2W", source_name="s01")
+        source_name = "s01"
+        assert ipk.create_source_power(
+            ipk.modeler["boxSource"].top_face_z.id, input_power="2W", source_name=source_name
+        )
+        with pytest.raises(AEDTRuntimeError, match=f"Failed to create boundary SourceIcepak {source_name}"):
+            ipk.create_source_power(ipk.modeler["boxSource"].top_face_z.id, input_power="2W", source_name=source_name)
 
     def test033__import_idf(self, ipk):
         assert ipk.import_idf(os.path.join(TESTS_GENERAL_PATH, "example_models", test_subfolder, "brd_board.emn"))
@@ -1036,9 +1040,10 @@ class TestClass:
             input_power="1W",
             thickness="1mm",
         )
-        assert not ipk.create_conduting_plate(
-            None, thermal_specification="Thickness", input_power="1W", thickness="1mm", radiate_low=True
-        )
+        with pytest.raises(AEDTRuntimeError, match=r"Failed to create boundary Conducting Plate Source_[A-Za-z0-9]*$"):
+            ipk.create_conduting_plate(
+                None, thermal_specification="Thickness", input_power="1W", thickness="1mm", radiate_low=True
+            )
         assert ipk.create_conduting_plate(
             box_fc_ids,
             thermal_specification="Thickness",
@@ -1115,13 +1120,16 @@ class TestClass:
             ext_surf_rad_ref_temp=0,
             ext_surf_rad_view_factor=0.5,
         )
-        assert not ipk.assign_stationary_wall_with_htc(
-            "surf01",
-            ext_surf_rad=True,
-            ext_surf_rad_material="Stainless-steel-cleaned",
-            ext_surf_rad_ref_temp=0,
-            ext_surf_rad_view_factor=0.5,
-        )
+        with pytest.raises(
+            AEDTRuntimeError, match=r"Failed to create boundary Stationary Wall StationaryWall_[A-Za-z0-9]*$"
+        ):
+            ipk.assign_stationary_wall_with_htc(
+                "surf01",
+                ext_surf_rad=True,
+                ext_surf_rad_material="Stainless-steel-cleaned",
+                ext_surf_rad_ref_temp=0,
+                ext_surf_rad_view_factor=0.5,
+            )
         ipk.solution_type = "Transient"
         assert ipk.assign_stationary_wall_with_temperature(
             "surf1",
@@ -1201,9 +1209,11 @@ class TestClass:
         block = ipk.assign_hollow_block("BlockBox5", "Total Power", power_dict, "Test")
         assert block
         block.delete()
-        block = ipk.assign_hollow_block("BlockBox5", "Total Power", "1W", boundary_name="TestH")
+        boundary_name = "TestH"
+        block = ipk.assign_hollow_block("BlockBox5", "Total Power", "1W", boundary_name=boundary_name)
         assert block
-        assert not ipk.assign_hollow_block("BlockBox5", "Total Power", "1W", boundary_name="TestH")
+        with pytest.raises(AEDTRuntimeError, match=f"Failed to create boundary Block {boundary_name}"):
+            ipk.assign_hollow_block("BlockBox5", "Total Power", "1W", boundary_name=boundary_name)
 
     def test056__assign_solid_block(self, ipk):
         ipk.solution_type = "Transient"
@@ -1225,9 +1235,11 @@ class TestClass:
         block = ipk.assign_solid_block("BlockBox3", "Joule Heating")
         assert block
         block.delete()
-        block = ipk.assign_solid_block("BlockBox3", "1W", boundary_name="Test")
+        boundary_name = "Test"
+        block = ipk.assign_solid_block("BlockBox3", "1W", boundary_name=boundary_name)
         assert block
-        assert not ipk.assign_solid_block("BlockBox3", "1W", boundary_name="Test")
+        with pytest.raises(AEDTRuntimeError, match=f"Failed to create boundary Block {boundary_name}"):
+            ipk.assign_solid_block("BlockBox3", "1W", boundary_name=boundary_name)
 
     def test057__assign_network_from_matrix(self, ipk):
         box = ipk.modeler.create_box([0, 0, 0], [20, 50, 80])
@@ -1441,7 +1453,10 @@ class TestClass:
             boundary_name="sym_bc03",
         )
         assert ipk.assign_symmetry_wall(geometry=region_fc_ids[1:4])
-        assert not ipk.assign_symmetry_wall(geometry="surf01")
+        with pytest.raises(
+            AEDTRuntimeError, match=r"Failed to create boundary Symmetry Wall SymmetryWall_[A-Za-z0-9]*$"
+        ):
+            ipk.assign_symmetry_wall(geometry="surf01")
 
     def test063__update_3d_component(self, ipk, local_scratch):
         file_path = local_scratch.path

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,19 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from unittest.mock import MagicMock
-from unittest.mock import patch
-
 from ansys.aedt.core.generic.settings import settings
-from ansys.aedt.core.maxwell import Maxwell3d
-import pytest
 
 settings.enable_error_handler = False
-
-
-@pytest.fixture
-def maxwell_3d_setup():
-    """Fixture used to mock the creation of a Maxwell instance."""
-    with patch("ansys.aedt.core.maxwell.Maxwell3d.__init__", lambda x: None):
-        mock_instance = MagicMock(spec=Maxwell3d)
-        yield mock_instance

--- a/tests/unit/test_maxwell_3d.py
+++ b/tests/unit/test_maxwell_3d.py
@@ -30,8 +30,16 @@ from ansys.aedt.core.maxwell import Maxwell3d
 import pytest
 
 
+@pytest.fixture
+def maxwell_3d_setup():
+    """Fixture used to mock the creation of a Maxwell instance."""
+    with patch("ansys.aedt.core.maxwell.Maxwell3d.__init__", lambda x: None):
+        mock_instance = MagicMock(spec=Maxwell3d)
+        yield mock_instance
+
+
 @patch.object(Maxwell3d, "solution_type", "Transient")
-@patch("ansys.aedt.core.maxwell.BoundaryObject", autospec=True)
+@patch("ansys.aedt.core.mixins.BoundaryObject", autospec=True)
 def test_maxwell_3d_assign_resistive_sheet_failure(mock_boundary_object, maxwell_3d_setup):
     boundary_object = MagicMock()
     boundary_object.create.return_value = False
@@ -40,5 +48,5 @@ def test_maxwell_3d_assign_resistive_sheet_failure(mock_boundary_object, maxwell
     maxwell._modeler = MagicMock()
     maxwell._logger = MagicMock()
 
-    with pytest.raises(AEDTRuntimeError, match=r"Boundary ResistiveSheet_\w+ was not created\."):
+    with pytest.raises(AEDTRuntimeError, match="Failed to create boundary"):
         maxwell.assign_resistive_sheet(None, None)


### PR DESCRIPTION
## Description
Using Mixin is a good practice, we should try to refactor the code and follow this kind of approach. This PR is a starting point in that direction and is currently only adding a CreateBoundaryMixin class.

A Mixin is used to add reusable functionality to multiple classes without creating deep inheritance hierarchies. Typically, such class are small, contain additional methods and **should not be instantiated on its own.**

> [!NOTE]
Currently the changes are not applied to all main classes of PyAEDT as it is more a proof of concept. I'm only applying it in classes where the idea of a method used to create a boundary was already implemented.

## Issue linked
Associated to #5504 

## Checklist
- [ ] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
