### PR TITLE
FIX: Launch extension from a CPython process instead of Ironpython process

### DIFF
--- a/src/ansys/aedt/core/workflows/hfss/shielding_effectiveness.py
+++ b/src/ansys/aedt/core/workflows/hfss/shielding_effectiveness.py
@@ -336,6 +336,7 @@ def main(extension_args):
     # Create sphere
 
     sphere = aedtapp.modeler.create_sphere(origin=center, radius=sphere_size, material="pec")
+    sphere.name = "dipole"
 
     # Assign incident wave
     is_electric = False
@@ -415,6 +416,10 @@ def main(extension_args):
 
     original_1meter = original.post.get_solution_data("Sphere1meter", report_category="Emission Test")
     original_3meters = original.post.get_solution_data("Sphere3meters", report_category="Emission Test")
+
+    if None in (free_space_1meter, free_space_3meters, original_1meter, original_3meters):  # pragma: no cover
+        aedtapp.logger.error("Data can not be obtained.")
+        return False
 
     frequencies = free_space_1meter.primary_sweep_values
     frequency_units = free_space_1meter.units_sweeps["Freq"]

--- a/src/ansys/aedt/core/workflows/templates/run_pyaedt_toolkit_script.py_build
+++ b/src/ansys/aedt/core/workflows/templates/run_pyaedt_toolkit_script.py_build
@@ -28,6 +28,7 @@ The script executes the PyAEDT workflow.
 """
 import os
 import sys
+import platform
 
 is_linux = os.name == "posix"
 
@@ -36,22 +37,22 @@ if is_linux:
 else:
     import subprocess
 
-toolkits_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-
-sys.path.append(toolkits_dir)
-
-import pyaedt_utils
+is_iron_python = platform.python_implementation().lower() == "ironpython"
 
 
-def main():
+def aedt_script():
     try:
+        toolkits_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+        sys.path.append(toolkits_dir)
+        import pyaedt_utils
+
         # Get AEDT version
         short_version = oDesktop.GetVersion()[2:6].replace(".", "")
         oDesktop.AddMessage("", "", 0, "Toolkit launched. Wait.")
         # CPython interpreter
         python_exe = r"##PYTHON_EXE##"
         # Python script
-        pyaedt_script = r"##PYTHON_SCRIPT##"
+        extension_pyaedt_script = os.path.normpath(__file__)
         # Check if CPython interpreter and AEDT release match
         python_exe = pyaedt_utils.sanitize_interpreter_path(python_exe, short_version)
         # Check python executable
@@ -59,7 +60,7 @@ def main():
         if not python_exe_flag:
             return
         # Check script file
-        pyaedt_script_flag = pyaedt_utils.check_file(pyaedt_script, oDesktop)
+        pyaedt_script_flag = pyaedt_utils.check_file(extension_pyaedt_script, oDesktop)
         if not pyaedt_script_flag:
             return
         # Add environment variables
@@ -67,11 +68,24 @@ def main():
         # Run workflow
         pyaedt_utils.set_ansys_em_environment(oDesktop)
         my_env = dict(os.environ.copy())
-        command = [python_exe, pyaedt_script]
+        command = [python_exe, extension_pyaedt_script]
         subprocess.Popen(command, env=my_env)
     except Exception as e:
         pyaedt_utils.show_error(str(e), oDesktop)
 
 
+def pyaedt_script():
+    # CPython interpreter
+    python_exe = r"##PYTHON_EXE##"
+    # Python script
+    pyaedt_script = r"##PYTHON_SCRIPT##"
+    command = [python_exe, pyaedt_script]
+    my_env = dict(os.environ.copy())
+    subprocess.Popen(command, env=my_env)
+
+
 if __name__ == "__main__":
-    main()
+    if is_iron_python:
+        aedt_script()
+    else:
+        pyaedt_script()

--- a/src/ansys/aedt/core/workflows/templates/run_pyaedt_toolkit_script.py_build
+++ b/src/ansys/aedt/core/workflows/templates/run_pyaedt_toolkit_script.py_build
@@ -32,16 +32,15 @@ import platform
 
 is_linux = os.name == "posix"
 
-if is_linux:
-    import subprocessdotnet as subprocess
-else:
-    import subprocess
-
 is_iron_python = platform.python_implementation().lower() == "ironpython"
 
 
 def aedt_script():
     try:
+        if is_linux:
+            import subprocessdotnet as subprocess
+        else:
+            import subprocess
         toolkits_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
         sys.path.append(toolkits_dir)
         import pyaedt_utils
@@ -75,6 +74,7 @@ def aedt_script():
 
 
 def pyaedt_script():
+    import subprocess
     # CPython interpreter
     python_exe = r"##PYTHON_EXE##"
     # Python script


### PR DESCRIPTION
## Description
Shielding Effectiveness extension was not working correctly when it was launched from AEDT. So, launching the extension script in a second process was the solution to fix it.

## Issue linked
Close #5805 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
