### PR TITLE
FIX: Incorrect suffix "m" in length units

### DIFF
--- a/src/ansys/aedt/core/generic/constants.py
+++ b/src/ansys/aedt/core/generic/constants.py
@@ -345,7 +345,6 @@ AEDT_UNITS = {
         "mm": 1e-3,
         "cm": 1e-2,
         "dm": 1e-1,
-        "m": 1.0,
         "meter": 1.0,
         "meters": 1.0,
         "km": 1e3,


### PR DESCRIPTION
## Description
"m" is used both as a length unit and a non-length unit which is inconsistent with AEDT.

## Issue linked
Resolve #5860

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
