### PR TITLE
CI: Fix timeout issues

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -178,7 +178,7 @@ jobs:
           PYTHONMALLOC: malloc
         run: |
           .venv\Scripts\Activate.ps1
-          pytest ${{ env.PYTEST_ARGUMENTS }} -m solvers --deselect=tests/system/solvers/test_45_FilterSolutions
+          pytest ${{ env.PYTEST_ARGUMENTS }} --timeout=180 -m solvers --deselect=tests/system/solvers/test_45_FilterSolutions
 
       - uses: codecov/codecov-action@v5
         with:
@@ -233,7 +233,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT251 }}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv/bin/activate
-          pytest ${{ env.PYTEST_ARGUMENTS }} -m solvers
+          pytest ${{ env.PYTEST_ARGUMENTS }} --timeout=180 -m solvers
 
       - uses: codecov/codecov-action@v5
         with:
@@ -293,10 +293,10 @@ jobs:
         with:
           max_attempts: 2
           retry_on: error
-          timeout_minutes: 50
+          timeout_minutes: 60
           command: |
             .venv\Scripts\Activate.ps1
-            pytest ${{ env.PYTEST_ARGUMENTS }} -n 4 --dist loadfile -m general
+            pytest ${{ env.PYTEST_ARGUMENTS }} -n 4 --dist loadfile  --timeout=180 -m general
 
       - uses: codecov/codecov-action@v5
         with:
@@ -359,11 +359,11 @@ jobs:
         with:
           max_attempts: 2
           retry_on: error
-          timeout_minutes: 50
+          timeout_minutes: 60
           command: |
             export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT251 }}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
             source .venv/bin/activate
-            pytest ${{ env.PYTEST_ARGUMENTS }} -n 4 --dist loadfile -m general
+            pytest ${{ env.PYTEST_ARGUMENTS }} -n 4 --dist loadfile --timeout=180 -m general
 
       - uses: codecov/codecov-action@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ tests = [
     # Never directly imported but required when loading ML related file see #4713
     "scikit-learn>=1.0.0,<1.7",
     "scikit-rf>=0.30.0,<1.7",
+    "pytest-timeout>=2.3.0,<2.4",
 ]
 dotnet = [
     "ansys-pythonnet>=3.1.0rc3",


### PR DESCRIPTION
## Description
Extend the timeout value general tests (seems like the addition of new tests has lead us to hitting 50 minutes from time to time).
Add a timeout of 3 minute for each test marked as `"solvers"` to avoid blocking a VM for 6 hours straight when something wrong occurs while running the `tests/system/solvers`

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
