### PR TITLE
CI: Ensure bot uses upper case

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -38,6 +38,7 @@ jobs:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+          use-upper-case: true
 
   pr-title:
     if: github.event_name == 'pull_request'

--- a/doc/changelog.d/5899.maintenance.md
+++ b/doc/changelog.d/5899.maintenance.md
@@ -1,0 +1,1 @@
+Ensure bot uses upper case


### PR DESCRIPTION
## Description
As title says. This will avoid the pyansys bot to create a PR like https://github.com/ansys/pyaedt/pull/5897

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
