### PR TITLE
CI: Fix release workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -40,15 +40,19 @@ jobs:
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
 
   pr-title:
-    if: github.event_name == 'pull_request'
-    name: Check the title of the pull request
+    name: Check the title of the PR (if needed)
     runs-on: ubuntu-latest
     steps:
       - name: Check the title of the pull request
+        if: github.event_name == 'pull_request'
         uses: ansys/actions/check-pr-title@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           use-upper-case: true
+      - name: Check the title of the pull request
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "::notice::Skipping PR title check for non-PR events"
 
   doc-style:
     name: Documentation style check
@@ -96,8 +100,6 @@ jobs:
       - name: Import python package
         run: |
           python -c "import ansys.aedt.core; from ansys.aedt.core import __version__"
-
-
 
   unit-tests:
     name: Running unit tests

--- a/doc/changelog.d/5900.maintenance.md
+++ b/doc/changelog.d/5900.maintenance.md
@@ -1,0 +1,1 @@
+Fix release workflow


### PR DESCRIPTION
## Description
Currently the CICD is stuck when releasing due to the `needs` we have added following the changelog addition. Indeed, to avoid wasting time on the VMs we decided to not run jobs unless the `pr-title` job was passing. However, this backfires when doing a release because this job is not run (we are not in a PR).
Therefore, the early jobs `doc-style` and `smoke-tests` are not launched and nothing is performed when we push a tag. 

The proposed changes consist in keeping the logic of not wasting our VMs when the `pr-title` job fails and to allow this job to succeed when running on a push commit / tag. This is the least intrusive change I can think of to make the workflow back on track.
Another approach would be to have a workflow dedicated to releasing. It would contain almost the same amount of code but would exclude the PR title job. Note that this would require us to update the PyPI settings because we are currently leveraging the "ci_cd.yml" workflow and would have to use another one like "release.yml" for example. For maintenance, I would advise not having those two files as they would be really close to each other and require to be maintained in parallel. However, this adds the "strange" behavior associated to checking PR when not working in a PR... :/

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
