### PR TITLE
CI: Add attestation to release notes

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -82,6 +82,10 @@ jobs:
   smoke-tests:
     name: Build wheelhouse and smoke tests
     runs-on: ${{ matrix.os }}
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     needs: [pr-title]
     strategy:
       fail-fast: false
@@ -97,6 +101,7 @@ jobs:
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
           target: ${{ matrix.target }}
+          attest-provenance: true
 
       - name: Import python package
         run: |
@@ -540,12 +545,17 @@ jobs:
             system-tests-visualization-linux,
             doc-build]
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     steps:
       - name: Build library source and wheel artifacts
         uses: ansys/actions/build-library@v8
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          attest-provenance: true
 
   # TODO: Si if we can fix the PDF issue and leverage classic ansys/release-github
   release:
@@ -570,6 +580,8 @@ jobs:
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: false
+          add-artifact-attestation-notes: true
 
   upload-release-doc:
     name: Upload release documentation

--- a/doc/changelog.d/5906.maintenance.md
+++ b/doc/changelog.d/5906.maintenance.md
@@ -1,0 +1,1 @@
+Add attestation to release notes


### PR DESCRIPTION
## Description
Add the possibility to verify the source distribution and wheel from the release page / PyPI / workflow artifacts.
Extend the release notes in Github with information on how to verify the release's artifact attestations using [GitHub CLI tool](https://cli.github.com/).

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
