### PR TITLE
FIX: issue 5864. Solve inside ON for Network objects 

### DIFF
--- a/doc/changelog.d/5923.fixed.md
+++ b/doc/changelog.d/5923.fixed.md
@@ -1,0 +1,1 @@
+issue 5864. Solve inside ON for Network objects

--- a/src/ansys/aedt/core/icepak.py
+++ b/src/ansys/aedt/core/icepak.py
@@ -3418,8 +3418,6 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
             },
             "SchematicData": ({}),
         }
-
-        self.modeler.primitives[object_name].material_name = "Ceramic_material"
         bound = self._create_boundary(object_name, props, "Network")
         return bound
 


### PR DESCRIPTION
No need to set the material for network block. Setting the material will turn on solve inside which will deactivate the network boundary condition.

Close #5864 

## Description
removed 

self.modeler.primitives[object_name].material_name = "Ceramic_material"

not necessary

## Issue linked
issue 5864

## Checklist
- [ x] I have tested my changes locally.
- [ x] I have added necessary documentation or updated existing documentation.
- [x ] I have followed the coding style guidelines of this project.
- [x ] I have added appropriate tests (unit, integration, system).
- [x ] I have reviewed my changes before submitting this pull request.
- [x ] I have linked the issue or issues that are solved by the PR if any.
- [ x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
