### PR TITLE
REFACTOR: add arg coefficient in core loss mat

### DIFF
--- a/doc/changelog.d/5939.miscellaneous.md
+++ b/doc/changelog.d/5939.miscellaneous.md
@@ -1,0 +1,1 @@
+add arg coefficient in core loss mat

--- a/src/ansys/aedt/core/modules/material.py
+++ b/src/ansys/aedt/core/modules/material.py
@@ -2381,7 +2381,7 @@ class Material(CommonMaterial, object):
             core_loss_model_type=core_loss_model_type,
             thickness=thickness,
             conductivity=conductivity,
-            coefficient_setup=coefficient_setup
+            coefficient_setup=coefficient_setup,
         )
         if core_loss_model_type == "Electrical Steel":
             self._props["core_loss_kh"] = str(coefficients[0])

--- a/src/ansys/aedt/core/modules/material.py
+++ b/src/ansys/aedt/core/modules/material.py
@@ -2377,7 +2377,11 @@ class Material(CommonMaterial, object):
                 self._props["AttachedData"]["CoreLossMultiCurveData"]["AllCurves"]["OneCurve"].append(one_curve)
 
         coefficients = self.get_core_loss_coefficients(
-            points_at_frequency, thickness=thickness, conductivity=conductivity, coefficient_setup=coefficient_setup
+            points_at_frequency,
+            core_loss_model_type=core_loss_model_type,
+            thickness=thickness,
+            conductivity=conductivity,
+            coefficient_setup=coefficient_setup
         )
         if core_loss_model_type == "Electrical Steel":
             self._props["core_loss_kh"] = str(coefficients[0])

--- a/src/ansys/aedt/core/modules/material.py
+++ b/src/ansys/aedt/core/modules/material.py
@@ -2377,7 +2377,7 @@ class Material(CommonMaterial, object):
                 self._props["AttachedData"]["CoreLossMultiCurveData"]["AllCurves"]["OneCurve"].append(one_curve)
 
         coefficients = self.get_core_loss_coefficients(
-            points_at_frequency, thickness=thickness, conductivity=conductivity
+            points_at_frequency, thickness=thickness, conductivity=conductivity, coefficient_setup=coefficient_setup
         )
         if core_loss_model_type == "Electrical Steel":
             self._props["core_loss_kh"] = str(coefficients[0])


### PR DESCRIPTION
## Description
**Add a new argument to get_core_loss to be able to setup coefficient**

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
