### PR TITLE
BUILD: Add setuptools bound to avoid PEP639 issues

### DIFF
--- a/doc/changelog.d/5949.dependencies.md
+++ b/doc/changelog.d/5949.dependencies.md
@@ -1,0 +1,1 @@
+Add setuptools bound to avoid PEP639 issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools<67.0.0", "wheel"] # THIS SHOULD BE REVERTED TO '["setuptools", "wheel"]'
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
## Description
Seems like the latest versions of setuptools are using PEP 639 which still induces bugs in our actions.
This is a temporary fix that should be reverted once ansys/actions@v9 is released.

Reference: https://github.com/pypa/setuptools/blob/main/NEWS.rst#v7700

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
