### PR TITLE
FEAT: Layered impedance boundary

### DIFF
--- a/doc/source/Getting_started/Contributing.rst
+++ b/doc/source/Getting_started/Contributing.rst
@@ -112,7 +112,7 @@ The following table illustrates the recommended conventions:
      - ``Hfss.create_setup()``, ``Hfss.create_linear_step_sweep()``
    * - ``usethickness``
      - ``thickness``
-     - ``Hfss.assign_coating()``
+     - ``Hfss.assign_finite_conductivity()``
    * - ``entities``
      - ``assignment``
      - ``Maxwell.assign_current_density()``

--- a/src/ansys/aedt/core/modeler/advanced_cad/stackup_3d.py
+++ b/src/ansys/aedt/core/modeler/advanced_cad/stackup_3d.py
@@ -2047,7 +2047,7 @@ class Patch(CommonObject, object):
                 name=patch_name,
                 material=signal_layer.material_name,
             )
-            application.assign_coating(self._aedt_object.name, signal_layer.material)
+            application.assign_finite_conductivity(self._aedt_object.name, signal_layer.material)
         application.modeler.set_working_coordinate_system("Global")
         application.modeler.subtract(blank_list=[signal_layer.name], tool_list=[patch_name], keep_originals=True)
 

--- a/src/ansys/aedt/core/modules/boundary/common.py
+++ b/src/ansys/aedt/core/modules/boundary/common.py
@@ -574,7 +574,7 @@ class BoundaryObject(BoundaryCommon, BinaryTreeNode):
         elif bound_type == "Impedance":
             self._app.oboundary.EditImpedance(self.name, self._get_args())
         elif bound_type == "Layered Impedance":
-            self._app.oboundary.EditLayeredImpedance(self.name, self._get_args())
+            self._app.oboundary.EditLayeredImp(self.name, self._get_args())
         elif bound_type == "Anisotropic Impedance":
             self._app.oboundary.EditAssignAnisotropicImpedance(self.name, self._get_args())  # pragma: no cover
         elif bound_type == "Primary":

--- a/src/ansys/aedt/core/modules/boundary/common.py
+++ b/src/ansys/aedt/core/modules/boundary/common.py
@@ -213,7 +213,7 @@ class BoundaryObject(BoundaryCommon, BinaryTreeNode):
     >>> origin = hfss.modeler.Position(0, 0, 0)
     >>> inner = hfss.modeler.create_cylinder(hfss.PLANE.XY,origin,3,200,0,"inner")
     >>> inner_id = hfss.modeler.get_obj_id("inner",)
-    >>> coat = hfss.assign_coating([inner_id],"copper",use_thickness=True,thickness="0.2mm")
+    >>> coat = hfss.assign_finite_conductivity([inner_id],"copper",use_thickness=True,thickness="0.2mm")
     """
 
     def __init__(self, app, name, props=None, boundarytype=None, auto_update=True):

--- a/src/ansys/aedt/core/workflows/hfss/choke_designer.py
+++ b/src/ansys/aedt/core/workflows/hfss/choke_designer.py
@@ -387,7 +387,7 @@ def main(extension_args):
     ground_radius = 1.2 * dictionary_values[1]["Outer Winding"]["Outer Radius"]
     ground_position = [0, 0, first_winding_list[1][0][2] - 2]
     ground = hfss.modeler.create_circle("XY", ground_position, ground_radius, name="GND", material="copper")
-    hfss.assign_coating(ground.name, is_infinite_ground=True)
+    hfss.assign_finite_conductivity(ground.name, is_infinite_ground=True)
     ground.transparency = 0.9
 
     # Create mesh operation

--- a/tests/system/general/test_04_SBR.py
+++ b/tests/system/general/test_04_SBR.py
@@ -311,7 +311,7 @@ class TestClass:
         plotter.plot_rays(os.path.join(self.local_scratch.path, "bounce2.jpg"))
         assert os.path.exists(os.path.join(self.local_scratch.path, "bounce2.jpg"))
 
-    def test_18_boundary_perfect_e(self):
+    def test_17_boundary_perfect_e(self):
         self.aedtapp.insert_design("sbr_boundaries_perfect_e")
         b = self.aedtapp.modeler.create_box([0, 0, 0], [10, 20, 30])
         model_units = self.aedtapp.modeler.model_units
@@ -325,7 +325,21 @@ class TestClass:
         with pytest.raises(AEDTRuntimeError):
             self.aedtapp.assign_perfect_e(name="b1", assignment=[b, b.faces[0]], height_deviation="3mm")
 
-    def test_19_boundaries_perfect_h(self):
+    def test_18_boundary_perfect_h(self):
+        self.aedtapp.insert_design("sbr_boundaries_perfect_h")
+        b = self.aedtapp.modeler.create_box([0, 0, 0], [10, 20, 30])
+        model_units = self.aedtapp.modeler.model_units
+
+        bound = self.aedtapp.assign_perfect_h(name="b1", assignment=[b, b.faces[0]], height_deviation=2, roughness=0.4)
+        assert bound.properties["SBR+ Rough Surface Height Standard Deviation"] == f"2{model_units}"
+
+        bound2 = self.aedtapp.assign_perfect_h(assignment=[b, b.faces[0]], height_deviation="3mm")
+        assert bound2.properties["SBR+ Rough Surface Height Standard Deviation"] == f"3mm"
+
+        with pytest.raises(AEDTRuntimeError):
+            self.aedtapp.assign_perfect_h(name="b1", assignment=[b, b.faces[0]], height_deviation="3mm")
+
+    def test_19_boundaries_finite_conductivity(self):
         self.aedtapp.insert_design("sbr_boundaries")
 
         # Finite Conductivity

--- a/tests/system/general/test_04_SBR.py
+++ b/tests/system/general/test_04_SBR.py
@@ -310,3 +310,15 @@ class TestClass:
         assert plotter
         plotter.plot_rays(os.path.join(self.local_scratch.path, "bounce2.jpg"))
         assert os.path.exists(os.path.join(self.local_scratch.path, "bounce2.jpg"))
+
+    def test_18_boundaries(self):
+        self.aedtapp.insert_design("sbr_boundaries")
+        b = self.aedtapp.modeler.create_box([0, 0, 0], [10, 20, 30])
+
+        # Finite Conductivity
+        bound = self.aedtapp.assign_finite_conductivity(assignment=[b, b.faces[0]], height_deviation="2mm")
+        bound.properties["SBR+ Rough Surface Height Standard Deviation"] == "2mm"
+
+        pass
+
+        # self.aedtapp.assign_layered_impendance()

--- a/tests/system/general/test_04_SBR.py
+++ b/tests/system/general/test_04_SBR.py
@@ -311,9 +311,22 @@ class TestClass:
         plotter.plot_rays(os.path.join(self.local_scratch.path, "bounce2.jpg"))
         assert os.path.exists(os.path.join(self.local_scratch.path, "bounce2.jpg"))
 
-    def test_18_boundaries(self):
-        self.aedtapp.insert_design("sbr_boundaries")
+    def test_18_boundary_perfect_e(self):
+        self.aedtapp.insert_design("sbr_boundaries_perfect_e")
         b = self.aedtapp.modeler.create_box([0, 0, 0], [10, 20, 30])
+        model_units = self.aedtapp.modeler.model_units
+
+        bound = self.aedtapp.assign_perfect_e(name="b1", assignment=[b, b.faces[0]], height_deviation=2, roughness=0.4)
+        assert bound.properties["SBR+ Rough Surface Height Standard Deviation"] == f"2{model_units}"
+
+        bound2 = self.aedtapp.assign_perfect_e(assignment=[b, b.faces[0]], height_deviation="3mm")
+        assert bound2.properties["SBR+ Rough Surface Height Standard Deviation"] == f"3mm"
+
+        with pytest.raises(AEDTRuntimeError):
+            self.aedtapp.assign_perfect_e(name="b1", assignment=[b, b.faces[0]], height_deviation="3mm")
+
+    def test_19_boundaries_perfect_h(self):
+        self.aedtapp.insert_design("sbr_boundaries")
 
         # Finite Conductivity
         bound = self.aedtapp.assign_finite_conductivity(assignment=[b, b.faces[0]], height_deviation="2mm")

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -1901,8 +1901,8 @@ class TestClass:
         bound = aedtapp.insert_near_field_points(input_file=sample_points_file)
         assert bound
 
-    def test_76_boundaries(self):
-        self.aedtapp.insert_design("hfss_boundaries")
+    def test_76_perfect_e(self):
+        self.aedtapp.insert_design("hfss_perfect_e")
         b = self.aedtapp.modeler.create_box([0, 0, 0], [10, 20, 30])
 
         bound = self.aedtapp.assign_perfect_e(name="b1", assignment=b.faces[0], is_infinite_ground=True)
@@ -1913,3 +1913,12 @@ class TestClass:
 
         with pytest.raises(AEDTRuntimeError):
             self.aedtapp.assign_perfect_e(name="b1", assignment=[b, b.faces[0]])
+
+    def test_77_perfect_h(self):
+        self.aedtapp.insert_design("hfss_perfect_h")
+        b = self.aedtapp.modeler.create_box([0, 0, 0], [10, 20, 30])
+
+        assert self.aedtapp.assign_perfect_h(name="b1", assignment=[b, b.faces[0]])
+
+        with pytest.raises(AEDTRuntimeError):
+            self.aedtapp.assign_perfect_h(name="b1", assignment=[b, b.faces[0]], height_deviation="3mm")

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -127,7 +127,7 @@ class TestClass:
         assert self.aedtapp.modeler["inner_1"].material_name == "copper"
         assert cyl_1.material_name == "teflon_based"
 
-    def test_04_assign_coating(self):
+    def test_04_assign_finite_conductivity(self):
         id = self.aedtapp.modeler.get_obj_id(
             "inner_1",
         )
@@ -141,14 +141,14 @@ class TestClass:
             "radius": "0.75um",
             "ratio": "3",
         }
-        coat = self.aedtapp.assign_coating([id, "inner_1", 41], **args)
+        coat = self.aedtapp.assign_finite_conductivity([id, "inner_1", 41], **args)
         coat.name = "Coating1inner"
         assert coat.update()
         assert coat.properties
         material = coat.props.get("Material", "")
         assert material == "aluminum"
         with pytest.raises(AEDTRuntimeError, match="Objects or Faces selected do not exist in the design."):
-            self.aedtapp.assign_coating(["insulator2", 45])
+            self.aedtapp.assign_finite_conductivity(["insulator2", 45])
 
     def test_05_create_wave_port_from_sheets(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -157,6 +157,8 @@ class TestClass:
         o6 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet1a")
         self.aedtapp.modeler.subtract(o6, "inner_1", keep_originals=True)
 
+        self.aedtapp.assign_finite_conductivity(material="aluminum", assignment="inner_1")
+
         port = self.aedtapp.wave_port(
             assignment=o6,
             reference=[outer_1.name],

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -1900,3 +1900,16 @@ class TestClass:
         aedtapp = add_app(project_name="test_75", solution_type="SBR+")
         bound = aedtapp.insert_near_field_points(input_file=sample_points_file)
         assert bound
+
+    def test_76_boundaries(self):
+        self.aedtapp.insert_design("hfss_boundaries")
+        b = self.aedtapp.modeler.create_box([0, 0, 0], [10, 20, 30])
+
+        bound = self.aedtapp.assign_perfect_e(name="b1", assignment=b.faces[0], is_infinite_ground=True)
+        assert bound.properties["Inf Ground Plane"]
+
+        bound2 = self.aedtapp.assign_perfect_e(name="b2", assignment=[b, b.faces[0]])
+        assert not bound2.properties["Inf Ground Plane"]
+
+        with pytest.raises(AEDTRuntimeError):
+            self.aedtapp.assign_perfect_e(name="b1", assignment=[b, b.faces[0]])


### PR DESCRIPTION
## Description
HFSS Layered impedance boundary.
THis pull request also adds PerfectE and PerfectH boundary to be consistent with new PYAEDT style.
Assign_coating method is deprecated to assign_finite_conductivity which follows HFSS naming

## Issue linked
Close #5963 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
