### PR TITLE
CI: Update vale logic to leverage reviewdog20

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -63,7 +63,8 @@ jobs:
       - name: Check documentation style
         uses: ansys/actions/doc-style@v8
         with:
-         token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fail-level: 'warning'
 
   doc-build:
     name: Documentation build

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -33,16 +33,3 @@ Vale.Terms = NO
 # Removing Google-specific rule - Not applicable under some circumstances
 Google.WordList = NO
 Google.Colons = NO
-
-
-# Removing Google-specific rule - Update severity level to error on rules with default warnings
-# See https://github.com/ansys/pyaedt/pull/4881 for more information
-Google.Ellipses = error
-Google.FirstPerson = error
-Google.Headings = error
-Google.HeadingPunctuation = error
-Google.OxfordComma = error
-Google.Spelling = error
-Google.We = error
-Google.Will = error
-Google.WordList = error

--- a/doc/changelog.d/5974.maintenance.md
+++ b/doc/changelog.d/5974.maintenance.md
@@ -1,0 +1,1 @@
+Update vale logic to leverage reviewdog20


### PR DESCRIPTION
## Description
Follow up of https://github.com/ansys/pyaedt/pull/4881 and https://github.com/ansys/actions/pull/545. We don't need to manually change the level of some google rues.

The latest release of the actions (8.2.Z) contains the changes to leverage a recent version of reviewdog in vale. This was performed through https://github.com/errata-ai/vale-action/pull/132 and https://github.com/errata-ai/vale-action/pull/140.

## Issue linked
Related to #4881

## Checklist
- [ ] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
