### PR TITLE
BUILD: Update install targets and dependencies

### DIFF
--- a/doc/changelog.d/5997.dependencies.md
+++ b/doc/changelog.d/5997.dependencies.md
@@ -1,0 +1,1 @@
+Update install targets and dependencies

--- a/doc/source/Getting_started/Installation.rst
+++ b/doc/source/Getting_started/Installation.rst
@@ -97,12 +97,6 @@ If you are not utilizing gRPC, you can install the required dotnet dependencies 
 
     pip install pyaedt[dotnet]
 
-If you want to install the PyAEDT panels in the AEDT Automation tab, use the following command:
-
-.. code:: python
-
-    pip install pyaedt[installer]
-
 Finally, in the Python console, run the following commands:
 
 .. code::
@@ -153,12 +147,6 @@ For example, on Windows with Python 3.10, install PyAEDT and all its dependencie
 .. code::
 
     pip install --no-cache-dir --no-index --find-links=file:///<path_to_wheelhouse>/PyAEDT-v<release_version>-wheelhouse-Windows-3.10 pyaedt[all]
-
-If you want to add the PyAEDT panels in the AEDT Automation tab, you need first to install the installer dependencies:
-
-.. code::
-
-    pip install --no-cache-dir --no-index --find-links=file:///<path_to_wheelhouse>/PyAEDT-v<release_version>-wheelhouse-Windows-3.10 pyaedt[installer]
 
 Finally, in the Python console, run the following commands:
 

--- a/doc/source/Resources/pyaedt_installer_from_aedt.py
+++ b/doc/source/Resources/pyaedt_installer_from_aedt.py
@@ -249,89 +249,68 @@ def install_pyaedt():
     if not venv_dir.exists():
         print("Creating the virtual environment in {}".format(venv_dir))
         if args.version <= "231":
-            subprocess.call([sys.executable, "-m", "venv", str(venv_dir), "--system-site-packages"])
+            subprocess.run([sys.executable, "-m", "venv", str(venv_dir), "--system-site-packages"], check=True)
         else:
-            subprocess.call([sys.executable, "-m", "venv", str(venv_dir)])
+            subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
 
         if args.wheel and Path(args.wheel).exists():
             print("Installing PyAEDT using provided wheels argument")
             unzipped_path = unzip_if_zip(Path(args.wheel))
+            command = [
+                str(pip_exe),
+                "install",
+                "--no-cache-dir",
+                "--no-index",
+                r"--find-links={}".format(str(unzipped_path)),
+            ]
             if args.version <= "231":
-                subprocess.call(
-                    [
-                        str(pip_exe),
-                        "install",
-                        "--no-cache-dir",
-                        "--no-index",
-                        r"--find-links={}".format(str(unzipped_path)),
-                        "pyaedt[all,dotnet]=='0.9.0'",
-                    ]
-                )
+                command.append("pyaedt[all,dotnet]=='0.9.0'")
             else:
-                subprocess.call(
-                    [
-                        str(pip_exe),
-                        "install",
-                        "--no-cache-dir",
-                        "--no-index",
-                        r"--find-links={}".format(str(unzipped_path)),
-                        "pyaedt[installer]",
-                    ]
-                )
-
+                command.append("pyaedt[all]") 
+            subprocess.run(command, check=True)  # nosec
         else:
             print("Installing PyAEDT using online sources")
-            subprocess.call([str(python_exe), "-m", "pip", "install", "--upgrade", "pip"])
-            subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "wheel"])
+            subprocess.run([str(python_exe), "-m", "pip", "install", "--upgrade", "pip"], check=True)  # nosec
+            subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "wheel"], check=True)  # nosec
             if args.version <= "231":
-                subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "pyaedt[all]=='0.9.0'"])
-                subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "jupyterlab"])
-                subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "ipython", "-U"])
-                subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "ipyvtklink"])
+                subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "pyaedt[all]=='0.9.0'"], check=True)  # nosec
+                subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "jupyterlab"], check=True)  # nosec
+                subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "ipython", "-U"], check=True)  # nosec
+                subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "ipyvtklink"], check=True)  # nosec
             else:
-                subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "pyaedt[installer]"])
+                subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "pyaedt[all]"], check=True)  # nosec
 
         if args.version <= "231":
-            subprocess.call([str(pip_exe), "uninstall", "-y", "pywin32"])
+            subprocess.run([str(pip_exe), "uninstall", "-y", "pywin32"], check=True)  # nosec
 
     else:
         print("Using existing virtual environment in {}".format(venv_dir))
-        subprocess.call([str(pip_exe), "uninstall", "-y", "pyaedt"])
+        subprocess.call([str(pip_exe), "uninstall", "-y", "pyaedt"], check=True)  # nosec
 
         if args.wheel and Path(args.wheel).exists():
             print("Installing PyAEDT using provided wheels argument")
             unzipped_path = unzip_if_zip(Path(args.wheel))
+            command = [
+                str(pip_exe),
+                "install",
+                "--no-cache-dir",
+                "--no-index",
+                r"--find-links={}".format(str(unzipped_path)),
+            ]
             if args.version <= "231":
-                subprocess.call(
-                    [
-                        str(pip_exe),
-                        "install",
-                        "--no-cache-dir",
-                        "--no-index",
-                        r"--find-links={}".format(str(unzipped_path)),
-                        "pyaedt[all,dotnet]=='0.9.0'",
-                    ]
-                )
+                command.append("pyaedt[all,dotnet]=='0.9.0'")
             else:
-                subprocess.call(
-                    [
-                        str(pip_exe),
-                        "install",
-                        "--no-cache-dir",
-                        "--no-index",
-                        r"--find-links={}".format(str(unzipped_path)),
-                        "pyaedt[installer]",
-                    ]
-                )
+                command.append("pyaedt[all]")
+            subprocess.run(command, check=True)  # nosec
         else:
             print("Installing PyAEDT using online sources")
             if args.version <= "231":
-                subprocess.call([str(pip_exe), "pip=1000", "install", "pyaedt[all]=='0.9.0'"])
-                subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "jupyterlab"])
-                subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "ipython", "-U"])
-                subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "ipyvtklink"])
+                subprocess.run([str(pip_exe), "pip=1000", "install", "pyaedt[all]=='0.9.0'"], check=True)  # nosec
+                subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "jupyterlab"], check=True)  # nosec
+                subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "ipython", "-U"], check=True)  # nosec
+                subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "ipyvtklink"], check=True)  # nosec
             else:
-                subprocess.call([str(pip_exe), "--default-timeout=1000", "install", "pyaedt[installer]"])
+                subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "pyaedt[all]"], check=True)  # nosec
     sys.exit(0)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ examples = [
     "pyvista==0.44.2",
     "fast-simplification==0.1.9",
     "joblib==1.4.2",
-    "plotly==5.24.0",
+    "plotly==6.0.1",
     "scikit-rf==1.6.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ dependencies = [
     "jsonschema",
     "psutil",
     "pyedb>=0.4.0; python_version == '3.7'",
-    "pyedb>=0.24.0; python_version > '3.7'",
-    "pyedb!=0.28.0; python_version > '3.7'",
+    "pyedb>=0.24.0,!=0.28.0; python_version > '3.7'",
     "tomli; python_version < '3.11'",
     "tomli-w",
     "rpyc>=6.0.0,<6.1",
@@ -113,20 +112,23 @@ all = [
     "ansys-tools-visualization-interface; python_version >= '3.10'",
     "tables; python_version >= '3.10'",
     "scikit-rf>=0.30.0,<1.7",
-]
-installer = [
-    "matplotlib>=3.5.0,<3.11",
-    "numpy>=1.20.0,<2.3",
-    "openpyxl>=3.1.0,<3.3",
-    "osmnx>=1.1.0,<2.1",
-    "pandas>=1.1.0,<2.3",
-    "pyvista[io]>=0.38.0,<0.45",
-    "fast-simplification>=0.1.7",
-    "ansys-tools-visualization-interface; python_version >= '3.10'",
-    "scikit-rf>=0.30.0,<1.7",
     "jupyterlab>=3.6.0,<4.4",
     "ipython>=7.30.0,<9.1",
     "ipyvtklink>=0.2.0,<0.2.4",
+]
+# Set of dependencies used to run our examples with CPython 3.10
+examples = [
+    "imageio==2.37.0",
+    "matplotlib==3.10.1",
+    "numpy==2.2.3",
+    "openpyxl==3.1.5",
+    "osmnx==2.0.1",
+    "pandas==2.2.3",
+    "pyvista==0.44.2",
+    "fast-simplification==0.1.9",
+    "joblib==1.4.2",
+    "plotly==5.24.0",
+    "scikit-rf==1.6.2",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Description
Update install targets by:
- removing `installer` target (this target was added at the begining to only install pyaedt but later evolved into something close to `all`)
- updating `all` target with jupyter related dependencies
- adding `examples` target install (copy of the pyaedt-examples requirements)

Also, some clean up has been performed where `installer` was used and backward compatibility has been added for the version extension.

> [!NOTE] 
Once merged, pyaedt-examples requirements should evolve to use the `examples` target.

## Issue linked
Associated to #5978

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
