### PR TITLE
CI: Add dependabot cooldown for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
@@ -7,6 +8,14 @@ updates:
       day: "saturday"
       time: "06:00"
       timezone: "Europe/Paris"
+    cooldown:
+      default-days: 7
+      include:
+        - "*"  # Include all dependencies in cooldown
+      exclude:
+        - "ansys-sphinx-theme"
+        - "ansys-tools-visualization-interface"
+        - "ansys-pythonnet"
     reviewers: 
       - "MaxJPRey"
       - "SMoraisAnsys"

--- a/doc/changelog.d/5999.maintenance.md
+++ b/doc/changelog.d/5999.maintenance.md
@@ -1,0 +1,1 @@
+Add dependabot cooldown for pip


### PR DESCRIPTION
## Description
Add a cooldown to updates associated to pip. This would mitigate, to some extent, exposure to supply chain attacks since dependabot wouldn't run CICD in our self hosted runners until 7 days after the release has been published. During those 7 days, if a vulnerability is found, we can hope for a new release fixing the vulnerability and avoiding us to be exposed.

> [!NOTE]
This cooldown feature is not yet available for github actions. See https://github.com/dependabot/dependabot-core/issues/3651

## Issue linked
Associated to https://github.com/ansys/pyaedt/issues/5524

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
