### PR TITLE
BUILD: Temporary add bound to wheel

### DIFF
--- a/doc/changelog.d/6002.dependencies.md
+++ b/doc/changelog.d/6002.dependencies.md
@@ -1,0 +1,1 @@
+Temporary add bound to wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<67.0.0", "wheel"] # THIS SHOULD BE REVERTED TO '["setuptools", "wheel"]'
+requires = ["setuptools<67.0.0", "wheel<0.46.0"] # THIS SHOULD BE REVERTED TO '["setuptools", "wheel"]'
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
## Description
Package `wheel` latest release (v0.46.0) is breaking the build process of pyaedt because the new release of `wheel` no longer contain the implementation of `setuptools` `bdist_wheel` command, see https://github.com/pypa/wheel?tab=readme-ov-file#historical-note.

This should be reverted once ansys/actions v9 is released.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
