### PR TITLE
BUILD: Remove patch on build

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -92,18 +92,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        target: ['all', 'installer']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: Build wheelhouse and perform smoke test
-        uses: ansys/actions/build-wheelhouse@v8
+        uses: ansys/actions/build-wheelhouse@v9
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
-          target: ${{ matrix.target }}
+          target: 'all'
           attest-provenance: true
-
       - name: Import python package
         run: |
           python -c "import ansys.aedt.core; from ansys.aedt.core import __version__"
@@ -570,11 +568,19 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - name: Release to the public PyPI repository
-        uses: ansys/actions/release-pypi-public@v8
+      - name: Download the library artifacts from build-library step
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          library-name: ${{ env.PACKAGE_NAME }}
-          use-trusted-publisher: true
+          name: ${{ env.PACKAGE_NAME }}-artifacts
+          path: ${{ env.PACKAGE_NAME }}-artifacts
+
+      - name: Release to PyPI using trusted publisher
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          repository-url: "https://upload.pypi.org/legacy/"
+          print-hash: true
+          packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
+          skip-existing: false
 
       - name: Release to GitHub
         uses: ansys/actions/release-github@v8

--- a/doc/changelog.d/6032.dependencies.md
+++ b/doc/changelog.d/6032.dependencies.md
@@ -1,0 +1,1 @@
+Remove patch on build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<67.0.0", "wheel<0.46.0"] # THIS SHOULD BE REVERTED TO '["setuptools", "wheel"]'
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 
@@ -44,8 +44,6 @@ dependencies = [
     "rpyc>=6.0.0,<6.1",
     "pyyaml",
     "defusedxml>=0.7,<8.0",
-    "attrs<24.3.0",
-    "referencing<0.36.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description
Now that ansys/action@v9 is available, we should leverage it to remove all the patches we had to apply to work in the changing python ecosystem. This is related to how evolved the PyPA action to release on PyPI and also to the new metadata version (2.4) that is used in multiple projects.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
