### PR TITLE
FIX: Return value of download_multiparts

### DIFF
--- a/src/ansys/aedt/core/examples/downloads.py
+++ b/src/ansys/aedt/core/examples/downloads.py
@@ -718,7 +718,7 @@ def download_multiparts(local_path: Optional[Union[str, Path]] = None) -> str:
 
     zip_file = _download_file("pyaedt/multiparts/library.zip", local_path=local_path, strip_prefix="pyaedt")
     unzip(zip_file, local_path / "multiparts")
-    return str(local_path / "multiparts")
+    return str(local_path / "multiparts" / "library")
 
 
 @pyaedt_function_handler(destination="local_path")


### PR DESCRIPTION
## Description
Following https://github.com/ansys/pyaedt/pull/6055 where the return value of a function was not correctly set.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
