### PR TITLE
FIX: Only force download file if specified

### DIFF
--- a/doc/changelog.d/6083.fixed.md
+++ b/doc/changelog.d/6083.fixed.md
@@ -1,0 +1,1 @@
+Only force download file if specified

--- a/src/ansys/aedt/core/examples/downloads.py
+++ b/src/ansys/aedt/core/examples/downloads.py
@@ -758,6 +758,8 @@ def download_twin_builder_data(
 
     if force_download:
         path_to_remove = local_path / "twin_builder"
+        if file_name:
+            path_to_remove = path_to_remove / file_name
         if path_to_remove.exists():
             pyaedt_logger.debug(f"Deleting {path_to_remove} to force download.")
             shutil.rmtree(path_to_remove, ignore_errors=True)


### PR DESCRIPTION
## Description
As title says. The previous behavior was to recreate the folder even if a specific file was passed as input.

## Issue linked
None

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
