### PR TITLE
FEAT: args deprecation decorator

### DIFF
--- a/src/ansys/aedt/core/application/analysis.py
+++ b/src/ansys/aedt/core/application/analysis.py
@@ -782,8 +782,12 @@ class Analysis(Design, object):
                 return [""]
 
     @pyaedt_function_handler()
+    @deprecate_argument(
+        "analyze", "The ``analyze`` argument will be deprecated in future versions." "Analyze before exporting results."
+    )
     def export_results(
         self,
+        analyze=False,
         export_folder=None,
         matrix_name="Original",
         matrix_type="S",
@@ -794,12 +798,13 @@ class Analysis(Design, object):
         include_gamma_comment=True,
         support_non_standard_touchstone_extension=False,
         variations=None,
-        **kwargs,
     ):
         """Export all available reports to a file, including profile, and convergence and sNp when applicable.
 
         Parameters
         ----------
+        analyze : bool
+            Whether to analyze before export. Solutions must be present for the design.
         export_folder : str, optional
             Full path to the project folder. The default is ``None``, in which case the
             working directory is used.
@@ -848,14 +853,6 @@ class Analysis(Design, object):
         >>> aedtapp.analyze()
         >>> exported_files = aedtapp.export_results()
         """
-        analyze = False
-        if "analyze" in kwargs:
-            warnings.warn(
-                "The ``analyze`` argument will be deprecated in future versions." "Analyze before exporting results.",
-                DeprecationWarning,
-            )
-            analyze = kwargs["analyze"]
-
         exported_files = []
         if not export_folder:
             export_folder = self.working_directory

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -39,6 +39,7 @@ from ansys.aedt.core.generic.data_handlers import from_rkm_to_aedt
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.file_utils import open_file
 from ansys.aedt.core.generic.file_utils import read_configuration_file
+from ansys.aedt.core.generic.general_methods import deprecate_argument
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.generic.settings import settings
@@ -1648,6 +1649,9 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods):
     @pyaedt_function_handler(
         touchstone="input_file", probe_pins="tx_schematic_pins", probe_ref_pins="tx_schematic_differential_pins"
     )
+    @deprecate_argument(
+        "analyze", "The ``analyze`` argument will be deprecated in future versions." "Analyze before exporting results."
+    )
     def create_tdr_schematic_from_snp(
         self,
         input_file,
@@ -1792,6 +1796,9 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods):
         return True, tdr_probe_names
 
     @pyaedt_function_handler(touchstone="input_file")
+    @deprecate_argument(
+        "analyze", "The ``analyze`` argument will be deprecated in future versions." "Analyze before exporting results."
+    )
     def create_lna_schematic_from_snp(
         self,
         input_file,
@@ -1906,6 +1913,9 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods):
         tx_refs="tx_schematic_differential_pins",
         rx_refs="rx_schematic_differentialial_pins",
     )
+    @deprecate_argument(
+        "analyze", "The ``analyze`` argument will be deprecated in future versions." "Analyze before exporting results."
+    )
     def create_ami_schematic_from_snp(
         self,
         input_file,
@@ -2008,6 +2018,9 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods):
         )
 
     @pyaedt_function_handler()
+    @deprecate_argument(
+        "analyze", "The ``analyze`` argument will be deprecated in future versions." "Analyze before exporting results."
+    )
     def create_ibis_schematic_from_snp(
         self,
         input_file,
@@ -2122,6 +2135,9 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods):
         )
 
     @pyaedt_function_handler()
+    @deprecate_argument(
+        "analyze", "The ``analyze`` argument will be deprecated in future versions." "Analyze before exporting results."
+    )
     def create_ibis_schematic_from_pins(
         self,
         ibis_tx_file,

--- a/src/ansys/aedt/core/q3d.py
+++ b/src/ansys/aedt/core/q3d.py
@@ -32,6 +32,7 @@ from ansys.aedt.core.application.analysis_3d import FieldAnalysis3D
 from ansys.aedt.core.generic.constants import MATRIXOPERATIONSQ2D
 from ansys.aedt.core.generic.constants import MATRIXOPERATIONSQ3D
 from ansys.aedt.core.generic.file_utils import generate_unique_name
+from ansys.aedt.core.generic.general_methods import deprecate_argument
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.generic.numbers import decompose_variable_value
 from ansys.aedt.core.generic.settings import settings
@@ -2499,6 +2500,9 @@ class Q2d(QExtractor, CreateBoundaryMixin):
         return True
 
     @pyaedt_function_handler()
+    @deprecate_argument(
+        "analyze", "The ``analyze`` argument will be deprecated in future versions." "Analyze before exporting results."
+    )
     def export_w_elements(self, analyze=False, export_folder=None):
         """Export all W-elements to files.
 


### PR DESCRIPTION
## Description
**In this PR I created a new decorator to deprecate arguments (whether they are positional or keywords) that will be removed in future versions. In this specific case I remove all analyze argument. We want to remove the possibility of analyzing the project within another method.**

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
