### PR TITLE
FIX: Schematic name argument optional in edit_external_circuit method

### DIFF
--- a/doc/changelog.d/6092.fixed.md
+++ b/doc/changelog.d/6092.fixed.md
@@ -1,0 +1,1 @@
+edit_external_circuit

--- a/doc/changelog.d/6092.fixed.md
+++ b/doc/changelog.d/6092.fixed.md
@@ -1,1 +1,1 @@
-edit_external_circuit
+Schematic name argument optional in edit_external_circuit method

--- a/src/ansys/aedt/core/maxwell.py
+++ b/src/ansys/aedt/core/maxwell.py
@@ -2016,7 +2016,7 @@ class Maxwell(CreateBoundaryMixin):
         return circuit
 
     @pyaedt_function_handler()
-    def edit_external_circuit(self, netlist_file_path, schematic_design_name, parameters=None):
+    def edit_external_circuit(self, netlist_file_path, schematic_design_name=None, parameters=None):
         """
         Edit the external circuit for the winding and allow editing of the circuit parameters.
 
@@ -2024,7 +2024,7 @@ class Maxwell(CreateBoundaryMixin):
         ----------
         netlist_file_path : str
             Path to the circuit netlist file.
-        schematic_design_name : str
+        schematic_design_name : str, optional
             Name of the schematic design.
         parameters : dict, optional
             Name and value of the circuit parameters.
@@ -2039,7 +2039,7 @@ class Maxwell(CreateBoundaryMixin):
         bool
             ``True`` when successful, ``False`` when failed.
         """
-        if schematic_design_name not in self.design_list:
+        if schematic_design_name and schematic_design_name not in self.design_list:
             raise AEDTRuntimeError(f"Schematic design '{schematic_design_name}' is not in design list.")
 
         odesign = self.desktop_class.active_design(self.oproject, schematic_design_name)

--- a/src/ansys/aedt/core/maxwell.py
+++ b/src/ansys/aedt/core/maxwell.py
@@ -2039,42 +2039,40 @@ class Maxwell(CreateBoundaryMixin):
         bool
             ``True`` when successful, ``False`` when failed.
         """
-        if schematic_design_name and schematic_design_name not in self.design_list:
-            raise AEDTRuntimeError(f"Schematic design '{schematic_design_name}' is not in design list.")
+        if schematic_design_name:
+            if schematic_design_name not in self.design_list:
+                raise AEDTRuntimeError(f"Schematic design '{schematic_design_name}' is not in design list.")
 
-        odesign = self.desktop_class.active_design(self.oproject, schematic_design_name)
-        oeditor = odesign.SetActiveEditor("SchematicEditor")
-        if is_linux and settings.aedt_version == "2024.1":  # pragma: no cover
-            time.sleep(1)
-            self.desktop_class.close_windows()
-        comps = oeditor.GetAllComponents()
-        sources_array = []
-        sources_type_array = []
-        for comp in comps:
-            if "Voltage Source" in oeditor.GetPropertyValue("ComponentTab", comp, "Description"):
-                comp_id = "V" + comp.split("@")[1].split(";")[1]
-            elif "Current Source" in oeditor.GetPropertyValue("ComponentTab", comp, "Description"):
-                comp_id = "I" + comp.split("@")[1].split(";")[1]
-            else:
-                continue
-            sources_array.append(comp_id)
-            refdes = oeditor.GetPropertyValue("ComponentTab", comp, "RefDes")
-            comp_instance = oeditor.GetCompInstanceFromRefDes(refdes)
-            if "DC" in oeditor.GetPropertyValue("ComponentTab", comp, "Description"):
-                sources_type_array.append(1)
-            else:
-                source_type = comp_instance.GetPropHost().GetText("Type")
-                if source_type == "TIME":
+            odesign = self.desktop_class.active_design(self.oproject, schematic_design_name)
+            oeditor = odesign.SetActiveEditor("SchematicEditor")
+
+            if is_linux and settings.aedt_version == "2024.1":  # pragma: no cover
+                time.sleep(1)
+                self.desktop_class.close_windows()
+
+            sources_array, sources_type_array = [], []
+            for comp in oeditor.GetAllComponents():
+                if "Voltage Source" in oeditor.GetPropertyValue("ComponentTab", comp, "Description"):
+                    comp_id = "V" + comp.split("@")[1].split(";")[1]
+                elif "Current Source" in oeditor.GetPropertyValue("ComponentTab", comp, "Description"):
+                    comp_id = "I" + comp.split("@")[1].split(";")[1]
+                else:
+                    continue
+
+                sources_array.append(comp_id)
+                refdes = oeditor.GetPropertyValue("ComponentTab", comp, "RefDes")
+                comp_instance = oeditor.GetCompInstanceFromRefDes(refdes)
+
+                if "DC" in oeditor.GetPropertyValue("ComponentTab", comp, "Description"):
                     sources_type_array.append(1)
-                elif source_type == "POS":
-                    sources_type_array.append(2)
-                elif source_type == "SPEED":
-                    sources_type_array.append(3)
+                else:
+                    source_type = comp_instance.GetPropHost().GetText("Type")
+                    sources_type_array.append({"TIME": 1, "POS": 2, "SPEED": 3}.get(source_type, 0))
+
         names = []
         values = []
         if parameters:
-            names = list(parameters.keys())
-            values = list(parameters.values())
+            names, values = list(parameters.keys()), list(parameters.values())
             netlist_file_path = ""
         self.oboundary.EditExternalCircuit(netlist_file_path, sources_array, sources_type_array, names, values)
         return True

--- a/tests/system/general/test_35_MaxwellCircuit.py
+++ b/tests/system/general/test_35_MaxwellCircuit.py
@@ -27,6 +27,7 @@ import os
 from ansys.aedt.core import Maxwell2d
 from ansys.aedt.core import MaxwellCircuit
 from ansys.aedt.core.generic.constants import SOLUTIONS
+from ansys.aedt.core.internal.checks import AEDTRuntimeError
 import pytest
 
 from tests import TESTS_GENERAL_PATH
@@ -110,6 +111,8 @@ class TestClass:
         m2d.assign_coil(assignment=["Circle_inner"])
         m2d.assign_winding(assignment=["Circle_inner"], winding_type="External", name="Ext_Wdg")
         assert m2d.edit_external_circuit(netlist_file, self.aedtapp.design_name)
+        with pytest.raises(AEDTRuntimeError):
+            m2d.edit_external_circuit(netlist_file, "invalid")
 
     def test_08_import_netlist(self):
         self.aedtapp.insert_design("SchematicImport")


### PR DESCRIPTION
## Description
**In this PR I made the schematic name as an optional argument because is not always needed to be provided.**

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
