### PR TITLE
FIX: Fix name of setup to match setup type

### DIFF
--- a/doc/changelog.d/6125.fixed.md
+++ b/doc/changelog.d/6125.fixed.md
@@ -1,0 +1,1 @@
+Fix name of setup to match setup type

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -2347,9 +2347,11 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods):
                 rx_eye_names.append(first_rx.name.split("@")[1])
         if create_setup:
             setup_type = "NexximTransient"
+            setup_name = "Transient"
             if is_ami:
                 setup_type = "NexximAMI"
-            setup_ibis = self.create_setup("Transient", setup_type)
+                setup_name = "AMI"
+            setup_ibis = self.create_setup(setup_name, setup_type)
             if use_convolution:
                 self.oanalysis.AddAnalysisOptions(
                     [


### PR DESCRIPTION
## Description
The name 'Transient' was being applied to both AMI and Transient setups which could cause confusion. This fix names an AMI setup 'AMI' and a transient setup 'Transient'.

## Checklist
- [ ] I have tested my changes locally.
- [ N/A ] I have added necessary documentation or updated existing documentation.
- [ X ] I have followed the coding style guidelines of this project.
- [ N/A ] I have added appropriate tests (unit, integration, system).
- [ X ] I have reviewed my changes before submitting this pull request.
- [ N/A ] I have linked the issue or issues that are solved by the PR if any.
- [ X ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
