### PR TITLE
FIX: External circuit import of renamed sources 

### DIFF
--- a/src/ansys/aedt/core/maxwell.py
+++ b/src/ansys/aedt/core/maxwell.py
@@ -2052,9 +2052,17 @@ class Maxwell(CreateBoundaryMixin):
         sources_type_array = []
         for comp in comps:
             if "Voltage Source" in oeditor.GetPropertyValue("ComponentTab", comp, "Description"):
-                comp_id = "V" + comp.split("@")[1].split(";")[1]
+                name = oeditor.GetPropertyValue("PassedParameterTab",comp,"Name")
+                if name is None:
+                    comp_id = "V" + comp.split("@")[1].split(";")[1]
+                else:
+                    comp_id = "V" + name
             elif "Current Source" in oeditor.GetPropertyValue("ComponentTab", comp, "Description"):
-                comp_id = "I" + comp.split("@")[1].split(";")[1]
+                name = oeditor.GetPropertyValue("PassedParameterTab",comp,"Name")
+                if name is None:
+                    comp_id = "I" + comp.split("@")[1].split(";")[1]
+                else:
+                    comp_id = "I" + name
             else:
                 continue
             sources_array.append(comp_id)

--- a/tests/system/general/test_35_MaxwellCircuit.py
+++ b/tests/system/general/test_35_MaxwellCircuit.py
@@ -110,6 +110,13 @@ class TestClass:
         m2d.assign_coil(assignment=["Circle_inner"])
         m2d.assign_winding(assignment=["Circle_inner"], winding_type="External", name="Ext_Wdg")
         assert m2d.edit_external_circuit(netlist_file, self.aedtapp.design_name)
+        netlist_file_2 = os.path.join(self.local_scratch.path, "export_netlist_2.sph")
+        v_source.parameters["Name"]="VSource"
+        i_source.parameters["Name"]="ISource"
+        self.aedtapp.export_netlist_from_schematic(netlist_file_2)
+        assert m2d.edit_external_circuit(netlist_file_2, self.aedtapp.design_name)
+
+
 
     def test_08_import_netlist(self):
         self.aedtapp.insert_design("SchematicImport")


### PR DESCRIPTION
## Description
Created a check whether the source has a custom name before evaluating the label to pass as an argument on Maxwell3D.edit_external_circuit

## Issue linked
 #6127 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
