### PR TITLE
FIX: ISAR 2D range extents

### DIFF
--- a/doc/changelog.d/6162.fixed.md
+++ b/doc/changelog.d/6162.fixed.md
@@ -1,0 +1,1 @@
+ISAR 2D range extents

--- a/src/ansys/aedt/core/visualization/advanced/farfield_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/farfield_visualization.py
@@ -29,6 +29,7 @@ import shutil
 import sys
 import warnings
 
+from ansys.aedt.core.generic.constants import SpeedOfLight
 from ansys.aedt.core.aedt_logger import pyaedt_logger as logger
 from ansys.aedt.core.generic.constants import AEDT_UNITS
 from ansys.aedt.core.generic.constants import unit_converter
@@ -548,8 +549,7 @@ class FfdSolutionData(object):
         ph, th = np.meshgrid(data["Phi"], data["Theta"])
         ph = np.deg2rad(ph)
         th = np.deg2rad(th)
-        c = 299792458
-        k = 2 * np.pi * self.frequency / c
+        k = 2 * np.pi * self.frequency / SpeedOfLight
         kx_grid = k * np.sin(th) * np.cos(ph)
         ky_grid = k * np.sin(th) * np.sin(ph)
         kz_grid = k * np.cos(th)
@@ -741,8 +741,7 @@ class FfdSolutionData(object):
         float
             Phase shift in degrees.
         """
-        c = 299792458
-        k = (2 * math.pi * self.frequency) / c
+        k = (2 * math.pi * self.frequency) / SpeedOfLight
         a = int(a)
         b = int(b)
         theta = np.deg2rad(theta)

--- a/src/ansys/aedt/core/visualization/advanced/farfield_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/farfield_visualization.py
@@ -29,9 +29,9 @@ import shutil
 import sys
 import warnings
 
-from ansys.aedt.core.generic.constants import SpeedOfLight
 from ansys.aedt.core.aedt_logger import pyaedt_logger as logger
 from ansys.aedt.core.generic.constants import AEDT_UNITS
+from ansys.aedt.core.generic.constants import SpeedOfLight
 from ansys.aedt.core.generic.constants import unit_converter
 from ansys.aedt.core.generic.file_utils import open_file
 from ansys.aedt.core.generic.general_methods import conversion_function

--- a/src/ansys/aedt/core/visualization/advanced/frtm_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/frtm_visualization.py
@@ -277,7 +277,7 @@ class FRTMData(object):
         """Velocity resolution (m/s)."""
         fc = self.frequency_center
         tpt = self.time_duration
-        vr = 299792458.0 / (2 * fc * tpt)
+        vr = SpeedOfLight / (2 * fc * tpt)
         return vr
 
     @property

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -1243,11 +1243,14 @@ class MonostaticRCSPlotter(object):
         if "range_profile" not in self.all_scene_actors["annotations"]:
             self.all_scene_actors["annotations"]["range_profile"] = {}
 
+        # TODO: Do we want to support non-centered Range profile?
+        center = np.array([0., 0., 0.])
+
         # Main red line
         name = "main_line"
         main_line_az_mesh = self._create_line(
-            pointa=(range_first + self.center[0], self.extents[2] * 10 + self.center[1], self.center[2]),
-            pointb=(range_last + self.center[0], self.extents[2] * 10 + self.center[1], self.center[2]),
+            pointa=(range_first + center[0], self.extents[2] * 10 + center[1], center[2]),
+            pointb=(range_last + center[0], self.extents[2] * 10 + center[1], center[2]),
             name=name,
             color=line_color,
         )
@@ -1259,14 +1262,14 @@ class MonostaticRCSPlotter(object):
         for tick in range(num_ticks + 1):  # create line with tick marks
             if tick % 1 == 0:  # only do every nth tick
                 tick_pos_start = (
-                    range_first - range_resolution * tick + self.center[0],
-                    self.extents[2] * 10 + self.center[1],
-                    self.center[2],
+                    range_first - range_resolution * tick + center[0],
+                    self.extents[2] * 10 + center[1],
+                    center[2],
                 )
                 tick_pos_end = (
-                    range_first - range_resolution * tick + self.center[0],
-                    self.extents[2] * 10 + tick_length + self.center[1],
-                    self.center[2],
+                    range_first - range_resolution * tick + center[0],
+                    self.extents[2] * 10 + tick_length + center[1],
+                    center[2],
                 )
                 tick_lines += pv.Line(pointa=tick_pos_start, pointb=tick_pos_end)
 
@@ -1281,7 +1284,7 @@ class MonostaticRCSPlotter(object):
         self.all_scene_actors["annotations"]["range_profile"][annotation_name] = tick_lines_mesh
 
         start_geo = pv.Disc(
-            center=(range_last + self.center[0], self.extents[2] * 10 + self.center[1], self.center[2]),
+            center=(range_last + center[0], self.extents[2] * 10 + center[1], center[2]),
             outer=tick_length,
             inner=0,
             normal=(-1, 0, 0),
@@ -1299,7 +1302,7 @@ class MonostaticRCSPlotter(object):
         self.all_scene_actors["annotations"]["range_profile"][annotation_name] = disc_geo_mesh
 
         name = "cone"
-        cone_center = (range_first + self.center[0], self.extents[2] * 10 + self.center[1], self.center[2])
+        cone_center = (range_first + center[0], self.extents[2] * 10 + center[1], center[2])
         end_geo_mesh = self._create_cone(
             center=cone_center,
             direction=(-1, 0, 0),
@@ -1339,7 +1342,9 @@ class MonostaticRCSPlotter(object):
             Color of the cone. The default is green (``"#00ff00"``).
         """
         radius_max = self.radius
-        center = [self.center[0], self.center[1], self.center[2]]
+        
+        # TODO: Do we want to support non-centered waterfall?
+        center = np.array([0., 0., 0.])
 
         angle = aspect_ang_phi - 1
 
@@ -1383,8 +1388,8 @@ class MonostaticRCSPlotter(object):
                     y_start = center[1] + radius_max * 0.95 * np.sin(np.deg2rad(tick * tick_spacing_deg))
                     x_stop = center[0] + radius_max * 1.05 * np.cos(np.deg2rad(tick * tick_spacing_deg))
                     y_stop = center[1] + radius_max * 1.05 * np.sin(np.deg2rad(tick * tick_spacing_deg))
-                    tick_pos_start = (x_start, y_start, self.center[2])
-                    tick_pos_end = (x_stop, y_stop, self.center[2])
+                    tick_pos_start = (x_start, y_start, center[2])
+                    tick_pos_end = (x_stop, y_stop, center[2])
                     tick_lines += pv.Line(pointa=tick_pos_start, pointb=tick_pos_end)
 
             annotation_name = "ticks"
@@ -1400,7 +1405,7 @@ class MonostaticRCSPlotter(object):
         end_point = [
             center[0] + radius_max * np.cos(np.deg2rad(angle)),
             center[1] + radius_max * np.sin(np.deg2rad(angle)),
-            self.center[2],
+            center[2],
         ]
         end_point_plus_one = [
             center[0] + radius_max * np.cos(np.deg2rad(aspect_ang_phi)),
@@ -1492,18 +1497,23 @@ class MonostaticRCSPlotter(object):
         num_ticks = range_num
         num_ticks_az = range_num_az
 
-        # Using 5% of total range length
+        # Using 5% of total range length (^o^) let me think... maybe + range_resolution?
         tick_length = size_range * 0.05
         tick_length_az = size_cross_range * 0.05
 
         if "range_profile" not in self.all_scene_actors["annotations"]:
             self.all_scene_actors["annotations"]["isar_2d"] = {}
 
+        # Issue 47: self.center was incorrect. Do we want to support non-centered 2D ISAR? 
+        # The center can be moved only toward offset direction for example, it can be moved in 
+        # z direction if a plot in xy-plane
+        center = np.array([0., 0., 0.])
+
         # Main red line
         name = "main_line"
         main_line_mesh = self._create_line(
-            pointa=(range_first + self.center[0], range_first_az + self.center[1], self.center[2]),
-            pointb=(range_last + self.center[0], range_first_az + self.center[1], self.center[2]),
+            pointa=(range_first + center[0], range_first_az + center[1], center[2]),
+            pointb=(range_last + center[0], range_first_az + center[1], center[2]),
             name=name,
             color=line_color,
         )
@@ -1512,8 +1522,8 @@ class MonostaticRCSPlotter(object):
 
         name = "main_line_opposite"
         main_line_opposite_mesh = self._create_line(
-            pointa=(range_first + self.center[0], range_last_az + self.center[1], self.center[2]),
-            pointb=(range_last + self.center[0], range_last_az + self.center[1], self.center[2]),
+            pointa=(range_first + center[0], range_last_az + center[1], center[2]),
+            pointb=(range_last + center[0], range_last_az + center[1], center[2]),
             name=name,
             color=line_color,
         )
@@ -1522,16 +1532,16 @@ class MonostaticRCSPlotter(object):
 
         name = "main_line_az"
         main_line_az_mesh = self._create_line(
-            pointa=(range_first + self.center[0], range_first_az + self.center[1], self.center[2]),
-            pointb=(range_first + self.center[0], range_last_az + self.center[1], self.center[2]),
+            pointa=(range_first + center[0], range_first_az + center[1], center[2]),
+            pointb=(range_first + center[0], range_last_az + center[1], center[2]),
             name=name,
             color=line_color,
         )
 
         self.all_scene_actors["annotations"]["isar_2d"][name] = main_line_az_mesh
 
-        pointa = (range_last + self.center[0], range_first_az + self.center[1], self.center[2])
-        pointb = (range_last + self.center[0], range_last_az + self.center[1], self.center[2])
+        pointa = (range_last + center[0], range_first_az + center[1], center[2])
+        pointb = (range_last + center[0], range_last_az + center[1], center[2])
         name = "main_line_az_opposite"
         main_line_az_opposite_mesh = self._create_line(pointa=pointa, pointb=pointb, name=name, color=line_color)
         self.all_scene_actors["annotations"]["isar_2d"][name] = main_line_az_opposite_mesh
@@ -1540,14 +1550,14 @@ class MonostaticRCSPlotter(object):
             tick_lines = pv.PolyData()
             for tick in range(1, num_ticks, 2):  # create line with tick marks
                 tick_pos_start = (
-                    distance_range[tick] + self.center[0],
-                    range_first_az + self.center[1],
-                    self.center[2],
+                    distance_range[tick] + center[0],
+                    range_first_az + center[1],
+                    center[2],
                 )
                 tick_pos_end = (
-                    distance_range[tick] + self.center[0],
-                    range_first_az - tick_length + self.center[1],
-                    self.center[2],
+                    distance_range[tick] + center[0],
+                    range_first_az - tick_length + center[1],
+                    center[2],
                 )
                 tick_lines += pv.Line(pointa=tick_pos_start, pointb=tick_pos_end)
 
@@ -1565,11 +1575,11 @@ class MonostaticRCSPlotter(object):
         if num_ticks_az <= 256:  # don't display too many ticks
             tick_lines = pv.PolyData()
             for tick in range(1, num_ticks_az - 1, 2):  # create line with tick marks
-                tick_pos_start = (range_first + self.center[0], range_az[tick] + self.center[1], self.center[2])
+                tick_pos_start = (range_first + center[0], range_az[tick] + center[1], center[2])
                 tick_pos_end = (
-                    range_first + tick_length_az + self.center[0],
-                    range_az[tick] + self.center[1],
-                    self.center[2],
+                    range_first + tick_length_az + center[0],
+                    range_az[tick] + center[1],
+                    center[2],
                 )
                 tick_lines += pv.Line(pointa=tick_pos_start, pointb=tick_pos_end)
 
@@ -1670,7 +1680,7 @@ class MonostaticRCSPlotter(object):
         num_ticks_az = range_num_az
         num_ticks_el = range_num_el
 
-        # Using 5% of total range length
+        # Using 5% of total range length (^o^) revisit this
         tick_length = size_range * 0.05
         tick_length_az = size_cross_range * 0.05
         tick_length_el = size_elevation_range * 0.05
@@ -1678,11 +1688,14 @@ class MonostaticRCSPlotter(object):
         if "range_profile" not in self.all_scene_actors["annotations"]:
             self.all_scene_actors["annotations"]["isar_3d"] = {}
 
+        # TODO: Do we want to support non-centered 3D ISAR?
+        center = np.array([0., 0., 0.])
+
         # Main red line
         name = "main_line"
         main_line_mesh = self._create_line(
-            pointa=(range_first + self.center[0], range_first_az + self.center[1], self.center[2]),
-            pointb=(range_last + self.center[0], range_first_az + self.center[1], self.center[2]),
+            pointa=(range_first + center[0], range_first_az + center[1], center[2]),
+            pointb=(range_last + center[0], range_first_az + center[1], center[2]),
             name=name,
             color=line_color,
         )
@@ -1691,8 +1704,8 @@ class MonostaticRCSPlotter(object):
 
         name = "main_line_opposite"
         main_line_opposite_mesh = self._create_line(
-            pointa=(range_first + self.center[0], range_last_az + self.center[1], self.center[2]),
-            pointb=(range_last + self.center[0], range_last_az + self.center[1], self.center[2]),
+            pointa=(range_first + center[0], range_last_az + center[1], center[2]),
+            pointb=(range_last + center[0], range_last_az + center[1], center[2]),
             name=name,
             color=line_color,
         )
@@ -1701,24 +1714,24 @@ class MonostaticRCSPlotter(object):
 
         name = "main_line_az"
         main_line_az_mesh = self._create_line(
-            pointa=(range_first + self.center[0], range_first_az + self.center[1], self.center[2]),
-            pointb=(range_first + self.center[0], range_last_az + self.center[1], self.center[2]),
+            pointa=(range_first + center[0], range_first_az + center[1], center[2]),
+            pointb=(range_first + center[0], range_last_az + center[1], center[2]),
             name=name,
             color=line_color,
         )
 
         self.all_scene_actors["annotations"]["isar_3d"][name] = main_line_az_mesh
 
-        pointa = (range_last + self.center[0], range_first_az + self.center[1], self.center[2])
-        pointb = (range_last + self.center[0], range_last_az + self.center[1], self.center[2])
+        pointa = (range_last + center[0], range_first_az + center[1], center[2])
+        pointb = (range_last + center[0], range_last_az + center[1], center[2])
         name = "main_line_az_opposite"
         main_line_az_opposite_mesh = self._create_line(pointa=pointa, pointb=pointb, name=name, color=line_color)
         self.all_scene_actors["annotations"]["isar_3d"][name] = main_line_az_opposite_mesh
 
         name = "main_line_el"
         main_line_el_mesh = self._create_line(
-            pointa=(range_first + self.center[0], range_first_az + self.center[1], range_first_el + self.center[2]),
-            pointb=(range_first + self.center[0], range_first_az + self.center[1], range_last_el + self.center[2]),
+            pointa=(range_first + center[0], range_first_az + center[1], range_first_el + center[2]),
+            pointb=(range_first + center[0], range_first_az + center[1], range_last_el + center[2]),
             name=name,
             color=line_color,
         )
@@ -1726,12 +1739,12 @@ class MonostaticRCSPlotter(object):
         self.all_scene_actors["annotations"]["isar_3d"][name] = main_line_el_mesh
 
         box_bounds = (
-            range_first + self.center[0],
-            range_last + self.center[0],
-            range_first_az + self.center[1],
-            range_last_az + self.center[1],
-            range_first_el + self.center[2],
-            range_last_el + self.center[2],
+            range_first + center[0],
+            range_last + center[0],
+            range_first_az + center[1],
+            range_last_az + center[1],
+            range_first_el + center[2],
+            range_last_el + center[2],
         )
         name = "box"
         box = pv.Box(box_bounds)
@@ -1752,14 +1765,14 @@ class MonostaticRCSPlotter(object):
             tick_lines = pv.PolyData()
             for tick in range(1, num_ticks, 2):  # create line with tick marks
                 tick_pos_start = (
-                    distance_range[tick] + self.center[0],
-                    range_first_az + self.center[1],
-                    self.center[2],
+                    distance_range[tick] + center[0],
+                    range_first_az + center[1],
+                    center[2],
                 )
                 tick_pos_end = (
-                    distance_range[tick] + self.center[0],
-                    range_first_az - tick_length + self.center[1],
-                    self.center[2],
+                    distance_range[tick] + center[0],
+                    range_first_az - tick_length + center[1],
+                    center[2],
                 )
                 tick_lines += pv.Line(pointa=tick_pos_start, pointb=tick_pos_end)
 
@@ -1777,11 +1790,11 @@ class MonostaticRCSPlotter(object):
         if num_ticks_az <= 256:  # don't display too many ticks
             tick_lines = pv.PolyData()
             for tick in range(1, num_ticks_az - 1, 2):  # create line with tick marks
-                tick_pos_start = (range_first + self.center[0], range_az[tick] + self.center[1], self.center[2])
+                tick_pos_start = (range_first + center[0], range_az[tick] + center[1], center[2])
                 tick_pos_end = (
-                    range_first + tick_length_az + self.center[0],
-                    range_az[tick] + self.center[1],
-                    self.center[2],
+                    range_first + tick_length_az + center[0],
+                    range_az[tick] + center[1],
+                    center[2],
                 )
                 tick_lines += pv.Line(pointa=tick_pos_start, pointb=tick_pos_end)
 
@@ -1800,14 +1813,14 @@ class MonostaticRCSPlotter(object):
             tick_lines = pv.PolyData()
             for tick in range(1, num_ticks_el - 1, 2):  # create line with tick marks
                 tick_pos_start = (
-                    range_first + self.center[0],
-                    range_first_az + self.center[1],
-                    range_el[tick] + self.center[2],
+                    range_first + center[0],
+                    range_first_az + center[1],
+                    range_el[tick] + center[2],
                 )
                 tick_pos_end = (
-                    range_first + tick_length_el + self.center[0],
-                    range_first_az + self.center[1],
-                    range_el[tick] + self.center[2],
+                    range_first + tick_length_el + center[0],
+                    range_first_az + center[1],
+                    range_el[tick] + center[2],
                 )
                 tick_lines += pv.Line(pointa=tick_pos_start, pointb=tick_pos_end)
 

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -1439,7 +1439,7 @@ class MonostaticRCSPlotter(object):
         line_color="#ff0000",
     ):
         """
-        Add a 2D ISAR (Inverse Synthetic Aperture Radar) visualization to the current 3D scene.
+        Add a preview frame of 2D ISAR (Inverse Synthetic Aperture Radar) visualization to the current 3D scene.
 
         This function creates a 2D range and cross-range profile in a 3D scene. It includes a main
         line to represent the range axis, tick marks to indicate distance intervals, and additional
@@ -1485,18 +1485,14 @@ class MonostaticRCSPlotter(object):
         distance_range = np.linspace(0, range_max, range_num)
         distance_range -= distance_range[range_num // 2]
         range_first = -distance_range[0]
-        range_last = -distance_range[-1]
         range_frame = np.array([-size_range/2, size_range/2])
-        #range_frame = np.array([range_first, range_last])
 
         range_max_az = size_cross_range
         range_num_az = int(np.round(size_cross_range / cross_range_resolution))
         range_az = np.linspace(0, range_max_az, range_num_az)
         range_az -= range_az[range_num_az // 2]
         range_first_az = range_az[0]
-        range_last_az = range_az[-1]
         range_frame_az = np.array([-size_cross_range/2, size_cross_range/2])
-        #range_frame_az = np.array([range_first_az, range_last_az])
 
         num_ticks = range_num
         num_ticks_az = range_num_az
@@ -1611,7 +1607,7 @@ class MonostaticRCSPlotter(object):
         line_color="#ff0000",
     ):
         """
-        Add a 3D ISAR (Inverse Synthetic Aperture Radar) visualization to the current 3D scene.
+        Add a a preview frame of 3D ISAR (Inverse Synthetic Aperture Radar) visualization to the current 3D scene.
 
         Parameters
         ----------

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -1994,14 +1994,12 @@ class MonostaticRCSPlotter(object):
         # mesh idx  1   2   3   4   5
         #           | * | * | * | * |
         # value idx   1   2   3   4
-        dx = down_range[1]-down_range[0];
-        down_range = down_range[:] - dx/2; 
-        down_range = np.append(down_range,down_range[-1] + dx)
-        dy = cross_range[1]-cross_range[0];
-        cross_range = cross_range[:] - dy/2; 
-        cross_range = np.append(cross_range,cross_range[-1] +dy)
+        dx = down_range[1]-down_range[0]
+        down_range_grid = np.linspace(down_range[0]-dx/2, down_range[-1]+dx/2, num=len(down_range)+1)
+        dy = cross_range[1]-cross_range[0]
+        cross_range_grid = np.linspace(cross_range[0]-dy/2, cross_range[-1]+dy/2, num=len(cross_range)+1)
 
-        x, y = np.meshgrid(down_range, cross_range)
+        x, y = np.meshgrid(down_range_grid, cross_range_grid)
         z = np.zeros_like(x)
 
         if plot_type.casefold() == "relief":
@@ -2013,7 +2011,7 @@ class MonostaticRCSPlotter(object):
             actor = pv.StructuredGrid()
             actor.points = np.c_[x.ravel(), y.ravel(), z.ravel()]
 
-            actor.dimensions = (len(down_range), len(cross_range), 1)
+            actor.dimensions = (len(down_range_grid), len(cross_range_grid), 1)
 
             actor["values"] = values_2d.ravel()
 

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -1994,6 +1994,17 @@ class MonostaticRCSPlotter(object):
 
         values_2d = data_isar_2d.pivot(index="Cross-range", columns="Down-range", values="Data").to_numpy()
 
+        # meshgrid must have one more pixel. In the other words, number of meshgrid points = number of values + 1
+        # mesh idx  1   2   3   4   5
+        #           | * | * | * | * |
+        # value idx   1   2   3   4
+        dx = down_range[1]-down_range[0];
+        down_range = down_range[:] - dx/2; 
+        down_range = np.append(down_range,down_range[-1] + dx)
+        dy = cross_range[1]-cross_range[0];
+        cross_range = cross_range[:] - dy/2; 
+        cross_range = np.append(cross_range,cross_range[-1] +dy)
+
         x, y = np.meshgrid(down_range, cross_range)
         z = np.zeros_like(x)
 

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -404,8 +404,6 @@ class MonostaticRCSData(object):
         """Range profile."""
         value = None
         if isinstance(self.raw_data, pd.DataFrame):
-            data_conversion_function_original = self.data_conversion_function
-            self.data_conversion_function = None
             data = self.rcs_active_theta_phi["Data"]
             # Take needed properties
             size = self.window_size
@@ -419,7 +417,6 @@ class MonostaticRCSData(object):
             sf_upsample = self.window_size / nfreq
             windowed_data = np.fft.fftshift(sf_upsample * np.fft.ifft(windowed_data.to_numpy(), n=size))
 
-            self.data_conversion_function = data_conversion_function_original
             data_converted = conversion_function(windowed_data, self.data_conversion_function)
 
             df = unit_converter((self.frequencies[1] - self.frequencies[0]), "Freq", self.frequency_units, "Hz")
@@ -468,8 +465,6 @@ class MonostaticRCSData(object):
 
             ndrng = self.upsample_range
             nxrng = self.upsample_azimuth
-            data_conversion_function_original = self.data_conversion_function
-            self.data_conversion_function = None
             if self.aspect_range == "Horizontal":
                 nangles = len(phis)
                 azel_samples = -phis.reshape(1, -1)
@@ -567,7 +562,6 @@ class MonostaticRCSData(object):
             df["Cross-range"] = xr_flat
             df["Data"] = isar_image_flat
 
-            self.data_conversion_function = data_conversion_function_original
         return df
 
     @staticmethod

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -379,8 +379,6 @@ class MonostaticRCSData(object):
         value = None
         if isinstance(self.raw_data, pd.DataFrame):
             data = self.raw_data.xs(key=self.incident_wave_theta, level="IWaveTheta")
-            if self.data_conversion_function:
-                data = conversion_function(data[self.name], self.data_conversion_function)
             df = data.reset_index()
             df.columns = ["Freq", "IWavePhi", "Data"]
             value = df
@@ -392,8 +390,6 @@ class MonostaticRCSData(object):
         value = None
         if isinstance(self.raw_data, pd.DataFrame):
             data = self.raw_data.xs(key=self.incident_wave_phi, level="IWavePhi")
-            if self.data_conversion_function:
-                data = conversion_function(data[self.name], self.data_conversion_function)
             df = data.reset_index()
             df.columns = ["Freq", "IWaveTheta", "Data"]
             value = df
@@ -742,12 +738,15 @@ class MonostaticRCSPlotter(object):
                 if all_secondary_sweep_value is None:
                     all_secondary_sweep_value = self.rcs_data.incident_wave_theta
                 data = self.rcs_data.rcs_active_phi
+                data["Data"] = conversion_function(data["Data"] , self.rcs_data.data_conversion_function)
                 y_key = "IWaveTheta"
 
             else:
                 if all_secondary_sweep_value is None:
                     all_secondary_sweep_value = self.rcs_data.incident_wave_phi
                 data = self.rcs_data.rcs_active_theta
+                data["Data"] = conversion_function(data["Data"] , self.rcs_data.data_conversion_function)
+
                 y_key = "IWavePhi"
         else:
             data = self.rcs_data.rcs_active_frequency

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -549,12 +549,10 @@ class MonostaticRCSData(object):
             x = np.transpose(np.arange(start=0, step=dx, stop=ndrng * dx))  # ndrng x 1
             y = np.arange(start=0, step=dy, stop=nxrng * dy)  # 1 x Ny
 
-            #  Make the center x and y values zero
-            #  these two lines ensure one value of x and y are zero when nx or ny are even
-
-            range_values = x - x[ndrng // 2]
+            #  Make the extents of the image symmetric about the origin.
+            range_values = x - (x[-1]-x[0])/2
             range_values_interp = np.linspace(range_values[0], range_values[-1], num=ndrng)
-            cross_range_values = y - y[nxrng // 2]
+            cross_range_values = y - (y[-1]-y[0])/2
             cross_range_values_interp = np.linspace(cross_range_values[0], cross_range_values[-1], num=nxrng)
 
             rr, xr = np.meshgrid(range_values_interp, cross_range_values_interp)

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -43,6 +43,8 @@ from ansys.aedt.core.internal.checks import check_graphics_available
 from ansys.aedt.core.internal.checks import graphics_required
 from ansys.aedt.core.visualization.plot.matplotlib import ReportPlotter
 
+from scipy.interpolate import RegularGridInterpolator
+
 try:
     import numpy as np
 except ImportError:  # pragma: no cover
@@ -2005,7 +2007,11 @@ class MonostaticRCSPlotter(object):
         if plot_type.casefold() == "relief":
             m = 2.0
             b = -1.0
-            z = (values_2d - values_2d.min()) / (values_2d.max() - values_2d.min()) * m + b
+            # z = (values_2d - values_2d.min()) / (values_2d.max() - values_2d.min()) * m + b
+
+            f_z = RegularGridInterpolator((cross_range, down_range), values_2d, fill_value=None, method = "linear", bounds_error=False)
+            z = f_z((y,x))
+            z = (z - z.min()) / (z.max() - z.min()) * m + b
 
         if plot_type.casefold() in ["relief", "plane"]:
             actor = pv.StructuredGrid()

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -1480,24 +1480,28 @@ class MonostaticRCSPlotter(object):
         )
 
         # Compute parameters
-        range_max = size_range - range_resolution
+        range_max = size_range
         range_num = int(np.round(size_range / range_resolution))
         distance_range = np.linspace(0, range_max, range_num)
         distance_range -= distance_range[range_num // 2]
         range_first = -distance_range[0]
         range_last = -distance_range[-1]
+        range_frame = np.array([-size_range/2, size_range/2])
+        #range_frame = np.array([range_first, range_last])
 
-        range_max_az = size_cross_range - cross_range_resolution
+        range_max_az = size_cross_range
         range_num_az = int(np.round(size_cross_range / cross_range_resolution))
         range_az = np.linspace(0, range_max_az, range_num_az)
         range_az -= range_az[range_num_az // 2]
         range_first_az = range_az[0]
         range_last_az = range_az[-1]
+        range_frame_az = np.array([-size_cross_range/2, size_cross_range/2])
+        #range_frame_az = np.array([range_first_az, range_last_az])
 
         num_ticks = range_num
         num_ticks_az = range_num_az
 
-        # Using 5% of total range length (^o^) let me think... maybe + range_resolution?
+        # Using 5% of total range length
         tick_length = size_range * 0.05
         tick_length_az = size_cross_range * 0.05
 
@@ -1512,8 +1516,8 @@ class MonostaticRCSPlotter(object):
         # Main red line
         name = "main_line"
         main_line_mesh = self._create_line(
-            pointa=(range_first + center[0], range_first_az + center[1], center[2]),
-            pointb=(range_last + center[0], range_first_az + center[1], center[2]),
+            pointa=(range_frame[0] + center[0], range_frame_az[0] + center[1], center[2]),
+            pointb=(range_frame[1] + center[0], range_frame_az[0] + center[1], center[2]),
             name=name,
             color=line_color,
         )
@@ -1522,8 +1526,8 @@ class MonostaticRCSPlotter(object):
 
         name = "main_line_opposite"
         main_line_opposite_mesh = self._create_line(
-            pointa=(range_first + center[0], range_last_az + center[1], center[2]),
-            pointb=(range_last + center[0], range_last_az + center[1], center[2]),
+            pointa=(range_frame[0] + center[0], range_frame_az[1] + center[1], center[2]),
+            pointb=(range_frame[1] + center[0], range_frame_az[1] + center[1], center[2]),
             name=name,
             color=line_color,
         )
@@ -1532,16 +1536,16 @@ class MonostaticRCSPlotter(object):
 
         name = "main_line_az"
         main_line_az_mesh = self._create_line(
-            pointa=(range_first + center[0], range_first_az + center[1], center[2]),
-            pointb=(range_first + center[0], range_last_az + center[1], center[2]),
+            pointa=(range_frame[0] + center[0], range_frame_az[0] + center[1], center[2]),
+            pointb=(range_frame[0] + center[0], range_frame_az[1] + center[1], center[2]),
             name=name,
             color=line_color,
         )
 
         self.all_scene_actors["annotations"]["isar_2d"][name] = main_line_az_mesh
 
-        pointa = (range_last + center[0], range_first_az + center[1], center[2])
-        pointb = (range_last + center[0], range_last_az + center[1], center[2])
+        pointa = (range_frame[1] + center[0], range_frame_az[0] + center[1], center[2])
+        pointb = (range_frame[1] + center[0], range_frame_az[1] + center[1], center[2])
         name = "main_line_az_opposite"
         main_line_az_opposite_mesh = self._create_line(pointa=pointa, pointb=pointb, name=name, color=line_color)
         self.all_scene_actors["annotations"]["isar_2d"][name] = main_line_az_opposite_mesh
@@ -1680,7 +1684,7 @@ class MonostaticRCSPlotter(object):
         num_ticks_az = range_num_az
         num_ticks_el = range_num_el
 
-        # Using 5% of total range length (^o^) revisit this
+        # Using 5% of total range length
         tick_length = size_range * 0.05
         tick_length_az = size_cross_range * 0.05
         tick_length_el = size_elevation_range * 0.05

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -32,9 +32,9 @@ if current_python_version < (3, 10):  # pragma: no cover
 
 import warnings
 
-from ansys.aedt.core.generic.constants import SpeedOfLight
 from ansys.aedt.core.aedt_logger import pyaedt_logger as logger
 from ansys.aedt.core.generic.constants import AEDT_UNITS
+from ansys.aedt.core.generic.constants import SpeedOfLight
 from ansys.aedt.core.generic.constants import unit_converter
 from ansys.aedt.core.generic.general_methods import conversion_function
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
@@ -43,7 +43,6 @@ from ansys.aedt.core.internal.checks import ERROR_GRAPHICS_REQUIRED
 from ansys.aedt.core.internal.checks import check_graphics_available
 from ansys.aedt.core.internal.checks import graphics_required
 from ansys.aedt.core.visualization.plot.matplotlib import ReportPlotter
-
 from scipy.interpolate import RegularGridInterpolator
 
 try:
@@ -522,17 +521,17 @@ class MonostaticRCSData(object):
             # The center of the first pixel in the second half of each domain is centered at zero
             # if the domain has odd length, but it is at dx/2 otherwise.
             if ndrng % 2 == 0:
-                dArg = np.pi/ndrng # 2pi/(dx/2)/(dx*ndrng)
-                tmp = np.floor(-0.5*nfreq)*dArg
+                dArg = np.pi / ndrng  # 2pi/(dx/2)/(dx*ndrng)
+                tmp = np.floor(-0.5 * nfreq) * dArg
                 rngShiftBase = complex(np.cos(tmp), np.sin(tmp))
                 rngShiftDelta = complex(np.cos(dArg), np.sin(dArg))
                 for iF in range(0, nfreq):
                     rdata[iF, :] *= rngShiftBase
                     rngShiftBase *= rngShiftDelta
-            
+
             if nxrng % 2 == 0:
-                dArg = np.pi/nxrng
-                tmp = np.floor(-0.5*nangles)*dArg
+                dArg = np.pi / nxrng
+                tmp = np.floor(-0.5 * nangles) * dArg
                 rngShiftBase = complex(np.cos(tmp), np.sin(tmp))
                 rngShiftDelta = complex(np.cos(dArg), np.sin(dArg))
                 for iA in range(0, nangles):
@@ -560,13 +559,13 @@ class MonostaticRCSData(object):
             isar_image = conversion_function(isar_image, self.data_conversion_function)
 
             isar_image = isar_image.transpose()
-            isar_image = isar_image[::-1, :] # this used to be flipped, but it matched range/cross range defs now
+            isar_image = isar_image[::-1, :]  # this used to be flipped, but it matched range/cross range defs now
 
             # bring the center of the PHYSICAL image to 0, which means the first pixel on the
             # second half is not at 0 for even length domains
-            range_values = x - 0.5*(x[-1]-x[0])
+            range_values = x - 0.5 * (x[-1] - x[0])
             range_values_interp = np.linspace(range_values[0], range_values[-1], num=ndrng)
-            cross_range_values = y - 0.5*(y[-1]-y[0])
+            cross_range_values = y - 0.5 * (y[-1] - y[0])
             cross_range_values_interp = np.linspace(cross_range_values[0], cross_range_values[-1], num=nxrng)
 
             rr, xr = np.meshgrid(range_values_interp, cross_range_values_interp)
@@ -761,14 +760,14 @@ class MonostaticRCSPlotter(object):
                 if all_secondary_sweep_value is None:
                     all_secondary_sweep_value = self.rcs_data.incident_wave_theta
                 data = self.rcs_data.rcs_active_phi
-                data["Data"] = conversion_function(data["Data"] , self.rcs_data.data_conversion_function)
+                data["Data"] = conversion_function(data["Data"], self.rcs_data.data_conversion_function)
                 y_key = "IWaveTheta"
 
             else:
                 if all_secondary_sweep_value is None:
                     all_secondary_sweep_value = self.rcs_data.incident_wave_phi
                 data = self.rcs_data.rcs_active_theta
-                data["Data"] = conversion_function(data["Data"] , self.rcs_data.data_conversion_function)
+                data["Data"] = conversion_function(data["Data"], self.rcs_data.data_conversion_function)
 
                 y_key = "IWavePhi"
         else:
@@ -1073,9 +1072,7 @@ class MonostaticRCSPlotter(object):
         }
 
         new.add_trace(plot_data, 0, props)
-        _ = new.plot_pcolor(
-            trace=0, snapshot_path=output_file, show=show, figure=figure
-        )
+        _ = new.plot_pcolor(trace=0, snapshot_path=output_file, show=show, figure=figure)
         return new
 
     @pyaedt_function_handler()
@@ -1260,7 +1257,7 @@ class MonostaticRCSPlotter(object):
             self.all_scene_actors["annotations"]["range_profile"] = {}
 
         # TODO: Do we want to support non-centered Range profile?
-        center = np.array([0., 0., 0.])
+        center = np.array([0.0, 0.0, 0.0])
 
         # Main red line
         name = "main_line"
@@ -1358,9 +1355,9 @@ class MonostaticRCSPlotter(object):
             Color of the cone. The default is green (``"#00ff00"``).
         """
         radius_max = self.radius
-        
+
         # TODO: Do we want to support non-centered waterfall?
-        center = np.array([0., 0., 0.])
+        center = np.array([0.0, 0.0, 0.0])
 
         angle = aspect_ang_phi - 1
 
@@ -1495,11 +1492,11 @@ class MonostaticRCSPlotter(object):
             cross_range_resolution, unit_system="Length", input_units="meter", output_units=self.model_units
         )
 
-        # Issue 47: self.center was incorrect. Do we want to support non-centered 2D ISAR? 
-        # The center can be moved only toward offset direction for example, it can be moved in 
+        # Issue 47: self.center was incorrect. Do we want to support non-centered 2D ISAR?
+        # The center can be moved only toward offset direction for example, it can be moved in
         # z direction if a plot in xy-plane
         # Do not use self.center, it is not correct
-        center = np.array([0., 0., 0.])
+        center = np.array([0.0, 0.0, 0.0])
 
         # maximum number of ticks
         max_ticks = 64
@@ -1508,14 +1505,14 @@ class MonostaticRCSPlotter(object):
         range_max = size_range - range_resolution
         range_num = int(np.round(size_range / range_resolution))
         range_ticks = np.linspace(0, range_max, range_num)
-        range_ticks -= (range_ticks[-1] - range_ticks[0])/2 + center[0]
-        range_frame = np.array([-size_range/2, size_range/2])
+        range_ticks -= (range_ticks[-1] - range_ticks[0]) / 2 + center[0]
+        range_frame = np.array([-size_range / 2, size_range / 2])
 
         range_max_az = size_cross_range - cross_range_resolution
         range_num_az = int(np.round(size_cross_range / cross_range_resolution))
         range_ticks_az = np.linspace(0, range_max_az, range_num_az)
-        range_ticks_az -= (range_ticks_az[-1] - range_ticks_az[0])/2 + center[1]
-        range_frame_az = np.array([-size_cross_range/2, size_cross_range/2])
+        range_ticks_az -= (range_ticks_az[-1] - range_ticks_az[0]) / 2 + center[1]
+        range_frame_az = np.array([-size_cross_range / 2, size_cross_range / 2])
 
         num_ticks = range_num
         num_ticks_az = range_num_az
@@ -1565,7 +1562,7 @@ class MonostaticRCSPlotter(object):
         self.all_scene_actors["annotations"]["isar_2d"][name] = main_line_az_opposite_mesh
 
         tick_lines = pv.PolyData()
-        for tick in range(0, num_ticks, num_ticks//max_ticks+1):  # create line with tick marks
+        for tick in range(0, num_ticks, num_ticks // max_ticks + 1):  # create line with tick marks
             tick_pos_start = (
                 range_ticks[tick] + center[0],
                 range_frame_az[0] + center[1],
@@ -1590,7 +1587,7 @@ class MonostaticRCSPlotter(object):
 
         # add azimuth line
         tick_lines = pv.PolyData()
-        for tick in range(0, num_ticks_az,num_ticks//max_ticks+1):  # create line with tick marks
+        for tick in range(0, num_ticks_az, num_ticks // max_ticks + 1):  # create line with tick marks
             tick_pos_start = (range_frame[-1] + center[0], range_ticks_az[tick] + center[1], center[2])
             tick_pos_end = (
                 range_frame[-1] + tick_length_az + center[0],
@@ -1705,7 +1702,7 @@ class MonostaticRCSPlotter(object):
             self.all_scene_actors["annotations"]["isar_3d"] = {}
 
         # TODO: Do we want to support non-centered 3D ISAR?
-        center = np.array([0., 0., 0.])
+        center = np.array([0.0, 0.0, 0.0])
 
         # Main red line
         name = "main_line"
@@ -2010,10 +2007,10 @@ class MonostaticRCSPlotter(object):
         # mesh idx  1   2   3   4   5
         #           | * | * | * | * |
         # value idx   1   2   3   4
-        dx = down_range[1]-down_range[0]
-        down_range_grid = np.linspace(down_range[0]-dx/2, down_range[-1]+dx/2, num=len(down_range)+1)
-        dy = cross_range[1]-cross_range[0]
-        cross_range_grid = np.linspace(cross_range[0]-dy/2, cross_range[-1]+dy/2, num=len(cross_range)+1)
+        dx = down_range[1] - down_range[0]
+        down_range_grid = np.linspace(down_range[0] - dx / 2, down_range[-1] + dx / 2, num=len(down_range) + 1)
+        dy = cross_range[1] - cross_range[0]
+        cross_range_grid = np.linspace(cross_range[0] - dy / 2, cross_range[-1] + dy / 2, num=len(cross_range) + 1)
 
         # TODO revisit this! this only works for 2D ISAR on the theta = 90 plane
         x, y = np.meshgrid(down_range_grid[::-1], cross_range_grid[::-1])
@@ -2024,8 +2021,10 @@ class MonostaticRCSPlotter(object):
             b = -1.0
             # z = (values_2d - values_2d.min()) / (values_2d.max() - values_2d.min()) * m + b
 
-            f_z = RegularGridInterpolator((cross_range, down_range), values_2d, fill_value=None, method = "linear", bounds_error=False)
-            z = f_z((y,x))
+            f_z = RegularGridInterpolator(
+                (cross_range, down_range), values_2d, fill_value=None, method="linear", bounds_error=False
+            )
+            z = f_z((y, x))
             z = (z - z.min()) / (z.max() - z.min()) * m + b
 
         if plot_type.casefold() in ["relief", "plane"]:

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -498,6 +498,16 @@ class MonostaticRCSData(object):
             rdata = scipy.interpolate.griddata((fxtrue, fytrue), data, (grid_x, grid_y), "linear", fill_value=0.0)
             rdata = rdata.transpose()
 
+            # Zero padding
+            if ndrng < nfreq:
+                # Warning('nx should be at least as large as the length of f -- increasing nx')
+                self.__logger.warning("nx should be at least as large as the number of frequencies.")
+                ndrng = nfreq
+            if nxrng < nangles:
+                # warning('ny should be at least as large as the length of az -- increasing ny');
+                self.__logger.warning("ny should be at least as large as the number of azimuth angles.")
+                nxrng = nangles
+
             #  Compute the image plane downrange and cross-range distance vectors (in
             #  meters)
             dfx = fx[1] - fx[0]  # difference in x-frequencies
@@ -534,16 +544,6 @@ class MonostaticRCSData(object):
 
             winx = winx.reshape(-1, 1)
             winy = winy.reshape(1, -1)
-
-            # Zero padding
-            if ndrng < nfreq:
-                # Warning('nx should be at least as large as the length of f -- increasing nx')
-                self.__logger.warning("nx should be at least as large as the number of frequencies.")
-                ndrng = nfreq
-            if nxrng < nangles:
-                # warning('ny should be at least as large as the length of az -- increasing ny');
-                self.__logger.warning("ny should be at least as large as the number of azimuth angles.")
-                nxrng = nangles
 
             iq = np.zeros((ndrng, nxrng), dtype=np.complex128)
             xshift = (ndrng - nfreq) // 2

--- a/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
+++ b/src/ansys/aedt/core/visualization/advanced/rcs_visualization.py
@@ -520,7 +520,7 @@ class MonostaticRCSData(object):
                     rdata[iF, :] *= rngShiftBase
                     rngShiftBase *= rngShiftDelta
             
-            if ndrng % 2 == 0:
+            if nxrng % 2 == 0:
                 dArg = np.pi/nxrng
                 tmp = np.floor(-0.5*nangles)*dArg
                 rngShiftBase = complex(np.cos(tmp), np.sin(tmp))

--- a/src/ansys/aedt/core/visualization/plot/matplotlib.py
+++ b/src/ansys/aedt/core/visualization/plot/matplotlib.py
@@ -1477,7 +1477,7 @@ class ReportPlotter:
         show=True,
         figure=None,
     ):
-        """Create a Matplotlib figure pcolor mesh based on a list of data.
+        """Create a Matplotlib figure pseudo color plot with a non-regular rectangular grid based on a list of data.
 
         Parameters
         ----------
@@ -1493,8 +1493,6 @@ class ReportPlotter:
         figure : :class:`matplotlib.pyplot.Figure`, optional
             An existing Matplotlib `Figure` to which the plot is added.
             If not provided, a new `Figure` and `Axes` object are created.
-        is_spherical : bool, optional
-            Whether to use spherical or cartesian data.
 
         Returns
         -------

--- a/src/ansys/aedt/core/visualization/plot/matplotlib.py
+++ b/src/ansys/aedt/core/visualization/plot/matplotlib.py
@@ -1459,13 +1459,7 @@ class ReportPlotter:
             th = tr._cartesian_data[1]
             data_to_plot = tr._cartesian_data[0]
 
-        contour = self.ax.contourf(
-            ph,
-            th,
-            data_to_plot,
-            levels=levels,
-            cmap="jet"
-        )
+        contour = self.ax.contourf(ph, th, data_to_plot, levels=levels, cmap="jet")
         if color_bar:
             cbar = self.fig.colorbar(contour, ax=self.ax)
             cbar.set_label(color_bar, rotation=270, labelpad=20)
@@ -1473,7 +1467,6 @@ class ReportPlotter:
         self.ax.yaxis.set_label_coords(-0.1, 0.5)
         self._plot(snapshot_path, show)
         return self.fig
-
 
     @pyaedt_function_handler()
     def plot_pcolor(
@@ -1527,20 +1520,14 @@ class ReportPlotter:
 
         self.ax.set(title=self.title)
         X = np.array(list(zip(*tr._cartesian_data[2]))[0])
-        dxO2 = (X[1] - X[0])/2
-        X = np.linspace(X[0]-dxO2, X[-1]+dxO2, len(X)+1)
+        dxO2 = (X[1] - X[0]) / 2
+        X = np.linspace(X[0] - dxO2, X[-1] + dxO2, len(X) + 1)
         Y = np.array(tr._cartesian_data[1][0])
-        dyO2 = (Y[1] - Y[0])/2
-        Y = np.linspace(Y[0]-dyO2, Y[-1]+dyO2, len(Y)+1)
+        dyO2 = (Y[1] - Y[0]) / 2
+        Y = np.linspace(Y[0] - dyO2, Y[-1] + dyO2, len(Y) + 1)
         data_to_plot = tr._cartesian_data[0]
 
-        contour = self.ax.pcolormesh(
-            X,
-            Y,
-            data_to_plot.T,
-            cmap="jet",
-            shading="flat"
-        )
+        contour = self.ax.pcolormesh(X, Y, data_to_plot.T, cmap="jet", shading="flat")
         if color_bar:
             cbar = self.fig.colorbar(contour, ax=self.ax)
             cbar.set_label(color_bar, rotation=270, labelpad=20)

--- a/src/ansys/aedt/core/visualization/plot/matplotlib.py
+++ b/src/ansys/aedt/core/visualization/plot/matplotlib.py
@@ -1464,7 +1464,82 @@ class ReportPlotter:
             th,
             data_to_plot,
             levels=levels,
+            cmap="jet"
+        )
+        if color_bar:
+            cbar = self.fig.colorbar(contour, ax=self.ax)
+            cbar.set_label(color_bar, rotation=270, labelpad=20)
+
+        self.ax.yaxis.set_label_coords(-0.1, 0.5)
+        self._plot(snapshot_path, show)
+        return self.fig
+
+
+    @pyaedt_function_handler()
+    def plot_pcolor(
+        self,
+        trace=0,
+        color_bar=None,
+        snapshot_path=None,
+        show=True,
+        figure=None,
+    ):
+        """Create a Matplotlib figure pcolor mesh based on a list of data.
+
+        Parameters
+        ----------
+        trace : int, str, optional
+            Trace index on which create the 3D Plot.
+        color_bar : str, optional
+            Color bar title. The default is ``None`` in which case the color bar is not included.
+        snapshot_path : str, optional
+            Full path to image file if a snapshot is needed.
+            The default value is ``None``.
+        show : bool, optional
+            Whether to show the plot or return the matplotlib object. Default is ``True``.
+        figure : :class:`matplotlib.pyplot.Figure`, optional
+            An existing Matplotlib `Figure` to which the plot is added.
+            If not provided, a new `Figure` and `Axes` object are created.
+        is_spherical : bool, optional
+            Whether to use spherical or cartesian data.
+
+        Returns
+        -------
+        :class:`matplotlib.pyplot.Figure`
+            Matplotlib figure object.
+        """
+        tr = self._retrieve_traces(trace)
+        if not tr:
+            return False
+        else:
+            tr = tr[0]
+        projection = "rectilinear"
+
+        if not figure:
+            self.fig, self.ax = plt.subplots(subplot_kw={"projection": projection})
+            self.ax = plt.gca()
+        else:
+            self.fig = figure
+            self.ax = figure.add_subplot(111, polar=False)
+
+        self.ax.set_xlabel(tr.x_label)
+        self.ax.set_ylabel(tr.y_label)
+
+        self.ax.set(title=self.title)
+        X = np.array(list(zip(*tr._cartesian_data[2]))[0])
+        dxO2 = (X[1] - X[0])/2
+        X = np.linspace(X[0]-dxO2, X[-1]+dxO2, len(X)+1)
+        Y = np.array(tr._cartesian_data[1][0])
+        dyO2 = (Y[1] - Y[0])/2
+        Y = np.linspace(Y[0]-dyO2, Y[-1]+dyO2, len(Y)+1)
+        data_to_plot = tr._cartesian_data[0]
+
+        contour = self.ax.pcolormesh(
+            Y,
+            X,
+            data_to_plot,
             cmap="jet",
+            shading="flat"
         )
         if color_bar:
             cbar = self.fig.colorbar(contour, ax=self.ax)

--- a/src/ansys/aedt/core/visualization/plot/matplotlib.py
+++ b/src/ansys/aedt/core/visualization/plot/matplotlib.py
@@ -1535,9 +1535,9 @@ class ReportPlotter:
         data_to_plot = tr._cartesian_data[0]
 
         contour = self.ax.pcolormesh(
-            Y,
             X,
-            data_to_plot,
+            Y,
+            data_to_plot.T,
             cmap="jet",
             shading="flat"
         )

--- a/tests/system/visualization/test_49_RCS_data_plotter.py
+++ b/tests/system/visualization/test_49_RCS_data_plotter.py
@@ -182,7 +182,7 @@ class TestClass:
         rcs_data.upsample_azimuth = 32
         assert rcs_data.upsample_azimuth == 32
 
-        assert isinstance(rcs_data.rcs, float)
+        assert isinstance(rcs_data.rcs, complex)
 
         assert isinstance(rcs_data.rcs_active_theta_phi, pd.DataFrame)
         assert isinstance(rcs_data.rcs_active_frequency, pd.DataFrame)


### PR DESCRIPTION
## Description
ISAR 2D calculations were not coded correctly.
Add a pcolor-like capability to pyaedt. Switch some hardwired values to SpeedOfLight.

## Issue linked
Corrects ISAR 2D calculations for ISAR images on the xy plane.
Adds pcolor plots to pyaedt for, e.g., rendering ISAR 2D images.

## Checklist
- [ v] I have tested my changes locally.
- [v ] I have added necessary documentation or updated existing documentation.
- [ v] I have followed the coding style guidelines of this project.
- [v ] I have added appropriate tests (unit, integration, system).
- [ v] I have reviewed my changes before submitting this pull request.
- [v ] I have linked the issue or issues that are solved by the PR if any.
- [v ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
