### PR TITLE
FEAT: Update create_setup method

### DIFF
--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -1795,6 +1795,10 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         name = self.generate_unique_setup_name(name)
         setup = self._create_setup(name=name, setup_type=setup_type)
         setup.auto_update = False
+        if "Frequency" in kwargs.keys():
+            if type(kwargs["Frequency"] ) is list:
+                if not "MultipleAdaptiveFreqsSetup" in kwargs.keys():
+                    kwargs["MultipleAdaptiveFreqsSetup"] = kwargs["Frequency"]
         for arg_name, arg_value in kwargs.items():
             if setup[arg_name] is not None:
                 if arg_name == "MultipleAdaptiveFreqsSetup":  # A list of frequency values is passed if

--- a/tests/system/general/test_11_Setup.py
+++ b/tests/system/general/test_11_Setup.py
@@ -108,6 +108,11 @@ class TestClass:
         assert setup2.props["SolveType"] == "MultiFrequency"
         assert setup2.props["MaximumPasses"] == 3
 
+        setup3 = self.aedtapp.create_setup( Frequency=["1GHz", "2GHz"], MaximumPasses=3
+        )
+        assert setup3.props["SolveType"] == "MultiFrequency"
+        assert setup3.props["MaximumPasses"] == 3
+
     def test_01b_create_hfss_sweep(self):
         self.aedtapp.save_project()
         setup1 = self.aedtapp.get_setup("My_HFSS_Setup")


### PR DESCRIPTION
Allow a list to be passed
for the "Frequency" argument to ``Hfss.create_setup()`` and automatically apply the multi-frequency adapt setup.

## Description
Resolve issue #6278. Add unit test to ``/test/system/general/test_11_Setup.py``

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
