### PR TITLE
FIX: lsf-job-submission-failure

### DIFF
--- a/doc/changelog.d/6318.fixed.md
+++ b/doc/changelog.d/6318.fixed.md
@@ -1,0 +1,1 @@
+Lsf-job-submission-failure

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -1589,7 +1589,7 @@ class Desktop(object):
 
         Parameters
         ----------
-        project_file : str
+        project_file : str or :class:`pathlib.Path`, optional
             Full path to the project. The path should be visible from the server where the
             simulation will run.
             If the client path is used then the
@@ -1682,8 +1682,6 @@ class Desktop(object):
         else:
             self.logger.warning("Setting file not found on client machine. Considering it as server path.")
             destination_reg = setting_file
-        if isinstance(destination_reg, Path):
-            destination_reg = destination_reg.as_posix()
         job = self.odesktop.SubmitJob(str(destination_reg), str(project_file))
         self.logger.info(f"Job submitted: {str(job)}")
         return job

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -1684,7 +1684,7 @@ class Desktop(object):
             destination_reg = setting_file
         if isinstance(destination_reg, Path):
             destination_reg = destination_reg.as_posix()
-        job = self.odesktop.SubmitJob(destination_reg, project_file)
+        job = self.odesktop.SubmitJob(str(destination_reg), str(project_file))
         self.logger.info(f"Job submitted: {str(job)}")
         return job
 

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -1682,7 +1682,8 @@ class Desktop(object):
         else:
             self.logger.warning("Setting file not found on client machine. Considering it as server path.")
             destination_reg = setting_file
-
+        if isinstance(destination_reg, Path):
+            destination_reg = destination_reg.as_posix()
         job = self.odesktop.SubmitJob(destination_reg, project_file)
         self.logger.info(f"Job submitted: {str(job)}")
         return job


### PR DESCRIPTION
## Description
This PR is fixing lsf job submission failure due to Pathlib.Path passed as argument into AEDT native api instead of string causing failure.

closing #6319 

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
