### PR TITLE
FIX: Dotnet use runtime spec

### DIFF
--- a/doc/changelog.d/6324.fixed.md
+++ b/doc/changelog.d/6324.fixed.md
@@ -1,0 +1,1 @@
+Dotnet use runtime spec

--- a/src/ansys/aedt/core/internal/clr_module.py
+++ b/src/ansys/aedt/core/internal/clr_module.py
@@ -53,6 +53,7 @@ if is_linux and cpython:
 
     dotnet_root = None
     runtime_config = None
+    runtime_spec = None
     # Use system .NET core runtime or fall back to dotnetcore2
     if os.environ.get("DOTNET_ROOT") is None:
         try:
@@ -91,11 +92,16 @@ if is_linux and cpython:
                     "Please ensure that .NET SDK is correctly installed or "
                     "that DOTNET_ROOT is correctly set."
                 )
-            runtime_config = candidates[0]
+            runtime_spec = candidates[0]
     # Use specific .NET core runtime
-    if dotnet_root is not None and runtime_config is not None:
+    if dotnet_root is not None and (runtime_config is not None or runtime_spec is not None):
         try:
-            load("coreclr", runtime_config=str(runtime_config), dotnet_root=str(dotnet_root))
+            load(
+                "coreclr",
+                runtime_config=str(runtime_config) if runtime_config else None,
+                runtime_spec=runtime_spec,
+                dotnet_root=str(dotnet_root),
+            )
             os.environ["DOTNET_ROOT"] = dotnet_root.as_posix()
             if "mono" not in os.getenv("LD_LIBRARY_PATH", ""):
                 warnings.warn("LD_LIBRARY_PATH needs to be setup to use pyaedt.")


### PR DESCRIPTION
## Description
Follow up of https://github.com/ansys/pyedb/pull/1307
It seems that the loading of dotnet was not correctly handled when leveraging the DOTNET_ROOT env variable.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
