### PR TITLE
REFACTOR: Use enum instead of custom class

### DIFF
--- a/doc/source/API/Constants.rst
+++ b/doc/source/API/Constants.rst
@@ -9,10 +9,10 @@ Example of constants usage:
 
     from ansys.aedt.core import constants
     ipk = Icepak()
-    # Use of AXIS Constant
-    cylinder = ipk.modeler.create_cylinder(constants.AXIS.X, [0,0,0],10,3)
+    # Use of Axis constant
+    cylinder = ipk.modeler.create_cylinder(constants.Axis.X, [0,0,0],10,3)
     # Use of PLANE Constant
-    ipk.modeler.split(cylinder, constants.PLANE.YZ, sides="Both")
+    ipk.modeler.split(cylinder, constants.Plane.YZ, sides="Both")
     ...
     ipk.release_desktop()
 

--- a/src/ansys/aedt/core/application/analysis.py
+++ b/src/ansys/aedt/core/application/analysis.py
@@ -42,12 +42,12 @@ import warnings
 from ansys.aedt.core.application.design import Design
 from ansys.aedt.core.application.job_manager import update_hpc_option
 from ansys.aedt.core.application.variables import Variable
-from ansys.aedt.core.generic.constants import AXIS
-from ansys.aedt.core.generic.constants import GRAVITY
-from ansys.aedt.core.generic.constants import PLANE
-from ansys.aedt.core.generic.constants import SETUPS
 from ansys.aedt.core.generic.constants import SOLUTIONS
-from ansys.aedt.core.generic.constants import VIEW
+from ansys.aedt.core.generic.constants import Axis
+from ansys.aedt.core.generic.constants import Gravity
+from ansys.aedt.core.generic.constants import Plane
+from ansys.aedt.core.generic.constants import Setups
+from ansys.aedt.core.generic.constants import View
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.file_utils import open_file
 from ansys.aedt.core.generic.general_methods import deprecate_argument
@@ -168,12 +168,6 @@ class Analysis(Design, object):
         self._parametrics = []
         self._optimizations = []
         self._native_components = []
-        self.SOLUTIONS = SOLUTIONS()
-        self.SETUPS = SETUPS()
-        self.AXIS = AXIS()
-        self.PLANE = PLANE()
-        self.VIEW = VIEW()
-        self.GRAVITY = GRAVITY()
 
         if not settings.lazy_load:
             self._materials = self.materials
@@ -181,6 +175,72 @@ class Analysis(Design, object):
             self._parametrics = self.parametrics
             self._optimizations = self.optimizations
             self._available_variations = self.available_variations
+
+    # TODO: Remove for release 1.0.0
+    @property
+    def SOLUTIONS(self):
+        """Deprecated: Use ``ansys.aedt.core.generic.constants.Solutions`` instead."""
+        warnings.warn(
+            "Usage of SOLUTIONS is deprecated. Use the solution types dedicated to your application and defined in ansys.aedt.core.generic.constants.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return SOLUTIONS
+
+    # TODO: Remove for release 1.0.0
+    @property
+    def SETUPS(self):
+        """Deprecated: Use ``ansys.aedt.core.generic.constants.Setups`` instead."""
+        warnings.warn(
+            "Usage of SETUPS is deprecated. Use ansys.aedt.core.generic.constants.Setups instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Setups
+
+    # TODO: Remove for release 1.0.0
+    @property
+    def AXIS(self):
+        """Deprecated: Use ``ansys.aedt.core.generic.constants.Axis`` instead."""
+        warnings.warn(
+            "Usage of AXIS is deprecated. Use ansys.aedt.core.generic.constants.Axis instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Axis
+
+    # TODO: Remove for release 1.0.0
+    @property
+    def PLANE(self):
+        """Deprecated: Use ``ansys.aedt.core.generic.constants.Plane`` instead."""
+        warnings.warn(
+            "Usage of PLANE is deprecated. Use ansys.aedt.core.generic.constants.Plane instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Plane
+
+    # TODO: Remove for release 1.0.0
+    @property
+    def VIEW(self):
+        """Deprecated: Use ``ansys.aedt.core.generic.constants.View`` instead."""
+        warnings.warn(
+            "Usage of VIEW is deprecated. Use ansys.aedt.core.generic.constants.View instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return View
+
+    # TODO: Remove for release 1.0.0
+    @property
+    def GRAVITY(self):
+        """Deprecated: Use ``ansys.aedt.core.generic.constants.Gravity`` instead."""
+        warnings.warn(
+            "Usage of GRAVITY is deprecated. Use ansys.aedt.core.generic.constants.Gravity instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Gravity
 
     @property
     def design_setups(self):
@@ -528,10 +588,10 @@ class Analysis(Design, object):
 
         Returns
         -------
-        SETUPS
-            List of all simulation setup types categorized by application.
+        Enum
+            All simulation setup types categorized by application.
         """
-        return SETUPS()
+        return Setups()
 
     @property
     def SolutionTypes(self):
@@ -539,10 +599,10 @@ class Analysis(Design, object):
 
         Returns
         -------
-        SOLUTIONS
-            List of all solution type categorized by application.
+        Enum
+            All solution type categorized by application.
         """
-        return SOLUTIONS()
+        return self.SOLUTIONS
 
     @property
     def excitations(self):
@@ -1153,7 +1213,7 @@ class Analysis(Design, object):
     @property
     def axis_directions(self):
         """Contains constants for the axis directions."""
-        return self.GRAVITY
+        return Gravity
 
     @pyaedt_function_handler()
     def get_setups(self):

--- a/src/ansys/aedt/core/application/analysis_nexxim.py
+++ b/src/ansys/aedt/core/application/analysis_nexxim.py
@@ -429,8 +429,9 @@ class FieldAnalysisCircuit(Analysis):
         --------
 
         >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
         >>> app = Circuit()
-        >>> app.create_setup(name="Setup1", setup_type=app.SETUPS.NexximLNA, Data="LINC 0GHz 4GHz 501")
+        >>> app.create_setup(name="Setup1", setup_type=Setups.NexximLNA, Data="LINC 0GHz 4GHz 501")
         """
         if setup_type is None:
             setup_type = self.design_solutions.default_setup

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -34,6 +34,7 @@ import time
 from ansys.aedt.core.application.analysis_hf import ScatteringMethods
 from ansys.aedt.core.application.analysis_nexxim import FieldAnalysisCircuit
 from ansys.aedt.core.generic import ibis_reader
+from ansys.aedt.core.generic.constants import Setups
 from ansys.aedt.core.generic.constants import unit_converter
 from ansys.aedt.core.generic.data_handlers import from_rkm_to_aedt
 from ansys.aedt.core.generic.file_utils import generate_unique_name
@@ -1772,7 +1773,7 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods):
             else:
                 tdr_probe_names.append(f"O(A{new_tdr_comp.id}:zl)")
 
-        setup = self.create_setup(name="Transient_TDR", setup_type=self.SETUPS.NexximTransient)
+        setup = self.create_setup(name="Transient_TDR", setup_type=Setups.NexximTransient)
         setup.props["TransientData"] = [f"{rise_time / 4}ns", f"{rise_time * 1000}ns"]
         if use_convolution:
             self.oanalysis.AddAnalysisOptions(

--- a/src/ansys/aedt/core/generic/constants.py
+++ b/src/ansys/aedt/core/generic/constants.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 from __future__ import absolute_import
 
+from enum import Enum
 from enum import IntEnum
 from enum import auto
 from enum import unique
@@ -113,7 +114,6 @@ def cel2kel(val, inverse=True):
         Temperature value converted to Kelvin.
 
     """
-
     if inverse:
         return val - 273.15
     else:
@@ -135,7 +135,6 @@ def unit_system(units):
     ``False`` when the units specified are not defined in AEDT units.
 
     """
-
     for unit_type, unit_dict in AEDT_UNITS.items():
         if units.lower() in [i.lower() for i in unit_dict.keys()]:
             return unit_type
@@ -582,447 +581,6 @@ UNIT_SYSTEM_OPERATIONS = {
     "Length_divide_Speed": "Time",
 }
 
-
-class INFINITE_SPHERE_TYPE(object):
-    """INFINITE_SPHERE_TYPE Enumerator class."""
-
-    (ThetaPhi, AzOverEl, ElOverAz) = ("Theta-Phi", "Az Over El", "El Over Az")
-
-
-class FILLET(object):
-    """FilletType Enumerator class."""
-
-    (Round, Mitered) = range(0, 2)
-
-
-class AXIS(object):
-    """CoordinateSystemAxis Enumerator class.
-
-    This static class defines integer constants corresponding to the
-    Cartesian axes: X, Y, and Z. Attributes can be
-    assigned to the `orientation` keyword argument for
-    geometry creation methods of
-    the :class:`ansys.aedt.core.modeler.modeler_3d.Modeler3D` and
-    :class:`ansys.aedt.core.modeler.modeler_2d.Modeler2D` classes.
-
-    Attributes
-    ----------
-    X : int
-        Axis index corresponding to the X axis (typically 0).
-    Y : int
-        Axis index corresponding to the Y axis (typically 1).
-    Z : int
-        Axis index corresponding to the Z axis (typically 2).
-
-    Examples
-    --------
-    >>> from ansys.aedt.core.generic import constants
-    >>> from ansys.aedt.core import Hfss
-    >>> hfss = Hfss()
-    >>> cylinder1 = hfss.modeler.create_cylinder(
-    ...     orientation=constants.AXIS.Z,
-    ...     origin=[0, 0, 0],
-    ...     radius="0.5mm",
-    ...     height="3cm",
-    ... )
-
-    """
-
-    (X, Y, Z) = range(0, 3)
-
-
-class PLANE(object):
-    """CoordinateSystemPlane Enumerator class.
-
-    This static class defines integer constants corresponding to the
-    Y-Z, Z-X, and X-Y planes of the current coordinate system.
-
-    Attributes
-    ----------
-    YZ : int
-        Y-Z plane (typically 0).
-    ZX : int
-        Z-X plane (typically 1).
-    XY : int
-        X-Y plane (typically 2).
-
-    """
-
-    (YZ, ZX, XY) = range(0, 3)
-
-
-class GRAVITY(object):
-    """GravityDirection Enumerator class.
-
-    This static class defines integer constants corresponding to the
-    positive direction of gravity force.
-
-    Attributes
-    ----------
-    XNeg : int
-        Positive gravity force is in the -X direction.
-    YNeg : int
-        Positive gravity force is in the -Y direction.
-    ZNeg : int
-        Positive gravity force is in the -Z direction.
-    XPos : int
-        Positive gravity force is in the +X direction.
-    YPos : int
-        Positive gravity force is in the +Y direction.
-    ZPos : int
-        Positive gravity force is in the +Z direction.
-
-    """
-
-    (XNeg, YNeg, ZNeg, XPos, YPos, ZPos) = range(0, 6)
-
-
-class VIEW(object):
-    """View Enumerator class.
-
-    This static class defines integer constants corresponding to the
-    Y-Z, Z-X, and X-Y planes of the current coordinate system.
-
-    Attributes
-    ----------
-    XY : int
-        Set the view along the Z-Axis (view of the XY plane).
-    YZ : int
-        Set the view along the X-Axis (view of the YZ plane).
-    ZX : int
-        Set the view along the Y-Axis (view of the ZX plane).
-    ISO : int
-        Isometric view from the (x=1, y=1, z=1) direction.
-    """
-
-    (XY, YZ, ZX, ISO) = ("XY", "YZ", "ZX", "iso")
-
-
-class GLOBALCS(object):
-    """GlobalCS Enumerator class."""
-
-    (XY, YZ, ZX) = ("Global:XY", "Global:YZ", "Global:XZ")
-
-
-class MATRIXOPERATIONSQ3D(object):
-    """Matrix Reduction types."""
-
-    (JoinSeries, JoinParallel, FloatNet, GroundNet, FloatTerminal, FloatInfinity, ReturnPath, AddSink, MoveSink) = (
-        "JoinSeries",
-        "JoinParallel",
-        "FloatNet",
-        "GroundNet",
-        "FloatTerminal",
-        "FloatInfinity",
-        "ReturnPath",
-        "AddSink",
-        "MoveSink",
-    )
-
-
-class MATRIXOPERATIONSQ2D(object):
-    """Matrix Reduction types."""
-
-    (AddGround, SetReferenceGround, Float, Parallel, DiffPair) = (
-        "AddGround",
-        "SetReferenceGround",
-        "Float",
-        "Parallel",
-        "DiffPair",
-    )
-
-
-class CATEGORIESQ3D(object):
-    """Plot Categories for Q2d and Q3d."""
-
-    class Q2D(object):
-        (
-            CMatrix,
-            GMatrix,
-            RMatrix,
-            LMatrix,
-            LumpedC,
-            LumpedG,
-            LumpedR,
-            LumpedL,
-            CharacteristicImpedance,
-            CrossTalkForward,
-            LumpedCrossTalkForward,
-            CrossTalkBackward,
-        ) = ("C", "G", "R", "L", "lumpC", "lumpG", "lumpR", "lumpL", "Z0", "Kf", "lumpKf", "Kb")
-
-    class Q3D(object):
-        (C, G, DCL, DCR, ACL, ACR) = ("C", "G", "DCL", "DCR", "ACL", "ACR")
-
-
-class CSMODE(object):
-    """COORDINATE SYSTEM MODE Enumerator class."""
-
-    (View, Axis, ZXZ, ZYZ, AXISROTATION) = ("view", "axis", "zxz", "zyz", "axisrotation")
-
-
-class SEGMENTTYPE(object):
-    """CROSSSECTION Enumerator class."""
-
-    (Line, Arc, Spline, AngularArc) = range(0, 4)
-
-
-class CROSSSECTION(object):
-    """CROSSSECTION Enumerator class."""
-
-    (NONE, Line, Circle, Rectangle, Trapezoid) = range(0, 5)
-
-
-class SWEEPDRAFT(object):
-    """SweepDraftType Enumerator class."""
-
-    (Extended, Round, Natural, Mixed) = range(0, 4)
-
-
-class FlipChipOrientation(object):
-    """Chip orientation enumerator class."""
-
-    (Up, Down) = range(0, 2)
-
-
-class SolverType(object):
-    """Provides solver type classes."""
-
-    (Hfss, Siwave, Q3D, Maxwell, Nexxim, TwinBuilder, Hfss3dLayout, SiwaveSYZ, SiwaveDC) = range(0, 9)
-
-
-class CutoutSubdesignType(object):
-    (BoundingBox, Conformal, ConvexHull, Invalid) = range(0, 4)
-
-
-class RadiationBoxType(object):
-    (BoundingBox, Conformal, ConvexHull, Polygon, Invalid) = range(0, 5)
-
-
-class SweepType(object):
-    (Linear, LogCount, Invalid) = range(0, 3)
-
-
-class BasisOrder(object):
-    """Enumeration-class for HFSS basis order settings.
-
-    Warning: the value ``single`` has been renamed to ``Single`` for consistency. Please update references to
-    ``single``.
-    """
-
-    (Mixed, Zero, Single, Double, Invalid) = (-1, 0, 1, 2, 3)
-
-
-class NodeType(object):
-    """Type of node for source creation."""
-
-    (Positive, Negative, Floating) = range(0, 3)
-
-
-class SourceType(object):
-    """Type of excitation enumerator."""
-
-    (CoaxPort, CircPort, LumpedPort, Vsource, Isource, Rlc, DcTerminal) = range(0, 7)
-
-
-class SOLUTIONS(object):
-    """Provides the names of default solution types."""
-
-    class Hfss(object):
-        """Provides HFSS solution types."""
-
-        (DrivenModal, DrivenTerminal, EigenMode, Transient, SBR, Characteristic) = (
-            "Modal",
-            "Terminal",
-            "Eigenmode",
-            "Transient Network",
-            "SBR+",
-            "Characteristic",
-        )
-
-    class Maxwell3d(object):
-        """Provides Maxwell 3D solution types."""
-
-        (
-            Transient,
-            Magnetostatic,
-            EddyCurrent,
-            ElectroStatic,
-            DCConduction,
-            ElectroDCConduction,
-            ACConduction,
-            ElectricTransient,
-            TransientAPhiFormulation,
-            DCBiasedEddyCurrent,
-            ACMagnetic,
-            TransientAPhi,
-            ElectricDCConduction,
-        ) = (
-            "Transient",
-            "Magnetostatic",
-            "EddyCurrent",
-            "Electrostatic",
-            "DCConduction",
-            "ElectroDCConduction",
-            "ACConduction",
-            "ElectricTransient",
-            "TransientAPhiFormulation",
-            "DCBiasedEddyCurrent",
-            "AC Magnetic",
-            "Transient APhi",
-            "Electric DC Conduction",
-        )
-
-    class Maxwell2d(object):
-        """Provides Maxwell 2D solution types."""
-
-        (
-            TransientXY,
-            TransientZ,
-            MagnetostaticXY,
-            MagnetostaticZ,
-            EddyCurrentXY,
-            EddyCurrentZ,
-            ElectroStaticXY,
-            ElectroStaticZ,
-            DCConductionXY,
-            DCConductionZ,
-            ACConductionXY,
-            ACConductionZ,
-        ) = (
-            "TransientXY",
-            "TransientZ",
-            "MagnetostaticXY",
-            "MagnetostaticZ",
-            "EddyCurrentXY",
-            "EddyCurrentZ",
-            "ElectrostaticXY",
-            "ElectrostaticZ",
-            "DCConductionXY",
-            "DCConductionZ",
-            "ACConductionXY",
-            "ACConductionZ",
-        )
-
-    class Icepak(object):
-        """Provides Icepak solution types."""
-
-        (
-            SteadyState,
-            Transient,
-        ) = (
-            "SteadyState",
-            "Transient",
-        )
-
-    class Circuit(object):
-        """Provides Circuit solution types."""
-
-        (
-            NexximLNA,
-            NexximDC,
-            NexximTransient,
-            NexximQuickEye,
-            NexximVerifEye,
-            NexximAMI,
-            NexximOscillatorRSF,
-            NexximOscillator1T,
-            NexximOscillatorNT,
-            NexximHarmonicBalance1T,
-            NexximHarmonicBalanceNT,
-            NexximSystem,
-            NexximTVNoise,
-            HSPICE,
-            TR,
-        ) = (
-            "NexximLNA",
-            "NexximDC",
-            "NexximTransient",
-            "NexximQuickEye",
-            "NexximVerifEye",
-            "NexximAMI",
-            "NexximOscillatorRSF",
-            "NexximOscillator1T",
-            "NexximOscillatorNT",
-            "NexximHarmonicBalance1T",
-            "NexximHarmonicBalanceNT",
-            "NexximSystem",
-            "NexximTVNoise",
-            "HSPICE",
-            "TR",
-        )
-
-    class Mechanical(object):
-        """Provides Mechanical solution types."""
-
-        (Thermal, Structural, Modal, SteadyStateThermal, TransientThermal) = (
-            "Thermal",
-            "Structural",
-            "Modal",
-            "Steady-State Thermal",
-            "Transient Thermal",
-        )
-
-
-class SETUPS(object):
-    """Provides constants for the default setup types."""
-
-    (
-        HFSSDrivenAuto,
-        HFSSDrivenDefault,
-        HFSSEigen,
-        HFSSTransient,
-        HFSSSBR,
-        MaxwellTransient,
-        Magnetostatic,
-        EddyCurrent,
-        Electrostatic,
-        ElectrostaticDC,
-        ElectricTransient,
-        SteadyState,
-        SteadyState,
-        SteadyState,
-        Matrix,
-        NexximLNA,
-        NexximDC,
-        NexximTransient,
-        NexximQuickEye,
-        NexximVerifEye,
-        NexximAMI,
-        NexximOscillatorRSF,
-        NexximOscillator1T,
-        NexximOscillatorNT,
-        NexximHarmonicBalance1T,
-        NexximHarmonicBalanceNT,
-        NexximSystem,
-        NexximTVNoise,
-        HSPICE,
-        HFSS3DLayout,
-        Open,
-        Close,
-        MechTerm,
-        MechModal,
-        GRM,
-        TR,
-        Transient,
-        Transient,
-        Transient,
-        DFIG,
-        TPIM,
-        SPIM,
-        TPSM,
-        BLDC,
-        ASSM,
-        PMDC,
-        SRM,
-        LSSM,
-        UNIM,
-        DCM,
-        CPSM,
-        NSSM,
-    ) = range(0, 52)
-
-
 CSS4_COLORS = {
     "chocolate": "#D2691E",
     "darkgreen": "#006400",
@@ -1131,8 +689,516 @@ CSS4_COLORS = {
 }
 
 
-class LineStyle(object):
-    """Provides trace line style constants."""
+def deprecate_enum(new_enum):
+    """Decorator to mark an enumeration class as deprecated.
+
+    It allows you to keep the old enumeration class in the code
+    and redirect its attributes to a new enumeration class.
+    """
+
+    def decorator(cls):
+        class Wrapper:
+            # NOTE: Required to handle correctly the documentation, name of the class and nested classes.
+            __doc__ = cls.__doc__
+            __name__ = cls.__name__
+            __qualname__ = cls.__qualname__
+
+            def __getattr__(self, name):
+                warnings.warn(
+                    f"{cls.__qualname__} is deprecated. Use {new_enum.__qualname__} instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return getattr(new_enum, name)
+
+            def __dir__(self):
+                return dir(new_enum)
+
+        return Wrapper()
+
+    return decorator
+
+
+@unique
+class InfiniteSphereType(str, Enum):
+    """Infinite sphere type enum class."""
+
+    ThetaPhi = "Theta-Phi"
+    AzOverEl = "Az Over El"
+    ElOverAz = "El Over Az"
+
+
+@unique
+class Fillet(IntEnum):
+    """Fillet enum class."""
+
+    (Round, Mitered) = range(2)
+
+
+@unique
+class Axis(IntEnum):
+    """Coordinate system axis enum class.
+
+    This static class defines integer constants corresponding to the
+    Cartesian axes: X, Y, and Z. Attributes can be
+    assigned to the `orientation` keyword argument for
+    geometry creation methods of
+    the :class:`ansys.aedt.core.modeler.modeler_3d.Modeler3D` and
+    :class:`ansys.aedt.core.modeler.modeler_2d.Modeler2D` classes.
+
+    Attributes
+    ----------
+    X : int
+        Axis index corresponding to the X axis (typically 0).
+    Y : int
+        Axis index corresponding to the Y axis (typically 1).
+    Z : int
+        Axis index corresponding to the Z axis (typically 2).
+
+    Examples
+    --------
+    >>> from ansys.aedt.core.generic import constants
+    >>> from ansys.aedt.core import Hfss
+    >>> hfss = Hfss()
+    >>> cylinder1 = hfss.modeler.create_cylinder(
+    ...     orientation=constants.Axis.Z,
+    ...     origin=[0, 0, 0],
+    ...     radius="0.5mm",
+    ...     height="3cm",
+    ... )
+
+    """
+
+    (X, Y, Z) = range(3)
+
+
+@unique
+class Plane(IntEnum):
+    """Coordinate system plane enum class.
+
+    This static class defines integer constants corresponding to the
+    Y-Z, Z-X, and X-Y planes of the current coordinate system.
+
+    Attributes
+    ----------
+    YZ : int
+        Y-Z plane (typically 0).
+    ZX : int
+        Z-X plane (typically 1).
+    XY : int
+        X-Y plane (typically 2).
+
+    """
+
+    (YZ, ZX, XY) = range(3)
+
+
+@unique
+class Gravity(IntEnum):
+    """Gravity direction enum class.
+
+    This static class defines integer constants corresponding to the
+    positive direction of gravity force.
+
+    Attributes
+    ----------
+    XNeg : int
+        Positive gravity force is in the -X direction.
+    YNeg : int
+        Positive gravity force is in the -Y direction.
+    ZNeg : int
+        Positive gravity force is in the -Z direction.
+    XPos : int
+        Positive gravity force is in the +X direction.
+    YPos : int
+        Positive gravity force is in the +Y direction.
+    ZPos : int
+        Positive gravity force is in the +Z direction.
+    """
+
+    (XNeg, YNeg, ZNeg, XPos, YPos, ZPos) = range(6)
+
+
+@unique
+class View(str, Enum):
+    """View enum class.
+
+    This static class defines integer constants corresponding to the
+    X-Y, Y-Z, and Z-X planes of the current coordinate system, and
+    ISO for isometric view.
+
+    Attributes
+    ----------
+    XY : int
+        Set the view along the Z-Axis (view of the XY plane).
+    YZ : int
+        Set the view along the X-Axis (view of the YZ plane).
+    ZX : int
+        Set the view along the Y-Axis (view of the ZX plane).
+    ISO : int
+        Isometric view from the (x=1, y=1, z=1) direction.
+    """
+
+    (XY, YZ, ZX, ISO) = ("XY", "YZ", "ZX", "iso")
+
+
+@unique
+class GlobalCS(str, Enum):
+    """Global coordinate system enum class."""
+
+    (XY, YZ, ZX) = ("Global:XY", "Global:YZ", "Global:XZ")
+
+
+@unique
+class MatrixOperationsQ3D(str, Enum):
+    """Matrix operations for Q3D."""
+
+    (JoinSeries, JoinParallel, FloatNet, GroundNet, FloatTerminal, FloatInfinity, ReturnPath, AddSink, MoveSink) = (
+        "JoinSeries",
+        "JoinParallel",
+        "FloatNet",
+        "GroundNet",
+        "FloatTerminal",
+        "FloatInfinity",
+        "ReturnPath",
+        "AddSink",
+        "MoveSink",
+    )
+
+
+@unique
+class MatrixOperationsQ2D(str, Enum):
+    """Matrix operations for Q2D."""
+
+    (AddGround, SetReferenceGround, Float, Parallel, DiffPair) = (
+        "AddGround",
+        "SetReferenceGround",
+        "Float",
+        "Parallel",
+        "DiffPair",
+    )
+
+
+@unique
+class PlotCategoriesQ3D(str, Enum):
+    """Plot categories for Q3D."""
+
+    (C, G, DCL, DCR, ACL, ACR) = ("C", "G", "DCL", "DCR", "ACL", "ACR")
+
+
+@unique
+class PlotCategoriesQ2D(str, Enum):
+    """Plot categories for Q2D."""
+
+    (
+        CMatrix,
+        GMatrix,
+        RMatrix,
+        LMatrix,
+        LumpedC,
+        LumpedG,
+        LumpedR,
+        LumpedL,
+        CharacteristicImpedance,
+        CrossTalkForward,
+        LumpedCrossTalkForward,
+        CrossTalkBackward,
+    ) = ("C", "G", "R", "L", "lumpC", "lumpG", "lumpR", "lumpL", "Z0", "Kf", "lumpKf", "Kb")
+
+
+@unique
+class CSMode(str, Enum):
+    """Coordinate system mode enum class."""
+
+    (View, Axis, ZXZ, ZYZ, AXISROTATION) = ("view", "axis", "zxz", "zyz", "axisrotation")
+
+
+@unique
+class SegmentType(IntEnum):
+    """Segment type enum class."""
+
+    (Line, Arc, Spline, AngularArc) = range(0, 4)
+
+
+@unique
+class CrossSection(IntEnum):
+    """Cross section enum class."""
+
+    (NONE, Line, Circle, Rectangle, Trapezoid) = range(0, 5)
+
+
+@unique
+class SweepDraft(IntEnum):
+    """Sweep draft type enum class."""
+
+    (Extended, Round, Natural, Mixed) = range(0, 4)
+
+
+@unique
+class FlipChipOrientation(IntEnum):
+    """Flip chip orientation enum class."""
+
+    (Up, Down) = range(0, 2)
+
+
+@unique
+class SolverType(IntEnum):
+    """Provides solver type classes."""
+
+    (Hfss, Siwave, Q3D, Maxwell, Nexxim, TwinBuilder, Hfss3dLayout, SiwaveSYZ, SiwaveDC) = range(0, 9)
+
+
+@unique
+class CutoutSubdesignType(IntEnum):
+    """Cutout subdesign type enum class."""
+
+    (BoundingBox, Conformal, ConvexHull, Invalid) = range(0, 4)
+
+
+@unique
+class RadiationBoxType(IntEnum):
+    """Radiation box type enum class."""
+
+    (BoundingBox, Conformal, ConvexHull, Polygon, Invalid) = range(0, 5)
+
+
+@unique
+class SweepType(IntEnum):
+    """Sweep type enum class."""
+
+    (Linear, LogCount, Invalid) = range(0, 3)
+
+
+@unique
+class BasisOrder(IntEnum):
+    """HFSS basis order settings enum class.
+
+    Warning: the value ``single`` has been renamed to ``Single`` for consistency. Please update references to
+    ``single``.
+    """
+
+    (Mixed, Zero, Single, Double, Invalid) = (-1, 0, 1, 2, 3)
+
+
+@unique
+class NodeType(IntEnum):
+    """Enum class on the type of node for source creation."""
+
+    (Positive, Negative, Floating) = range(0, 3)
+
+
+@unique
+class SourceType(IntEnum):
+    """Type of excitation enum class."""
+
+    (CoaxPort, CircPort, LumpedPort, Vsource, Isource, Rlc, DcTerminal) = range(0, 7)
+
+
+@unique
+class SolutionsHfss(str, Enum):
+    """HFSS solution types enum class."""
+
+    (DrivenModal, DrivenTerminal, EigenMode, Transient, SBR, Characteristic) = (
+        "Modal",
+        "Terminal",
+        "Eigenmode",
+        "Transient Network",
+        "SBR+",
+        "Characteristic",
+    )
+
+
+@unique
+class SolutionsMaxwell3D(str, Enum):
+    """Maxwell 3D solution types enum class."""
+
+    (
+        Transient,
+        Magnetostatic,
+        EddyCurrent,
+        ElectroStatic,
+        DCConduction,
+        ElectroDCConduction,
+        ACConduction,
+        ElectricTransient,
+        TransientAPhiFormulation,
+        DCBiasedEddyCurrent,
+        ACMagnetic,
+        TransientAPhi,
+        ElectricDCConduction,
+    ) = (
+        "Transient",
+        "Magnetostatic",
+        "EddyCurrent",
+        "Electrostatic",
+        "DCConduction",
+        "ElectroDCConduction",
+        "ACConduction",
+        "ElectricTransient",
+        "TransientAPhiFormulation",
+        "DCBiasedEddyCurrent",
+        "AC Magnetic",
+        "Transient APhi",
+        "Electric DC Conduction",
+    )
+
+
+@unique
+class SolutionsMaxwell2D(str, Enum):
+    """Maxwell 2D solution types enum class."""
+
+    (
+        TransientXY,
+        TransientZ,
+        MagnetostaticXY,
+        MagnetostaticZ,
+        EddyCurrentXY,
+        EddyCurrentZ,
+        ElectroStaticXY,
+        ElectroStaticZ,
+        DCConductionXY,
+        DCConductionZ,
+        ACConductionXY,
+        ACConductionZ,
+    ) = (
+        "TransientXY",
+        "TransientZ",
+        "MagnetostaticXY",
+        "MagnetostaticZ",
+        "EddyCurrentXY",
+        "EddyCurrentZ",
+        "ElectrostaticXY",
+        "ElectrostaticZ",
+        "DCConductionXY",
+        "DCConductionZ",
+        "ACConductionXY",
+        "ACConductionZ",
+    )
+
+
+@unique
+class SolutionsIcepak(str, Enum):
+    """Icepak solution types enum class."""
+
+    (SteadyState, Transient) = (
+        "SteadyState",
+        "Transient",
+    )
+
+
+@unique
+class SolutionsCircuit(str, Enum):
+    """Circuit solution types enum class."""
+
+    (
+        NexximLNA,
+        NexximDC,
+        NexximTransient,
+        NexximQuickEye,
+        NexximVerifEye,
+        NexximAMI,
+        NexximOscillatorRSF,
+        NexximOscillator1T,
+        NexximOscillatorNT,
+        NexximHarmonicBalance1T,
+        NexximHarmonicBalanceNT,
+        NexximSystem,
+        NexximTVNoise,
+        HSPICE,
+        TR,
+    ) = (
+        "NexximLNA",
+        "NexximDC",
+        "NexximTransient",
+        "NexximQuickEye",
+        "NexximVerifEye",
+        "NexximAMI",
+        "NexximOscillatorRSF",
+        "NexximOscillator1T",
+        "NexximOscillatorNT",
+        "NexximHarmonicBalance1T",
+        "NexximHarmonicBalanceNT",
+        "NexximSystem",
+        "NexximTVNoise",
+        "HSPICE",
+        "TR",
+    )
+
+
+@unique
+class SolutionsMechanical(str, Enum):
+    """Mechanical solution types enum class"""
+
+    (Thermal, Structural, Modal, SteadyStateThermal, TransientThermal) = (
+        "Thermal",
+        "Structural",
+        "Modal",
+        "Steady-State Thermal",
+        "Transient Thermal",
+    )
+
+
+@unique
+class Setups(IntEnum):
+    """Setup types enum class."""
+
+    HFSSDrivenAuto = 0
+    HFSSDrivenDefault = 1
+    HFSSEigen = 2
+    HFSSTransient = 3
+    HFSSSBR = 4
+    MaxwellTransient = 5
+    Magnetostatic = 6
+    EddyCurrent = 7
+    Electrostatic = 8
+    ElectrostaticDC = 9
+    ElectricTransient = 10
+    SteadyState = 11
+    # SteadyState = 10
+    # SteadyState = 10
+    Matrix = 14
+    NexximLNA = 15
+    NexximDC = 16
+    NexximTransient = 17
+    NexximQuickEye = 18
+    NexximVerifEye = 19
+    NexximAMI = 20
+    NexximOscillatorRSF = 21
+    NexximOscillator1T = 22
+    NexximOscillatorNT = 23
+    NexximHarmonicBalance1T = 24
+    NexximHarmonicBalanceNT = 25
+    NexximSystem = 26
+    NexximTVNoise = 27
+    HSPICE = 28
+    HFSS3DLayout = 29
+    Open = 30
+    Close = 31
+    MechTerm = 32
+    MechModal = 33
+    GRM = 34
+    TR = 35
+    Transient = 36
+    # Transient,
+    # Transient,
+    DFIG = 39
+    TPIM = 40
+    SPIM = 41
+    TPSM = 42
+    BLDC = 43
+    ASSM = 44
+    PMDC = 45
+    SRM = 46
+    LSSM = 47
+    UNIM = 48
+    DCM = 49
+    CPSM = 50
+    NSSM = 51
+
+
+@unique
+class LineStyle(str, Enum):
+    """Line style enum class."""
 
     (Solid, Dot, ShortDash, DotShortDash, Dash, DotDash, DotDot, DotDotDash, LongDash) = (
         "Solid",
@@ -1147,8 +1213,9 @@ class LineStyle(object):
     )
 
 
-class TraceType(object):
-    """Provides trace type constants."""
+@unique
+class TraceType(str, Enum):
+    """Trace type enum class."""
 
     (Continuous, Discrete, StickZero, StickInfinity, BarZero, BarInfinity, Histogram, Step, Stair, Digital) = (
         "Continuous",
@@ -1164,8 +1231,9 @@ class TraceType(object):
     )
 
 
-class SymbolStyle(object):
-    """Provides symbol style constants."""
+@unique
+class SymbolStyle(str, Enum):
+    """Symbol style enum class."""
 
     (
         Box,
@@ -2332,3 +2400,118 @@ class AllowedMarkers(IntEnum):
     Sphere = 9
     Box = 10
     Arrow = 0
+
+
+# ########################## Deprecated enumeration classes #############################
+
+# TODO: Remove these classes in v1.0.0.
+
+
+@deprecate_enum(InfiniteSphereType)
+class INFINITE_SPHERE_TYPE:
+    """Deprecated: Use `InfiniteSphereType` instead."""
+
+
+@deprecate_enum(Fillet)
+class FILLET:
+    """Deprecated: Use `Fillet` instead."""
+
+
+@deprecate_enum(Axis)
+class AXIS:
+    """Deprecated: Use `Axis` instead."""
+
+
+@deprecate_enum(Plane)
+class PLANE:
+    """Deprecated: Use `Plane` instead."""
+
+
+@deprecate_enum(Gravity)
+class GRAVITY:
+    """Deprecated: Use `Gravity` instead."""
+
+
+@deprecate_enum(View)
+class VIEW:
+    """Deprecated: Use `View` instead."""
+
+
+@deprecate_enum(GlobalCS)
+class GLOBALCS:
+    """Deprecated: Use `GlobalCS` instead."""
+
+
+@deprecate_enum(MatrixOperationsQ3D)
+class MATRIXOPERATIONSQ3D:
+    """Deprecated: Use `MatricOperationsQ3D` instead."""
+
+
+@deprecate_enum(MatrixOperationsQ2D)
+class MATRIXOPERATIONSQ2D:
+    """Deprecated: Use `MatricOperationsQ2D` instead."""
+
+
+class CATEGORIESQ3D:
+    """Deprecated: Use `PlotCategoriesQ3D` or `PlotCategoriesQ2D` instead."""
+
+    @deprecate_enum(PlotCategoriesQ2D)
+    class Q2D:
+        """Deprecated: Use `PlotCategoriesQ2D` instead."""
+
+    @deprecate_enum(PlotCategoriesQ3D)
+    class Q3D:
+        """Deprecated: Use `PlotCategoriesQ3D` instead."""
+
+
+@deprecate_enum(CSMode)
+class CSMODE:
+    """Deprecated: Use `CSMode` instead."""
+
+
+@deprecate_enum(SegmentType)
+class SEGMENTTYPE:
+    """Deprecated: Use `SegmentType` instead."""
+
+
+@deprecate_enum(CrossSection)
+class CROSSSECTION:
+    """Deprecated: Use `CrossSection` instead."""
+
+
+@deprecate_enum(SweepDraft)
+class SWEEPDRAFT:
+    """Deprecated: Use `SweepDraft` instead."""
+
+
+class SOLUTIONS:
+    """Deprecated"""
+
+    @deprecate_enum(SolutionsHfss)
+    class Hfss:
+        """Deprecated: Use `SolutionsHfss` instead."""
+
+    @deprecate_enum(SolutionsMaxwell3D)
+    class Maxwell3d:
+        """Deprecated: Use `SolutionsMaxwell3d` instead."""
+
+    @deprecate_enum(SolutionsMaxwell2D)
+    class Maxwell2d:
+        """Deprecated: Use `SolutionsMaxwell2d` instead."""
+
+    @deprecate_enum(SolutionsIcepak)
+    class Icepak:
+        """Deprecated: Use `SolutionsIcepak` instead."""
+
+    @deprecate_enum(SolutionsCircuit)
+    class Circuit:
+        """Deprecated: Use `SolutionsCircuit` instead."""
+
+    @deprecate_enum(SolutionsMechanical)
+    class Mechanical:
+        """Deprecated: Use `SolutionsMechanical` instead."""
+
+
+@deprecate_enum(Setups)
+class SETUPS:
+    """Deprecated: Use `Setups` instead."""

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -33,8 +33,8 @@ import warnings
 
 from ansys.aedt.core.application.analysis_3d import FieldAnalysis3D
 from ansys.aedt.core.application.analysis_hf import ScatteringMethods
-from ansys.aedt.core.generic.constants import INFINITE_SPHERE_TYPE
-from ansys.aedt.core.generic.constants import SOLUTIONS
+from ansys.aedt.core.generic.constants import InfiniteSphereType
+from ansys.aedt.core.generic.constants import SolutionsHfss
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.data_handlers import str_to_bool
 from ansys.aedt.core.generic.data_handlers import variation_string_to_dict
@@ -720,10 +720,11 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         outer face.
 
         >>> from ansys.aedt.core import Hfss
+        >>> from ansys.aedt.core.generic.constants import Plane
         >>> hfss = Hfss()
         >>> origin = hfss.modeler.Position(0, 0, 0)
-        >>> inner = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 3, 200, 0, "inner")
-        >>> outer = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 4, 200, 0, "outer")
+        >>> inner = hfss.modeler.create_cylinder(Plane.XY, origin, 3, 200, 0, "inner")
+        >>> outer = hfss.modeler.create_cylinder(Plane.XY, origin, 4, 200, 0, "outer")
         >>> coat = hfss.assign_finite_conductivity(
         ...     ["inner", outer.faces[2].id], "copper", use_thickness=True, thickness="0.2mm"
         ... )
@@ -828,10 +829,11 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         outer face.
 
         >>> from ansys.aedt.core import Hfss
+        >>> from ansys.aedt.core.generic.constants import Plane
         >>> hfss = Hfss()
         >>> origin = hfss.modeler.Position(0, 0, 0)
-        >>> inner = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 3, 200, 0, "inner")
-        >>> outer = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 4, 200, 0, "outer")
+        >>> inner = hfss.modeler.create_cylinder(Plane.XY, origin, 3, 200, 0, "inner")
+        >>> outer = hfss.modeler.create_cylinder(Plane.XY, origin, 4, 200, 0, "outer")
         >>> coat = hfss.assign_finite_conductivity(
         ...     ["inner", outer.faces[2].id], "copper", use_thickness=True, thickness="0.2mm"
         ... )
@@ -938,9 +940,10 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         --------
 
         >>> from ansys.aedt.core import Hfss
+        >>> from ansys.aedt.core.generic.constants import Plane
         >>> hfss = Hfss()
         >>> origin = hfss.modeler.Position(0, 0, 0)
-        >>> inner = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 3, 200, 0, "inner")
+        >>> inner = hfss.modeler.create_cylinder(Plane.XY, origin, 3, 200, 0, "inner")
         >>> coat = hfss.assign_perfect_e(["inner", outer.faces[2].id])
         """
 
@@ -1010,9 +1013,10 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         --------
 
         >>> from ansys.aedt.core import Hfss
+        >>> from ansys.aedt.core.generic.constants import Plane
         >>> hfss = Hfss()
         >>> origin = hfss.modeler.Position(0, 0, 0)
-        >>> inner = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 3, 200, 0, "inner")
+        >>> inner = hfss.modeler.create_cylinder(Plane.XY, origin, 3, 200, 0, "inner")
         >>> coat = hfss.assign_perfect_h(["inner", outer.faces[2].id])
         """
 
@@ -1100,10 +1104,11 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         outer face.
 
         >>> from ansys.aedt.core import Hfss
+        >>> from ansys.aedt.core.generic.constants import Plane
         >>> hfss = Hfss()
         >>> origin = hfss.modeler.Position(0, 0, 0)
-        >>> inner = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 3, 200, 0, "inner")
-        >>> outer = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 4, 200, 0, "outer")
+        >>> inner = hfss.modeler.create_cylinder(Plane.XY, origin, 3, 200, 0, "inner")
+        >>> outer = hfss.modeler.create_cylinder(Plane.XY, origin, 4, 200, 0, "outer")
         >>> coat = hfss.assign_finite_conductivity(
         ...     ["inner", outer.faces[2].id], "copper", use_thickness=True, thickness="0.2mm"
         ... )
@@ -1234,9 +1239,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         if not self.modeler.does_object_exists(assignment) or not self.modeler.does_object_exists(reference):
             raise ValueError("One or both objects do not exist. Check and retry.")
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -1305,9 +1310,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         if not self.modeler.does_object_exists(assignment) or not self.modeler.does_object_exists(reference):
             raise ValueError("One or both objects do not exist. Check and retry.")
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -1346,9 +1351,10 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         --------
 
         Create a sheet and use it to create a Perfect E.
-
+        >>> from ansys.aedt.core.generic.constants import Plane
+        >>>
         >>> sheet = hfss.modeler.create_rectangle(
-        ...     hfss.PLANE.XY, [0, 0, -90], [10, 2], name="PerfectESheet", material="Copper"
+        ...     Plane.XY, [0, 0, -90], [10, 2], name="PerfectESheet", material="Copper"
         ... )
         >>> perfect_e_from_sheet = hfss.assign_perfecte_to_sheets(sheet.name, "PerfectEFromSheet")
         >>> type(perfect_e_from_sheet)
@@ -1356,11 +1362,11 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
 
         """
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
-            SOLUTIONS.Hfss.SBR,
-            SOLUTIONS.Hfss.EigenMode,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
+            SolutionsHfss.SBR,
+            SolutionsHfss.EigenMode,
         ):  # pragma: no cover
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -1396,8 +1402,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
 
         Create a sheet and use it to create a Perfect H.
 
+        >>> from ansys.aedt.core.generic.constants import Plane
         >>> sheet = hfss.modeler.create_rectangle(
-        ...     hfss.PLANE.XY, [0, 0, -90], [10, 2], name="PerfectHSheet", material="Copper"
+        ...     Plane.XY, [0, 0, -90], [10, 2], name="PerfectHSheet", material="Copper"
         ... )
         >>> perfect_h_from_sheet = hfss.assign_perfecth_to_sheets(sheet.name, "PerfectHFromSheet")
         >>> type(perfect_h_from_sheet)
@@ -1405,11 +1412,11 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
 
         """
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
-            SOLUTIONS.Hfss.SBR,
-            SOLUTIONS.Hfss.EigenMode,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
+            SolutionsHfss.SBR,
+            SolutionsHfss.EigenMode,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -1489,9 +1496,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         if not self.modeler.does_object_exists(start_assignment) or not self.modeler.does_object_exists(end_assignment):
             raise AEDTRuntimeError("One or both objects do not exist. Check and retry.")
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -3159,9 +3166,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
             raise AEDTRuntimeError("One or both objects doesn't exists. Check and retry")
 
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -3220,9 +3227,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
             raise ValueError("One or both objects do not exist. Check and retry.")
 
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -3807,9 +3814,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         if not self.modeler.does_object_exists(assignment) or not self.modeler.does_object_exists(reference):
             raise AEDTRuntimeError("One or both objects do not exist. Check and retry.")
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
         if not (resistance or inductance or capacitance):
@@ -3912,8 +3919,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         --------
         Create a sheet and assign to it some voltage.
 
+        >>> from ansys.aedt.core.generic.constants import Plane
         >>> sheet = hfss.modeler.create_rectangle(
-        ...     hfss.PLANE.XY, [0, 0, -70], [10, 2], name="VoltageSheet", material="copper"
+        ...     Plane.XY, [0, 0, -70], [10, 2], name="VoltageSheet", material="copper"
         ... )
         >>> v1 = hfss.assign_voltage_source_to_sheet(sheet.name, hfss.AxisDir.XNeg, "VoltageSheetExample")
         >>> v2 = hfss.assign_voltage_source_to_sheet(
@@ -3922,9 +3930,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
 
         """
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -3968,9 +3976,8 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
 
         Create a sheet and assign some current to it.
 
-        >>> sheet = hfss.modeler.create_rectangle(
-        ...     hfss.PLANE.XY, [0, 0, -50], [5, 1], name="CurrentSheet", material="copper"
-        ... )
+        >>> from ansys.aedt.core.generic.constants import Plane
+        >>> sheet = hfss.modeler.create_rectangle(Plane.XY, [0, 0, -50], [5, 1], name="CurrentSheet", material="copper")
         >>> hfss.assign_current_source_to_sheet(sheet.name, hfss.AxisDir.XNeg, "CurrentSheetExample")
         'CurrentSheetExample'
         >>> c1 = hfss.assign_current_source_to_sheet(
@@ -3980,9 +3987,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         """
 
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -4054,9 +4061,8 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
 
         Create a sheet and use it to create a lumped RLC.
 
-        >>> sheet = hfss.modeler.create_rectangle(
-        ...     hfss.PLANE.XY, [0, 0, -90], [10, 2], name="RLCSheet", material="Copper"
-        ... )
+        >>> from ansys.aedt.core.generic.constants import Plane
+        >>> sheet = hfss.modeler.create_rectangle(Plane.XY, [0, 0, -90], [10, 2], name="RLCSheet", material="Copper")
         >>> lumped_rlc_to_sheet = hfss.assign_lumped_rlc_to_sheet(
         ...     sheet.name, hfss.AxisDir.XPos, resistance=50, inductance=1e-9, capacitance=1e-6
         ... )
@@ -4072,11 +4078,11 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
 
         """
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
-            SOLUTIONS.Hfss.SBR,
-            SOLUTIONS.Hfss.EigenMode,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
+            SolutionsHfss.SBR,
+            SolutionsHfss.EigenMode,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
         if not (resistance or inductance or capacitance):
@@ -4161,15 +4167,16 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
 
         Create a sheet and use it to create an impedance.
 
+        >>> from ansys.aedt.core.generic.constants import Plane
         >>> sheet = hfss.modeler.create_rectangle(
-        ...     hfss.PLANE.XY, [0, 0, -90], [10, 2], name="ImpedanceSheet", material="Copper"
+        ...     Plane.XY, [0, 0, -90], [10, 2], name="ImpedanceSheet", material="Copper"
         ... )
         >>> impedance_to_sheet = hfss.assign_impedance_to_sheet(sheet.name, "ImpedanceFromSheet", 100, 50)
 
         Create a sheet and use it to create an anisotropic impedance.
 
         >>> sheet = hfss.modeler.create_rectangle(
-        ...     hfss.PLANE.XY, [0, 0, -90], [10, 2], name="ImpedanceSheet", material="Copper"
+        ...     Plane.XY, [0, 0, -90], [10, 2], name="ImpedanceSheet", material="Copper"
         ... )
         >>> anistropic_impedance_to_sheet = hfss.assign_impedance_to_sheet(
         ...     sheet.name, "ImpedanceFromSheet", [377, 0, 0, 377], [0, 50, 0, 0]
@@ -4178,10 +4185,10 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         """
 
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
-            SOLUTIONS.Hfss.EigenMode,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
+            SolutionsHfss.EigenMode,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -4281,7 +4288,8 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         Create a circuit port from the first edge of the first rectangle
         toward the first edge of the second rectangle.
 
-        >>> plane = hfss.PLANE.XY
+        >>> from ansys.aedt.core.generic.constants import Plane
+        >>> plane = Plane.XY
         >>> rectangle1 = hfss.modeler.create_rectangle(plane, [10, 10, 10], [10, 10], name="rectangle1_for_port")
         >>> edges1 = hfss.modeler.get_object_edges(rectangle1.id)
         >>> first_edge = edges1[0]
@@ -4457,7 +4465,8 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         Create a circle sheet and use it to create a wave port.
         Set up the thermal power for this wave port.
 
-        >>> sheet = hfss.modeler.create_circle(hfss.PLANE.YZ, [-20, 0, 0], 10, name="sheet_for_source")
+        >>> from ansys.aedt.core.generic.constants import Plane
+        >>> sheet = hfss.modeler.create_circle(Plane.YZ, [-20, 0, 0], 10, name="sheet_for_source")
         >>> hfss.solution_type = "Modal"
         >>> wave_port = hfss.create_wave_port_from_sheet(sheet, 5, hfss.AxisDir.XNeg, 40, 2, "SheetWavePort", True)
         >>> hfss.edit_source("SheetWavePort" + ":1", "10W")
@@ -4467,7 +4476,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         """
         warnings.warn("`edit_sources` is deprecated. Use `edit_sources` method instead.", DeprecationWarning)
 
-        if self.solution_type != SOLUTIONS.Hfss.EigenMode:
+        if self.solution_type != SolutionsHfss.EigenMode:
             if assignment is None:
                 raise AEDTRuntimeError(f"Port and mode must be defined for solution type {self.solution_type}")
             self.logger.info(f'Setting up power to "{assignment}" = {power}')
@@ -4691,7 +4700,8 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         Create a circle sheet and use it to create a wave port.
         Set the thickness of this circle sheet to ``"2 mm"``.
 
-        >>> sheet_for_thickness = hfss.modeler.create_circle(hfss.PLANE.YZ, [60, 60, 60], 10, name="SheetForThickness")
+        >>> from ansys.aedt.core.generic.constants import Plane
+        >>> sheet_for_thickness = hfss.modeler.create_circle(Plane.YZ, [60, 60, 60], 10, name="SheetForThickness")
         >>> port_for_thickness = hfss.create_wave_port_from_sheet(
         ...     sheet_for_thickness, 5, hfss.AxisDir.XNeg, 40, 2, "WavePortForThickness", True
         ... )
@@ -5240,7 +5250,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         ----------
         >>> oModule.InsertSetup
         """
-        if self.solution_type != SOLUTIONS.Hfss.SBR:
+        if self.solution_type != SolutionsHfss.SBR:
             raise AEDTRuntimeError("Method applies only to the SBR+ solution.")
 
         if not setup:
@@ -5336,7 +5346,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         ----------
         >>> oModule.InsertSetup
         """
-        if self.solution_type != SOLUTIONS.Hfss.SBR:
+        if self.solution_type != SolutionsHfss.SBR:
             raise AEDTRuntimeError("Method Applies only to SBR+ Solution.")
 
         if not setup:
@@ -5444,7 +5454,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         """
         from ansys.aedt.core.modeler.advanced_cad.actors import Radar
 
-        if self.solution_type != SOLUTIONS.Hfss.SBR:
+        if self.solution_type != SolutionsHfss.SBR:
             raise AEDTRuntimeError("Method applies only to SBR+ solution.")
 
         if offset is None:
@@ -5467,7 +5477,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
     @pyaedt_function_handler()
     def insert_infinite_sphere(
         self,
-        definition=INFINITE_SPHERE_TYPE.ThetaPhi,
+        definition=InfiniteSphereType.ThetaPhi,
         x_start=0,
         x_stop=180,
         x_step=10,
@@ -5490,7 +5500,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         ----------
         definition : str
             Coordinate definition type. The default is ``"Theta-Phi"``.
-            It can be a ``ansys.aedt.core.generic.constants.INFINITE_SPHERE_TYPE`` enumerator value.
+            It can be a ``ansys.aedt.core.generic.constants.InfiniteSphereType`` enumerator value.
         x_start : float, str, optional
             First angle start value. The default is ``0``.
         x_stop : float, str, optional
@@ -5898,7 +5908,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         ----------
         >>> oModule.EditGlobalCurrentSourcesOption
         """
-        if self.solution_type != SOLUTIONS.Hfss.SBR:
+        if self.solution_type != SolutionsHfss.SBR:
             raise AEDTRuntimeError("Method Applies only to SBR+ Solution.")
 
         current_conformance = "Disable"
@@ -5972,7 +5982,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         >>> oModule.EditDiffPairs
         """
 
-        if self.solution_type not in (SOLUTIONS.Hfss.Transient, SOLUTIONS.Hfss.DrivenTerminal):  # pragma: no cover
+        if self.solution_type not in (SolutionsHfss.Transient, SolutionsHfss.DrivenTerminal):  # pragma: no cover
             raise AEDTRuntimeError("Differential pairs can be defined only in Terminal and Transient solution types.")
 
         props = {}
@@ -6529,7 +6539,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         <class 'from ansys.aedt.core.modules.boundary.common.BoundaryObject'>
 
         """
-        if self.solution_type not in (SOLUTIONS.Hfss.DrivenModal, SOLUTIONS.Hfss.EigenMode):
+        if self.solution_type not in (SolutionsHfss.DrivenModal, SolutionsHfss.EigenMode):
             raise AEDTRuntimeError("Symmetry is only available with 'Modal' and 'Eigenmode' solution types.")
         if not isinstance(assignment, list):
             raise TypeError("Entities have to be provided as a list.")
@@ -6572,7 +6582,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         >>> hfss.set_impedance_multiplier(2.0)
 
         """
-        if self.solution_type != SOLUTIONS.Hfss.DrivenModal:
+        if self.solution_type != SolutionsHfss.DrivenModal:
             raise AEDTRuntimeError("Symmetry is only available with 'Modal' solution type.")
 
         self.oboundary.ChangeImpedanceMult(multiplier)
@@ -6736,7 +6746,8 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         Create a circuit port from the first edge of the first rectangle
         toward the first edge of the second rectangle.
 
-        >>> plane = hfss.PLANE.XY
+        >>> from ansys.aedt.core.generic.constants import Plane
+        >>> plane = Plane.XY
         >>> rectangle1 = hfss.modeler.create_rectangle(plane, [10, 10, 10], [10, 10], name="rectangle1_for_port")
         >>> edges1 = hfss.modeler.get_object_edges(rectangle1.id)
         >>> first_edge = edges1[0]
@@ -6750,9 +6761,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
         'PortExample'
         """
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -6857,9 +6868,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
                 point0, point1 = self.modeler.get_mid_points_on_dir(sheet_name, integration_line)
 
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -7041,9 +7052,9 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
             else:
                 int_start = int_stop = None
         if self.solution_type not in (
-            SOLUTIONS.Hfss.DrivenModal,
-            SOLUTIONS.Hfss.DrivenTerminal,
-            SOLUTIONS.Hfss.Transient,
+            SolutionsHfss.DrivenModal,
+            SolutionsHfss.DrivenTerminal,
+            SolutionsHfss.Transient,
         ):
             raise AEDTRuntimeError("Invalid solution type.")
 
@@ -7063,7 +7074,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
                 self._create_pec_cap(face, assignment, dist / 10)
         name = self._get_unique_source_name(name, "Port")
 
-        if self.solution_type == SOLUTIONS.Hfss.DrivenModal:
+        if self.solution_type == SolutionsHfss.DrivenModal:
             if isinstance(characteristic_impedance, str):
                 characteristic_impedance = [characteristic_impedance] * modes
             elif modes != len(characteristic_impedance):

--- a/src/ansys/aedt/core/icepak.py
+++ b/src/ansys/aedt/core/icepak.py
@@ -31,7 +31,8 @@ import re
 import warnings
 
 from ansys.aedt.core.application.analysis_icepak import FieldAnalysisIcepak
-from ansys.aedt.core.generic.constants import SOLUTIONS
+from ansys.aedt.core.generic.constants import Plane
+from ansys.aedt.core.generic.constants import SolutionsIcepak
 from ansys.aedt.core.generic.data_handlers import _arg2dict
 from ansys.aedt.core.generic.data_handlers import _dict2arg
 from ansys.aedt.core.generic.data_handlers import random_string
@@ -931,7 +932,8 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
 
         Create a rectangle named ``"Surface1"`` and assign a temperature monitor to that surface.
 
-        >>> surface = icepak.modeler.create_rectangle(icepak.PLANE.XY, [0, 0, 0], [10, 20], name="Surface1")
+        >>> >>> from ansys.aedt.core.generic.constants import Plane
+        >>> surface = icepak.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 20], name="Surface1")
         >>> icepak.assign_surface_monitor("Surface1", monitor_name="monitor")
         'monitor'
         """
@@ -1199,7 +1201,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
            the heatsink. The default is ``[0, 0, 0]``.
         plane_enum : str, int, optional
             Plane for orienting the heat sink.
-            :class:`ansys.aedt.core.constants.PLANE` Enumerator can be used as input.
+            :class:`ansys.aedt.core.constants.Plane` Enumerator can be used as input.
             The default is ``0``.
         rotation : int, float, optional
             The default is ``0``.
@@ -1216,6 +1218,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
         Create a symmetric fin heat sink.
 
         >>> from ansys.aedt.core import Icepak
+        >>> from ansys.aedt.core.generic.constants import Plane
         >>> icepak = Icepak()
         >>> icepak.insert_design("Heat_Sink_Example")
         >>> icepak.create_parametric_fin_heat_sink(
@@ -1225,7 +1228,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
         ...     vertical_separation=5.5,
         ...     material="Steel",
         ...     center=[10, 0, 0],
-        ...     plane_enum=icepak.PLANE.XY,
+        ...     plane_enum=Plane.XY,
         ...     rotation=45,
         ...     tolerance=0.005,
         ... )
@@ -1538,7 +1541,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
             reference_cs=cs,
         )
         self.modeler.set_working_coordinate_system(cs_ymax.name)
-        self.modeler.split(fin_base.name, self.PLANE.ZX, "NegativeOnly")
+        self.modeler.split(fin_base.name, Plane.ZX, "NegativeOnly")
         cs_ymin = self.modeler.create_coordinate_system(
             self.Position(0, "-" + name_map["HSHeight"], 0),
             mode="view",
@@ -1547,7 +1550,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
             reference_cs=cs_ymax.name,
         )
         self.modeler.set_working_coordinate_system(cs_ymin.name)
-        self.modeler.split(fin_base.name, self.PLANE.ZX, "PositiveOnly")
+        self.modeler.split(fin_base.name, Plane.ZX, "PositiveOnly")
 
         if symmetric:
             cs_center_right_sep = self.modeler.create_coordinate_system(
@@ -1558,7 +1561,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
                 reference_cs=cs_ymax.name,
             )
 
-            self.modeler.split(fin_base.name, self.PLANE.YZ, "NegativeOnly")
+            self.modeler.split(fin_base.name, Plane.YZ, "NegativeOnly")
             self.modeler.create_coordinate_system(
                 self.Position(name_map["SymSeparation"] + "/2", 0, 0),
                 mode="view",
@@ -1576,7 +1579,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
                 reference_cs=cs,
             )
             self.modeler.set_working_coordinate_system(cs_xmax.name)
-            self.modeler.split(fin_base.name, self.PLANE.YZ, "NegativeOnly")
+            self.modeler.split(fin_base.name, Plane.YZ, "NegativeOnly")
         all_obj = [obj for obj in self.modeler.object_names if obj not in all_obj]
         hs_final_name = self.modeler.unite(all_obj)
         hs = self.modeler[hs_final_name]
@@ -4001,7 +4004,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
 
     @pyaedt_function_handler()
     def _parse_variation_data(self, quantity, variation_type, variation_value, function):
-        if variation_type == "Transient" and self.solution_type == SOLUTIONS.Icepak.SteadyState:
+        if variation_type == "Transient" and self.solution_type == SolutionsIcepak.SteadyState:
             raise AEDTRuntimeError("A transient boundary condition cannot be assigned for a non-transient simulation.")
         if variation_type == "Temp Dep" and function != "Piecewise Linear":
             raise AEDTRuntimeError("Temperature dependent assignment support only piecewise linear function.")
@@ -4666,7 +4669,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
             ]
         for quantity, assignment in possible_transient_properties:
             if isinstance(assignment, (dict, BoundaryDictionary)):
-                if self.solution_type != SOLUTIONS.Icepak.Transient:
+                if self.solution_type != SolutionsIcepak.Transient:
                     raise AEDTRuntimeError("Transient assignment is supported only in transient designs.")
 
                 assignment = self._parse_variation_data(
@@ -5168,7 +5171,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
                 }
 
         if isinstance(total_power, (dict, BoundaryDictionary)):
-            if self.solution_type != SOLUTIONS.Icepak.Transient:
+            if self.solution_type != SolutionsIcepak.Transient:
                 raise AEDTRuntimeError("Transient assignment is supported only in transient designs.")
 
             assignment = self._parse_variation_data(
@@ -5516,9 +5519,9 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
                 "``conductance_external_temperature`` must be specified when ``thermal_specification`` "
                 'is ``"Conductance"``. Setting ``conductance_external_temperature`` to ``"AmbientTemp"``.'
             )
-        if (start_time is not None or end_time is not None) and self.solution_type != SOLUTIONS.Icepak.Transient:
+        if (start_time is not None or end_time is not None) and self.solution_type != SolutionsIcepak.Transient:
             self.logger.warning("``start_time`` and ``end_time`` only effect steady-state simulations.")
-        elif self.solution_type == SOLUTIONS.Icepak.Transient and not (start_time is not None and end_time is not None):
+        elif self.solution_type == SolutionsIcepak.Transient and not (start_time is not None and end_time is not None):
             self.logger.warning(
                 '``start_time`` and ``end_time`` should be declared for transient simulations. Setting them to "0s".'
             )
@@ -5536,7 +5539,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
         props["ExtractFace"] = extract_face
         props["Thermal Condition"] = thermal_specification
         if isinstance(assignment_value, (dict, BoundaryDictionary)):
-            if self.solution_type != SOLUTIONS.Icepak.Transient:
+            if self.solution_type != SolutionsIcepak.Transient:
                 raise AEDTRuntimeError("Transient assignment is supported only in transient designs.")
             assignment = self._parse_variation_data(
                 assignment_dict[thermal_specification],
@@ -5550,7 +5553,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
         if thermal_specification == "Conductance":
             props["External Temp"] = conductance_external_temperature
         if isinstance(flow_assignment, (dict, BoundaryDictionary)):
-            if self.solution_type != SOLUTIONS.Icepak.Transient:
+            if self.solution_type != SolutionsIcepak.Transient:
                 raise AEDTRuntimeError("Transient assignment is supported only in transient designs.")
 
             assignment = self._parse_variation_data(
@@ -5572,7 +5575,7 @@ class Icepak(FieldAnalysisIcepak, CreateBoundaryMixin):
                 raise ValueError("``flow_direction`` must have only three components.")
             for direction, val in zip(["X", "Y", "Z"], flow_direction):
                 props[direction] = str(val)
-        if self.solution_type == SOLUTIONS.Icepak.Transient:
+        if self.solution_type == SolutionsIcepak.Transient:
             props["Start"] = start_time
             props["End"] = end_time
         if not boundary_name:

--- a/src/ansys/aedt/core/maxwell.py
+++ b/src/ansys/aedt/core/maxwell.py
@@ -30,7 +30,8 @@ import re
 import time
 
 from ansys.aedt.core.application.analysis_3d import FieldAnalysis3D
-from ansys.aedt.core.generic.constants import SOLUTIONS
+from ansys.aedt.core.generic.constants import SolutionsMaxwell2D
+from ansys.aedt.core.generic.constants import SolutionsMaxwell3D
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.file_utils import open_file
 from ansys.aedt.core.generic.file_utils import read_configuration_file
@@ -242,9 +243,9 @@ class Maxwell(CreateBoundaryMixin):
         >>> m3d.release_desktop(True, True)
         """
         if self.solution_type not in (
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
-            SOLUTIONS.Maxwell3d.Transient,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
+            SolutionsMaxwell3D.Transient,
         ):
             raise AEDTRuntimeError(
                 "Core losses is only available with `EddyCurrent`, `ACMagnetic` and `Transient` solutions."
@@ -326,9 +327,9 @@ class Maxwell(CreateBoundaryMixin):
 
         assignment = self.modeler.convert_to_selections(assignment, True)
         if self.solution_type in (
-            SOLUTIONS.Maxwell3d.ElectroStatic,
-            SOLUTIONS.Maxwell3d.ACConduction,
-            SOLUTIONS.Maxwell3d.DCConduction,
+            SolutionsMaxwell3D.ElectroStatic,
+            SolutionsMaxwell3D.ACConduction,
+            SolutionsMaxwell3D.DCConduction,
         ):
             turns = ["1"] * len(assignment)
             branches = None
@@ -344,7 +345,7 @@ class Maxwell(CreateBoundaryMixin):
             else:
                 group_sources = None
 
-        elif self.solution_type == SOLUTIONS.Maxwell3d.Magnetostatic:
+        elif self.solution_type == SolutionsMaxwell3D.Magnetostatic:
             if group_sources:
                 if isinstance(group_sources, dict):
                     new_group = group_sources.copy()
@@ -369,14 +370,14 @@ class Maxwell(CreateBoundaryMixin):
                 else:
                     self.logger.warning("Group of sources is not a dictionary")
                     group_sources = None
-        elif self.solution_type in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+        elif self.solution_type in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
             group_sources = None
             branches = None
             turns = ["1"] * len(assignment)
             self.logger.info("Infinite is the only return path option in EddyCurrent.")
             return_path = ["infinite"] * len(assignment)
 
-        if self.solution_type not in (SOLUTIONS.Maxwell3d.Transient, SOLUTIONS.Maxwell3d.ElectricTransient):
+        if self.solution_type not in (SolutionsMaxwell3D.Transient, SolutionsMaxwell3D.ElectricTransient):
             if not matrix_name:
                 matrix_name = generate_unique_name("Matrix")
             if not turns or len(assignment) != len(self.modeler.convert_to_selections(turns, True)):
@@ -405,7 +406,7 @@ class Maxwell(CreateBoundaryMixin):
                 props = dict({"MatrixEntry": dict({"MatrixEntry": []}), "MatrixGroup": []})
 
             for element in range(len(assignment)):
-                if self.solution_type == SOLUTIONS.Maxwell3d.Magnetostatic and self.design_type == "Maxwell 2D":
+                if self.solution_type == SolutionsMaxwell3D.Magnetostatic and self.design_type == "Maxwell 2D":
                     prop = dict(
                         {
                             "Source": assignment[element],
@@ -413,7 +414,7 @@ class Maxwell(CreateBoundaryMixin):
                             "ReturnPath": return_path[element],
                         }
                     )
-                elif self.solution_type in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+                elif self.solution_type in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
                     prop = dict({"Source": assignment[element], "ReturnPath": return_path[element]})
                 else:
                     prop = dict({"Source": assignment[element], "NumberOfTurns": turns[element]})
@@ -421,9 +422,9 @@ class Maxwell(CreateBoundaryMixin):
 
             if group_sources:
                 if self.solution_type in (
-                    SOLUTIONS.Maxwell3d.ElectroStatic,
-                    SOLUTIONS.Maxwell3d.ACConduction,
-                    SOLUTIONS.Maxwell3d.DCConduction,
+                    SolutionsMaxwell3D.ElectroStatic,
+                    SolutionsMaxwell3D.ACConduction,
+                    SolutionsMaxwell3D.DCConduction,
                 ):
                     source_list = ",".join(group_sources)
                     props["GroundSources"] = source_list
@@ -469,7 +470,7 @@ class Maxwell(CreateBoundaryMixin):
         bool
             ``True`` when successful and ``False`` when failed.
         """
-        if self.solution_type != SOLUTIONS.Maxwell3d.Transient:
+        if self.solution_type != SolutionsMaxwell3D.Transient:
             raise AEDTRuntimeError("Control Program is only available in Maxwell 2D and 3D Transient solutions.")
 
         self._py_file = setupname + ".py"
@@ -560,7 +561,7 @@ class Maxwell(CreateBoundaryMixin):
             if not enable_eddy_effects:
                 enable_displacement_current = False
             for obj in solid_objects_names:
-                if self.solution_type in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+                if self.solution_type in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
                     if obj in assignment:
                         EddyVector.append(
                             [
@@ -585,7 +586,7 @@ class Maxwell(CreateBoundaryMixin):
                                 bool(self.oboundary.GetDisplacementCurrent(obj)),
                             ]
                         )
-                if self.solution_type == SOLUTIONS.Maxwell3d.Transient:
+                if self.solution_type == SolutionsMaxwell3D.Transient:
                     if obj in assignment:
                         EddyVector.append(
                             [
@@ -662,7 +663,7 @@ class Maxwell(CreateBoundaryMixin):
         >>> m2d.release_desktop(True, True)
         """
 
-        if self.solution_type != SOLUTIONS.Maxwell3d.Transient:
+        if self.solution_type != SolutionsMaxwell3D.Transient:
             raise AEDTRuntimeError("Y connections only available for Transient solutions.")
 
         if assignment:
@@ -738,17 +739,17 @@ class Maxwell(CreateBoundaryMixin):
                     }
                 )
             if self.solution_type not in (
-                SOLUTIONS.Maxwell3d.Magnetostatic,
-                SOLUTIONS.Maxwell3d.DCConduction,
-                SOLUTIONS.Maxwell3d.ElectricTransient,
-                SOLUTIONS.Maxwell3d.TransientAPhiFormulation,
-                SOLUTIONS.Maxwell3d.ElectroDCConduction,
+                SolutionsMaxwell3D.Magnetostatic,
+                SolutionsMaxwell3D.DCConduction,
+                SolutionsMaxwell3D.ElectricTransient,
+                SolutionsMaxwell3D.TransientAPhiFormulation,
+                SolutionsMaxwell3D.ElectroDCConduction,
             ):
                 props["Phase"] = phase
             if self.solution_type not in (
-                SOLUTIONS.Maxwell3d.DCConduction,
-                SOLUTIONS.Maxwell3d.ElectricTransient,
-                SOLUTIONS.Maxwell3d.ElectroDCConduction,
+                SolutionsMaxwell3D.DCConduction,
+                SolutionsMaxwell3D.ElectricTransient,
+                SolutionsMaxwell3D.ElectroDCConduction,
             ):
                 props["IsSolid"] = solid
             props["Point out of terminal"] = swap_direction
@@ -789,7 +790,7 @@ class Maxwell(CreateBoundaryMixin):
             Coordinate system name. The default is ``"Global"``.
         axis : str or int, optional
             Coordinate system axis. The default is ``"Z"``.
-            It can be a ``ansys.aedt.core.generic.constants.AXIS`` enumerator value.
+            It can be a ``ansys.aedt.core.generic.constants.Axis`` enumerator value.
         positive_movement : bool, optional
             Whether movement is positive. The default is ``True``.
         start_position : float or str, optional
@@ -829,7 +830,7 @@ class Maxwell(CreateBoundaryMixin):
         ----------
         >>> oModule.AssignBand
         """
-        if self.solution_type != SOLUTIONS.Maxwell3d.Transient:
+        if self.solution_type != SolutionsMaxwell3D.Transient:
             raise AEDTRuntimeError("Motion applies only to the Transient setup.")
 
         if not motion_name:
@@ -886,7 +887,7 @@ class Maxwell(CreateBoundaryMixin):
             Coordinate system name. The default is ``"Global"``.
         axis : str or int, optional
             Coordinate system axis. The default is ``"Z"``.
-            It can be a ``ansys.aedt.core.generic.constants.AXIS`` enumerator value.
+            It can be a ``ansys.aedt.core.generic.constants.Axis`` enumerator value.
         positive_movement : bool, optional
             Whether the movement is positive. The default is ``True``.
         start_position : float or str, optional
@@ -924,7 +925,7 @@ class Maxwell(CreateBoundaryMixin):
         ----------
         >>> oModule.AssignBand
         """
-        if self.solution_type != SOLUTIONS.Maxwell3d.Transient:
+        if self.solution_type != SolutionsMaxwell3D.Transient:
             raise AEDTRuntimeError("Motion applies only to the Transient setup.")
 
         names = list(self.omodelsetup.GetMotionSetupNames())
@@ -1086,7 +1087,7 @@ class Maxwell(CreateBoundaryMixin):
 
         >>> from ansys.aedt.core import Maxwell2d
         >>> m2d = Maxwell2d(version="2025.1")
-        >>> m2d.solution_type = SOLUTIONS.Maxwell2d.ElectroStaticXY
+        >>> m2d.solution_type = SolutionsMaxwell2D.ElectroStaticXY
         >>> rect = m2d.modeler.create_rectangle([0, 0, 0], [3, 1], name="Rectangle1")
         >>> floating = m2d.assign_floating(assignment=rect, charge_value=3, name="floating_test")
         >>> m2d.release_desktop(True, True)
@@ -1094,14 +1095,14 @@ class Maxwell(CreateBoundaryMixin):
         Assign a floating excitation for a Maxwell 3d Electrostatic design providing an object
         >>> from ansys.aedt.core import Maxwell3d
         >>> m3d = Maxwell3d(version="2025.1")
-        >>> m3d.solution_type = SOLUTIONS.Maxwell3d.ElectroStatic
+        >>> m3d.solution_type = SolutionsMaxwell3D.ElectroStatic
         >>> box = m3d.modeler.create_box([0, 0, 0], [10, 10, 10], name="Box1")
         >>> floating = m3d.assign_floating(assignment=box, charge_value=3)
         Assign a floating excitation providing a list of faces
         >>> floating1 = m3d.assign_floating(assignment=[box.faces[0], box.faces[1]], charge_value=3)
         >>> m3d.release_desktop(True, True)
         """
-        if self.solution_type not in (SOLUTIONS.Maxwell3d.ElectroStatic, SOLUTIONS.Maxwell3d.ElectricTransient):
+        if self.solution_type not in (SolutionsMaxwell3D.ElectroStatic, SolutionsMaxwell3D.ElectricTransient):
             raise AEDTRuntimeError(
                 "Assign floating excitation is only valid for electrostatic or electric transient solvers."
             )
@@ -1352,7 +1353,7 @@ class Maxwell(CreateBoundaryMixin):
         >>> m3d.assign_force("conductor1", is_virtual=False, force_name="force_copper")  # conductor, use Lorentz force
         >>> m3d.release_desktop(True, True)
         """
-        if self.solution_type in (SOLUTIONS.Maxwell3d.ACConduction, SOLUTIONS.Maxwell3d.DCConduction):
+        if self.solution_type in (SolutionsMaxwell3D.ACConduction, SolutionsMaxwell3D.DCConduction):
             raise AEDTRuntimeError("Solution type has no 'Matrix' parameter.")
 
         assignment = self.modeler.convert_to_selections(assignment, True)
@@ -1414,10 +1415,10 @@ class Maxwell(CreateBoundaryMixin):
         ----------
         >>> oModule.AssignTorque
         """
-        if self.solution_type in (SOLUTIONS.Maxwell3d.ACConduction, SOLUTIONS.Maxwell3d.DCConduction):
+        if self.solution_type in (SolutionsMaxwell3D.ACConduction, SolutionsMaxwell3D.DCConduction):
             raise AEDTRuntimeError("Solution Type has not Matrix Parameter")
 
-        if self.solution_type == SOLUTIONS.Maxwell3d.Transient:
+        if self.solution_type == SolutionsMaxwell3D.Transient:
             is_virtual = True
         assignment = self.modeler.convert_to_selections(assignment, True)
         if not torque_name:
@@ -1485,7 +1486,7 @@ class Maxwell(CreateBoundaryMixin):
         ----------
         >>> oModule.ResetSetupToTimeZero
         """
-        if self.solution_type != SOLUTIONS.Maxwell3d.Transient:
+        if self.solution_type != SolutionsMaxwell3D.Transient:
             raise AEDTRuntimeError("This methods work only with Maxwell Transient Analysis.")
 
         self.oanalysis.ResetSetupToTimeZero(self._setup)
@@ -1625,10 +1626,10 @@ class Maxwell(CreateBoundaryMixin):
             ``True`` when successful, ``False`` when failed.
         """
         if self.solution_type not in (
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
-            SOLUTIONS.Maxwell3d.Magnetostatic,
-            SOLUTIONS.Maxwell3d.Transient,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
+            SolutionsMaxwell3D.Magnetostatic,
+            SolutionsMaxwell3D.Transient,
         ):
             raise AEDTRuntimeError(
                 "Current density can only be applied to `Eddy Current`, `ACMagnetic`, `Magnetostatic`,"
@@ -1645,7 +1646,7 @@ class Maxwell(CreateBoundaryMixin):
 
         try:
             if self.modeler._is3d:
-                if self.solution_type == SOLUTIONS.Maxwell3d.Transient:
+                if self.solution_type == SolutionsMaxwell3D.Transient:
                     raise AEDTRuntimeError(
                         "Current density can only be applied to Eddy Current or Magnetostatic solution types."
                     )
@@ -1664,13 +1665,13 @@ class Maxwell(CreateBoundaryMixin):
                     for x in range(0, len(objects_list)):
                         current_density_group_names.append(current_density_name + f"_{str(x + 1)}")
                     bound_props = {"items": current_density_group_names}
-                    if self.solution_type in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+                    if self.solution_type in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
                         common_props["Phase"] = phase
                     bound_props[current_density_group_names[0]] = common_props.copy()
                     bound_name = current_density_group_names[0]
                     bound_type = "CurrentDensityGroup"
                 else:
-                    if self.solution_type in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+                    if self.solution_type in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
                         common_props["Phase"] = phase
                     bound_props = common_props
                     bound_name = current_density_name
@@ -1686,13 +1687,13 @@ class Maxwell(CreateBoundaryMixin):
                     for x in range(0, len(objects_list)):
                         current_density_group_names.append(current_density_name + f"_{str(x + 1)}")
                     bound_props = {"items": current_density_group_names}
-                    if self.solution_type in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+                    if self.solution_type in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
                         common_props["Phase"] = phase
                     bound_props[current_density_group_names[0]] = common_props.copy()
                     bound_name = current_density_group_names[0]
                     bound_type = "CurrentDensityGroup"
                 else:
-                    if self.solution_type in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+                    if self.solution_type in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
                         common_props["Phase"] = phase
                     bound_props = common_props
                     bound_name = current_density_name
@@ -1738,7 +1739,7 @@ class Maxwell(CreateBoundaryMixin):
         >>> m3d.assign_radiation([box1, box2.faces[0]])
         >>> m3d.release_desktop(True, True)
         """
-        if self.solution_type not in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+        if self.solution_type not in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
             raise AEDTRuntimeError("Excitation applicable only to Eddy Current and AC Magnetic.")
         if not radiation:
             radiation = generate_unique_name("Radiation")
@@ -1791,7 +1792,7 @@ class Maxwell(CreateBoundaryMixin):
             ``True`` when successful, ``False`` when failed.
 
         """
-        if self.solution_type != SOLUTIONS.Maxwell3d.Transient:
+        if self.solution_type != SolutionsMaxwell3D.Transient:
             raise AEDTRuntimeError("This methods work only with Maxwell Transient Analysis.")
 
         assignment = self.modeler.convert_to_selections(assignment, True)
@@ -1878,7 +1879,7 @@ class Maxwell(CreateBoundaryMixin):
         bool
             ``True`` when successful, ``False`` when failed.
         """
-        if self.solution_type not in [SOLUTIONS.Maxwell3d.TransientAPhiFormulation, SOLUTIONS.Maxwell3d.TransientAPhi]:
+        if self.solution_type not in [SolutionsMaxwell3D.TransientAPhiFormulation, SolutionsMaxwell3D.TransientAPhi]:
             raise AEDTRuntimeError(
                 "This methods work only with Maxwell TransientAPhiFormulation Analysis and AC Magnetic."
             )
@@ -1952,7 +1953,7 @@ class Maxwell(CreateBoundaryMixin):
         str
             Path to the export directory.
         """
-        if self.solution_type not in (SOLUTIONS.Maxwell3d.Transient, SOLUTIONS.Maxwell3d.TransientAPhiFormulation):
+        if self.solution_type not in (SolutionsMaxwell3D.Transient, SolutionsMaxwell3D.TransientAPhiFormulation):
             raise AEDTRuntimeError("This methods work only with Maxwell Transient Analysis.")
 
         if not output_directory:
@@ -1999,9 +2000,9 @@ class Maxwell(CreateBoundaryMixin):
         >>> m2d.release_desktop(True, True)
         """
         if self.solution_type not in (
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
-            SOLUTIONS.Maxwell3d.Transient,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
+            SolutionsMaxwell3D.Transient,
         ):
             raise AEDTRuntimeError(
                 "External circuit excitation for windings is available only for Eddy Current, AC Magnetic "
@@ -2202,10 +2203,10 @@ class Maxwell(CreateBoundaryMixin):
             ``True`` when successful, ``False`` when failed.
         """
         if self.solution_type not in [
-            SOLUTIONS.Maxwell2d.EddyCurrentXY,
-            SOLUTIONS.Maxwell2d.EddyCurrentZ,
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
+            SolutionsMaxwell2D.EddyCurrentXY,
+            SolutionsMaxwell2D.EddyCurrentZ,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
         ]:
             raise AEDTRuntimeError("RL Matrix can only be exported if solution type is Eddy Current and AC Magnetic.")
 
@@ -2287,9 +2288,9 @@ class Maxwell(CreateBoundaryMixin):
             ``True`` when successful, ``False`` when failed.
         """
         if self.solution_type not in [
-            SOLUTIONS.Maxwell2d.ElectroStaticXY,
-            SOLUTIONS.Maxwell2d.ElectroStaticZ,
-            SOLUTIONS.Maxwell3d.ElectroStatic,
+            SolutionsMaxwell2D.ElectroStaticXY,
+            SolutionsMaxwell2D.ElectroStaticZ,
+            SolutionsMaxwell3D.ElectroStatic,
         ]:
             raise AEDTRuntimeError("C Matrix can only be exported if solution type is Electrostatic.")
 
@@ -2502,14 +2503,14 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         """
 
         if self.solution_type not in (
-            SOLUTIONS.Maxwell3d.Magnetostatic,
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
-            SOLUTIONS.Maxwell3d.Transient,
-            SOLUTIONS.Maxwell3d.TransientAPhiFormulation,
-            SOLUTIONS.Maxwell3d.DCConduction,
-            SOLUTIONS.Maxwell3d.ACConduction,
-            SOLUTIONS.Maxwell3d.ElectroDCConduction,
+            SolutionsMaxwell3D.Magnetostatic,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
+            SolutionsMaxwell3D.Transient,
+            SolutionsMaxwell3D.TransientAPhiFormulation,
+            SolutionsMaxwell3D.DCConduction,
+            SolutionsMaxwell3D.ACConduction,
+            SolutionsMaxwell3D.ElectroDCConduction,
         ):
             raise AEDTRuntimeError(f"This method does not work with solution type '{self.solution_type}'")
 
@@ -2581,9 +2582,9 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         >>> m3d.release_desktop(True, True)
         """
         if self.solution_type not in (
-            SOLUTIONS.Maxwell3d.Transient,
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
+            SolutionsMaxwell3D.Transient,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
         ):
             raise AEDTRuntimeError(f"This method does not work with solution type '{self.solution_type}'")
 
@@ -2630,9 +2631,9 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
             ``True`` when successful, ``False`` when failed.
         """
         if self.solution_type not in (
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
-            SOLUTIONS.Maxwell3d.Magnetostatic,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
+            SolutionsMaxwell3D.Magnetostatic,
         ):
             raise AEDTRuntimeError(
                 "Current density can only be applied to Eddy Current, AC Magnetic and Magnetostatic solution types."
@@ -2828,7 +2829,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         >>> flux_tangential = m3d.assign_flux_tangential(box.faces[0], "FluxExample")
         >>> m3d.release_desktop(True, True)
         """
-        if self.solution_type not in [SOLUTIONS.Maxwell3d.TransientAPhiFormulation, SOLUTIONS.Maxwell3d.TransientAPhi]:
+        if self.solution_type not in [SolutionsMaxwell3D.TransientAPhiFormulation, SolutionsMaxwell3D.TransientAPhi]:
             raise AEDTRuntimeError(
                 "Flux tangential boundary can only be assigned to a transient APhi and AC Magnetic solution type."
             )
@@ -2972,9 +2973,9 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         >>> oModule.AssignTangentialHField
         """
         if self.solution_type not in (
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
-            SOLUTIONS.Maxwell3d.Magnetostatic,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
+            SolutionsMaxwell3D.Magnetostatic,
         ):
             raise AEDTRuntimeError(
                 "Tangential H Field is applicable only to Eddy Current, AC Magnetic and Magnetostatic."
@@ -2995,10 +2996,10 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
                 }
             )
         props["ComponentXReal"] = x_component_real
-        if self.solution_type in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+        if self.solution_type in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
             props["ComponentXImag"] = x_component_imag
         props["ComponentYReal"] = y_component_real
-        if self.solution_type in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+        if self.solution_type in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
             props["ComponentYImag"] = y_component_imag
         if not origin and isinstance(assignment[0], int):
             edges = self.modeler.get_face_edges(assignment[0])
@@ -3031,7 +3032,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         ----------
         >>> oModule.AssignZeroTangentialHField
         """
-        if self.solution_type not in [SOLUTIONS.Maxwell3d.EddyCurrent, SOLUTIONS.Maxwell3d.ACMagnetic]:
+        if self.solution_type not in [SolutionsMaxwell3D.EddyCurrent, SolutionsMaxwell3D.ACMagnetic]:
             raise AEDTRuntimeError("Tangential H Field is applicable only to Eddy Current and AC Magnetic.")
 
         assignment = self.modeler.convert_to_selections(assignment, True)
@@ -3125,20 +3126,20 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         Examples
         --------
         >>> import ansys.aedt.core
-        >>> from ansys.aedt.core.generic.constants import SOLUTIONS
+        >>> from ansys.aedt.core.generic.constants import SolutionsMaxwell3D
         >>> m3d = ansys.aedt.core.Maxwell3d(solution_type="Transient")
         >>> my_box = m3d.modeler.create_box(origin=[0, 0, 0], sizes=[0.4, -1, 0.8], material="copper")
         >>> resistive_face = my_box.faces[0]
         >>> bound = m3d.assign_resistive_sheet(assignment=resistive_face, resistance="3ohm")
-        >>> m3d.solution_type = SOLUTIONS.Maxwell3d.Magnetostatic
+        >>> m3d.solution_type = SolutionsMaxwell3D.Magnetostatic
         >>> bound = m3d.assign_resistive_sheet(assignment=resistive_face, non_linear=True)
         >>> m3d.release_desktop()
         """
         if self.solution_type not in (
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
-            SOLUTIONS.Maxwell3d.Transient,
-            SOLUTIONS.Maxwell3d.Magnetostatic,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
+            SolutionsMaxwell3D.Transient,
+            SolutionsMaxwell3D.Magnetostatic,
         ):
             raise AEDTRuntimeError(
                 "Resistive sheet is applicable only to `Eddy Current`, `ACMagnetic`, `Transient`,"
@@ -3160,12 +3161,12 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
                 props["Faces"].append(sel)
 
         if self.solution_type in (
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
-            SOLUTIONS.Maxwell3d.Transient,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
+            SolutionsMaxwell3D.Transient,
         ):
             props["Resistance"] = resistance
-        elif self.solution_type == SOLUTIONS.Maxwell3d.Magnetostatic:
+        elif self.solution_type == SolutionsMaxwell3D.Magnetostatic:
             props["Nonlinear"] = non_linear
             props["AnodeParA"] = anode_a
             props["AnodeParB"] = anode_b
@@ -3591,9 +3592,9 @@ class Maxwell2d(Maxwell, FieldAnalysis3D, object):
         >>> oModule.AssignEndConnection
         """
         if self.solution_type not in (
-            SOLUTIONS.Maxwell3d.EddyCurrent,
-            SOLUTIONS.Maxwell3d.ACMagnetic,
-            SOLUTIONS.Maxwell3d.Transient,
+            SolutionsMaxwell3D.EddyCurrent,
+            SolutionsMaxwell3D.ACMagnetic,
+            SolutionsMaxwell3D.Transient,
         ):
             raise AEDTRuntimeError("Excitation applicable only to Eddy Current, AC Magnetic and Transient Solver.")
         if len(assignment) < 2:

--- a/src/ansys/aedt/core/mechanical.py
+++ b/src/ansys/aedt/core/mechanical.py
@@ -25,7 +25,7 @@
 """This module contains the ``Mechanical`` class."""
 
 from ansys.aedt.core.application.analysis_3d import FieldAnalysis3D
-from ansys.aedt.core.generic.constants import SOLUTIONS
+from ansys.aedt.core.generic.constants import SolutionsMechanical
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
@@ -216,9 +216,9 @@ class Mechanical(FieldAnalysis3D, CreateBoundaryMixin):
         >>> oModule.AssignEMLoss
         """
         if self.solution_type not in (
-            SOLUTIONS.Mechanical.Thermal,
-            SOLUTIONS.Mechanical.SteadyStateThermal,
-            SOLUTIONS.Mechanical.TransientThermal,
+            SolutionsMechanical.Thermal,
+            SolutionsMechanical.SteadyStateThermal,
+            SolutionsMechanical.TransientThermal,
         ):
             raise AEDTRuntimeError("This method works only in a Mechanical Thermal analysis.")
 
@@ -323,7 +323,7 @@ class Mechanical(FieldAnalysis3D, CreateBoundaryMixin):
         ----------
         >>> oModule.AssignThermalCondition
         """
-        if self.solution_type != SOLUTIONS.Mechanical.Structural:
+        if self.solution_type != SolutionsMechanical.Structural:
             raise AEDTRuntimeError("This method works only in a Mechanical Structural analysis.")
 
         if parameters is None:
@@ -403,9 +403,9 @@ class Mechanical(FieldAnalysis3D, CreateBoundaryMixin):
         >>> oModule.AssignConvection
         """
         if self.solution_type not in (
-            SOLUTIONS.Mechanical.Thermal,
-            SOLUTIONS.Mechanical.SteadyStateThermal,
-            SOLUTIONS.Mechanical.TransientThermal,
+            SolutionsMechanical.Thermal,
+            SolutionsMechanical.SteadyStateThermal,
+            SolutionsMechanical.TransientThermal,
         ):
             raise AEDTRuntimeError("This method works only in a Mechanical Thermal analysis.")
 
@@ -452,9 +452,9 @@ class Mechanical(FieldAnalysis3D, CreateBoundaryMixin):
         >>> oModule.AssignTemperature
         """
         if self.solution_type not in (
-            SOLUTIONS.Mechanical.Thermal,
-            SOLUTIONS.Mechanical.SteadyStateThermal,
-            SOLUTIONS.Mechanical.TransientThermal,
+            SolutionsMechanical.Thermal,
+            SolutionsMechanical.SteadyStateThermal,
+            SolutionsMechanical.TransientThermal,
         ):
             raise AEDTRuntimeError("This method works only in a Mechanical Thermal analysis.")
 
@@ -497,7 +497,7 @@ class Mechanical(FieldAnalysis3D, CreateBoundaryMixin):
         ----------
         >>> oModule.AssignFrictionlessSupport
         """
-        if self.solution_type not in (SOLUTIONS.Mechanical.Structural, SOLUTIONS.Mechanical.Modal):
+        if self.solution_type not in (SolutionsMechanical.Structural, SolutionsMechanical.Modal):
             raise AEDTRuntimeError("This method works only in a Mechanical Structural analysis.")
 
         props = {}
@@ -536,7 +536,7 @@ class Mechanical(FieldAnalysis3D, CreateBoundaryMixin):
         ----------
         >>> oModule.AssignFixedSupport
         """
-        if self.solution_type not in (SOLUTIONS.Mechanical.Structural, SOLUTIONS.Mechanical.Modal):
+        if self.solution_type not in (SolutionsMechanical.Structural, SolutionsMechanical.Modal):
             raise AEDTRuntimeError("This method works only in a Mechanical Structural analysis.")
 
         props = {}
@@ -594,9 +594,9 @@ class Mechanical(FieldAnalysis3D, CreateBoundaryMixin):
         >>> oModule.AssignHeatFlux
         """
         if self.solution_type not in (
-            SOLUTIONS.Mechanical.Thermal,
-            SOLUTIONS.Mechanical.SteadyStateThermal,
-            SOLUTIONS.Mechanical.TransientThermal,
+            SolutionsMechanical.Thermal,
+            SolutionsMechanical.SteadyStateThermal,
+            SolutionsMechanical.TransientThermal,
         ):
             raise AEDTRuntimeError("This method works only in a Mechanical Thermal analysis.")
 
@@ -641,9 +641,9 @@ class Mechanical(FieldAnalysis3D, CreateBoundaryMixin):
         >>> oModule.AssignHeatGeneration
         """
         if self.solution_type not in (
-            SOLUTIONS.Mechanical.Thermal,
-            SOLUTIONS.Mechanical.SteadyStateThermal,
-            SOLUTIONS.Mechanical.TransientThermal,
+            SolutionsMechanical.Thermal,
+            SolutionsMechanical.SteadyStateThermal,
+            SolutionsMechanical.TransientThermal,
         ):
             raise AEDTRuntimeError("This method works only in a Mechanical Thermal analysis.")
 

--- a/src/ansys/aedt/core/modeler/advanced_cad/stackup_3d.py
+++ b/src/ansys/aedt/core/modeler/advanced_cad/stackup_3d.py
@@ -386,7 +386,7 @@ class Layer3D(object):
 
             else:
                 obj_3d = self._app.modeler.create_rectangle(
-                    constants.PLANE.XY,
+                    constants.Plane.XY,
                     ["dielectric_x_position", "dielectric_y_position", layer_position],
                     ["dielectric_length", "dielectric_width"],
                     name=self._name,
@@ -402,7 +402,7 @@ class Layer3D(object):
                 )
             else:
                 obj_3d = self._app.modeler.create_rectangle(
-                    constants.PLANE.XY,
+                    constants.Plane.XY,
                     ["dielectric_x_position", "dielectric_y_position", layer_position],
                     ["dielectric_length", "dielectric_width"],
                     name=self._name,
@@ -2443,7 +2443,7 @@ class Patch(CommonObject, object):
             + reference_layer.elevation.name
         )
         rect = self.application.modeler.create_rectangle(
-            orientation=constants.PLANE.YZ,
+            orientation=constants.Plane.YZ,
             origin=[string_position_x, string_position_y, string_position_z],
             sizes=[string_width, string_length],
             name=self.name + "_port",
@@ -3184,7 +3184,7 @@ class Trace(CommonObject, object):
             + reference_layer.elevation.name
         )
         port = self.application.modeler.create_rectangle(
-            orientation=constants.PLANE.YZ,
+            orientation=constants.Plane.YZ,
             origin=[string_position_x, string_position_y, string_position_z],
             sizes=[string_width, string_length],
             name=self.name + "_port",

--- a/src/ansys/aedt/core/modeler/cad/components_3d.py
+++ b/src/ansys/aedt/core/modeler/cad/components_3d.py
@@ -567,7 +567,7 @@ class UserDefinedComponent(object):
         Parameters
         ----------
         axis
-            Coordinate system axis or the Application.AXIS object.
+            Coordinate system axis or the a value of the enum :class:`ansys.aedt.core.generic.constants.Axis`.
         angle : float, optional
             Angle of rotation. The units, defined by ``unit``, can be either
             degrees or radians. The default is ``90.0``.
@@ -628,7 +628,7 @@ class UserDefinedComponent(object):
 
         Parameters
         ----------
-        axis : Application.AXIS object
+        axis : Value of the :class:`ansys.aedt.core.generic.constants.Axis` enum
             Coordinate system axis of the object.
         angle : float, optional
             Angle of rotation in degrees. The default is ``90``.

--- a/src/ansys/aedt/core/modeler/cad/object_3d.py
+++ b/src/ansys/aedt/core/modeler/cad/object_3d.py
@@ -38,7 +38,7 @@ from pathlib import Path
 import re
 
 from ansys.aedt.core.generic.constants import AEDT_UNITS
-from ansys.aedt.core.generic.constants import PLANE
+from ansys.aedt.core.generic.constants import Plane
 from ansys.aedt.core.generic.constants import unit_converter
 from ansys.aedt.core.generic.file_utils import _uname
 from ansys.aedt.core.generic.file_utils import open_file
@@ -1479,7 +1479,7 @@ class Object3d(object):
         Parameters
         ----------
         plane : str
-            Coordinate plane of the cut or the Application.PLANE object.
+            Coordinate plane of the cut.
             Choices for the coordinate plane are ``"XY"``, ``"YZ"``, and ``"ZX"``.
         sides : str, optional
             Which side to keep. Options are ``"Both"``, ``"PositiveOnly"``,
@@ -1534,7 +1534,7 @@ class Object3d(object):
         Parameters
         ----------
         axis : int
-            Coordinate system axis or the Application.AXIS object.
+            Coordinate system axis or value of the :class:`ansys.aedt.core.generic.constants.Axis` enum.
         angle : float, optional
             Angle of rotation. The units, defined by ``unit``, can be either
             degrees or radians. The default is ``90.0``.
@@ -1585,7 +1585,7 @@ class Object3d(object):
 
         Parameters
         ----------
-        axis : Application.AXIS object
+        axis : :class:`ansys.aedt.core.generic.constants.Axis`
             Coordinate system axis of the object.
         angle : float
             Angle of rotation in degrees. The default is ``90``.
@@ -1703,7 +1703,7 @@ class Object3d(object):
 
         Parameters
         ----------
-        axis : :class:`ansys.aedt.core.generic.constants.AXIS`
+        axis : :class:`ansys.aedt.core.generic.constants.Axis`
             Coordinate system of the axis.
         sweep_angle : float, optional
              Sweep angle in degrees. The default is ``360``.
@@ -1729,8 +1729,8 @@ class Object3d(object):
 
         Parameters
         ----------
-        plane : from ansys.aedt.core.generic.constants.PLANE
-            Coordinate system of the plane object. Application.PLANE object
+        plane : from ansys.aedt.core.generic.constants.Plane
+            Coordinate system of the plane object.
         create_new : bool, optional
             Whether to create an object. The default is ``True``.
         section_cross_object : bool, optional
@@ -3051,11 +3051,11 @@ class PolylineSegment(object):
                 raise ValueError("Arc center must be a list of length 3.")
             self.arc_center = arc_center
         if isinstance(arc_plane, int):
-            if arc_plane == PLANE.XY:
+            if arc_plane == Plane.XY:
                 self.arc_plane = "XY"
-            elif arc_plane == PLANE.ZX:
+            elif arc_plane == Plane.ZX:
                 self.arc_plane = "ZX"
-            elif arc_plane == PLANE.YZ:
+            elif arc_plane == Plane.YZ:
                 self.arc_plane = "YZ"
             else:
                 raise ValueError("arc_plane must be 0, 1, or 2 ")

--- a/src/ansys/aedt/core/modeler/cad/primitives.py
+++ b/src/ansys/aedt/core/modeler/cad/primitives.py
@@ -34,6 +34,7 @@ import warnings
 
 import ansys.aedt.core
 from ansys.aedt.core.application.variables import Variable
+from ansys.aedt.core.generic.constants import Plane as PlaneEnum
 from ansys.aedt.core.generic.data_handlers import json_to_dict
 from ansys.aedt.core.generic.file_utils import _uname
 from ansys.aedt.core.generic.file_utils import generate_unique_name
@@ -1583,7 +1584,7 @@ class GeometryModeler(Modeler):
         mode : str, optional
             Definition mode. Options are ``"axis"``, ``"axisrotation"``,
             ``"view"``, ``"zxz"``, and ``"zyz"`` The default
-            is ``"axis"``.  You can also use the ``ansys.aedt.core.generic.constants.CSMODE``
+            is ``"axis"``.  You can also use the ``ansys.aedt.core.generic.constants.CSMode``
             enumerator.
 
             * If ``mode="axis"``, specify the ``x_pointing`` and ``y_pointing`` parameters.
@@ -1601,7 +1602,7 @@ class GeometryModeler(Modeler):
             View for the coordinate system if ``mode="view"``. Options
             are ``"iso"``, ``None``, ``"XY"``, ``"XZ"``, and ``"XY"``. The
             default is ``"iso"``. The ``"rotate"`` option is obsolete. You can
-            also use the ``ansys.aedt.core.generic.constants.VIEW`` enumerator.
+            also use the ``ansys.aedt.core.generic.constants.View`` enumerator.
 
             .. note::
               For backward compatibility, ``mode="view", view="rotate"`` are the same as
@@ -2430,13 +2431,13 @@ class GeometryModeler(Modeler):
             axisdist = -axisdist
 
         if divmod(orientation, 3)[1] == 0:
-            cs = self._app.PLANE.YZ
+            cs = PlaneEnum.YZ
             vector = [axisdist, 0, 0]
         elif divmod(orientation, 3)[1] == 1:
-            cs = self._app.PLANE.ZX
+            cs = PlaneEnum.ZX
             vector = [0, axisdist, 0]
         elif divmod(orientation, 3)[1] == 2:
-            cs = self._app.PLANE.XY
+            cs = PlaneEnum.XY
             vector = [0, 0, axisdist]
 
         offset = self.find_point_around(assignment, start, sheet_dim, cs)
@@ -2718,7 +2719,7 @@ class GeometryModeler(Modeler):
             One or more objects to split. A list can contain
             both strings (object names) and integers (object IDs).
         plane : str, optional
-            Coordinate plane of the cut or the Application.PLANE object.
+            Coordinate plane of the cut.
             The default value is ``None``.
             Choices for the coordinate plane are ``"XY"``, ``"YZ"``, and ``"ZX"``.
             If plane or tool parameter are not provided the method returns ``False``.
@@ -3040,7 +3041,7 @@ class GeometryModeler(Modeler):
         assignment : list, str, int, Object3d or UserDefinedComponent
             Name or ID of the object.
         axis : str
-            Coordinate system axis or the Application.AXIS object.
+            Coordinate system axis or value of the :class:`ansys.aedt.core.generic.constants.Axis` enum.
         angle : float, optional
             Angle rotation in degees. The default is ``90``.
         clones : int or str, optional
@@ -3359,7 +3360,7 @@ class GeometryModeler(Modeler):
         assignment : list, str, int, :class:`ansys.aedt.core.modeler.cad.object_3d.Object3d`
             Name or ID of the object.
         axis :
-            Coordinate system axis or the Application.AXIS object.
+            Coordinate system axis or value of the :class:`ansys.aedt.core.generic.constants.Axis` enum.
         sweep_angle : float
             Sweep angle in degrees. The default is ``360``.
         draft_angle : float
@@ -3414,7 +3415,7 @@ class GeometryModeler(Modeler):
         assignment : list, str, int, or  :class:`ansys.aedt.core.modeler.cad.object_3d.Object3d`
             One or more objects to section.
         plane : str
-            Coordinate plane or Application.PLANE object.
+            Coordinate plane.
             Choices for the coordinate plane are ``"XY"``, ``"YZ"``, and ``"ZX"``.'
         create_new : bool, optional
             The default is ``True``, but this parameter has no effect.
@@ -3501,7 +3502,7 @@ class GeometryModeler(Modeler):
         assignment :  list, str, int, or  :class:`ansys.aedt.core.modeler.cad.object_3d.Object3d`
              ID of the object.
         axis : str
-            Coordinate system axis or the Application.AXIS object.
+            Coordinate system axis or value of the :class:`ansys.aedt.core.generic.constants.Axis` enum.
         angle : float, str
             Angle of rotation. The units, defined by ``unit``, can be either
             degrees or radians. The default is ``90.0``.

--- a/src/ansys/aedt/core/modeler/cad/primitives_3d.py
+++ b/src/ansys/aedt/core/modeler/cad/primitives_3d.py
@@ -189,7 +189,7 @@ class Primitives3D(GeometryModeler):
         ----------
         orientation : int or str
             Axis of rotation of the starting point around the center point.
-            :class:`ansys.aedt.core.constants.AXIS` Enumerator can be used as input.
+            :class:`ansys.aedt.core.constants.Axis` Enumerator can be used as input.
         origin : list
             Center point of the cylinder in a list of ``(x, y, z)`` coordinates.
         radius : float
@@ -738,7 +738,7 @@ class Primitives3D(GeometryModeler):
         ----------
         orientation : str or int
             Coordinate system plane for orienting the rectangle.
-            :class:`ansys.aedt.core.constants.PLANE` Enumerator can be used as input.
+            :class:`ansys.aedt.core.constants.Plane` Enumerator can be used as input.
         origin : list or Position
             List of ``[x, y, z]`` coordinates of the lower-left corner of the rectangle or
             the position ApplicationName.modeler.Position(x,y,z) object.
@@ -798,7 +798,7 @@ class Primitives3D(GeometryModeler):
         ----------
         orientation : str or int
             Coordinate system plane for orienting the circle.
-            :class:`ansys.aedt.core.constants.PLANE` Enumerator can be used as input.
+            :class:`ansys.aedt.core.constants.Plane` Enumerator can be used as input.
         origin : list
             List of ``[x, y, z]`` coordinates for the center point of the circle.
         radius : float or str
@@ -887,7 +887,7 @@ class Primitives3D(GeometryModeler):
         ----------
         orientation : str or int
             Coordinate system plane for orienting the ellipse.
-            :class:`ansys.aedt.core.constants.PLANE` Enumerator can be used as input.
+            :class:`ansys.aedt.core.constants.Plane` Enumerator can be used as input.
         origin : list
             List of ``[x, y, z]`` coordinates for the center point of the ellipse.
         major_radius : float

--- a/src/ansys/aedt/core/modeler/geometry_operators.py
+++ b/src/ansys/aedt/core/modeler/geometry_operators.py
@@ -27,9 +27,9 @@ import re
 import sys
 import warnings
 
-from ansys.aedt.core.generic.constants import AXIS
-from ansys.aedt.core.generic.constants import PLANE
-from ansys.aedt.core.generic.constants import SWEEPDRAFT
+from ansys.aedt.core.generic.constants import Axis
+from ansys.aedt.core.generic.constants import Plane
+from ansys.aedt.core.generic.constants import SweepDraft
 from ansys.aedt.core.generic.constants import scale_units
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.generic.math_utils import MathUtils
@@ -142,7 +142,7 @@ class GeometryOperators(object):
         Parameters
         ----------
         val : int
-            ``PLANE`` enum vélo.
+            ``Plane`` enum.
 
         Returns
         -------
@@ -150,9 +150,9 @@ class GeometryOperators(object):
            String for the coordinate system plane.
 
         """
-        if val == PLANE.XY or val == "XY":
+        if val == Plane.XY or val == "XY":
             return "Z"
-        elif val == PLANE.YZ or val == "YZ":
+        elif val == Plane.YZ or val == "YZ":
             return "X"
         else:
             return "Y"
@@ -173,9 +173,9 @@ class GeometryOperators(object):
            String for the coordinate system plane.
 
         """
-        if val == PLANE.XY or val == "XY":
+        if val == Plane.XY or val == "XY":
             return "XY"
-        elif val == PLANE.YZ or val == "YZ":
+        elif val == Plane.YZ or val == "YZ":
             return "YZ"
         else:
             return "ZX"
@@ -188,7 +188,7 @@ class GeometryOperators(object):
         Parameters
         ----------
         val : int
-            ``AXIS`` enum value.
+            ``Axis`` enum value.
 
 
         Returns
@@ -197,9 +197,9 @@ class GeometryOperators(object):
             String for the coordinate system axis.
 
         """
-        if val == AXIS.X or val == "X":
+        if val == Axis.X or val == "X":
             return "X"
-        elif val == AXIS.Y or val == "Y":
+        elif val == Axis.Y or val == "Y":
             return "Y"
         else:
             return "Z"
@@ -212,7 +212,7 @@ class GeometryOperators(object):
         Parameters
         ----------
         val : int
-            ``SWEEPDRAFT`` enum value.
+            ``SweepDraft`` enum value.
 
         Returns
         -------
@@ -220,9 +220,9 @@ class GeometryOperators(object):
            Type of the draft.
 
         """
-        if val == SWEEPDRAFT.Extended:
+        if val == SweepDraft.Extended:
             return "Extended"
-        elif val == SWEEPDRAFT.Round:
+        elif val == SweepDraft.Round:
             return "Round"
         else:
             return "Natural"

--- a/src/ansys/aedt/core/modeler/modeler_3d.py
+++ b/src/ansys/aedt/core/modeler/modeler_3d.py
@@ -29,6 +29,7 @@ import os.path
 import warnings
 
 from ansys.aedt.core.application.variables import generate_validation_errors
+from ansys.aedt.core.generic.constants import Axis
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.file_utils import open_file
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
@@ -611,8 +612,8 @@ class Modeler3D(Primitives3D):
         origin : list
             List of ``[x, y, z]`` coordinates for the starting position.
         axis : int
-            Coordinate system AXIS (integer ``0`` for X, ``1`` for Y, ``2`` for Z) or
-            the :class:`Application.AXIS` enumerator.
+            Coordinate system axis (integer ``0`` for X, ``1`` for Y, ``2`` for Z) or value of
+            the :class:`ansys.aedt.core.generic.constants.Axis` enumerator.
         inner_radius : float, optional
             Inner coax radius. The default is ``1``.
         outer_radius : float, optional
@@ -644,10 +645,11 @@ class Modeler3D(Primitives3D):
         This example shows how to create a Coaxial Along X Axis waveguide.
 
         >>> from ansys.aedt.core import Hfss
+        >>> from ansys.aedt.core.generic.constants import Axis
         >>> app = Hfss()
         >>> position = [0, 0, 0]
         >>> coax = app.modeler.create_coaxial(
-        ...     position, app.AXIS.X, inner_radius=0.5, outer_radius=0.8, diel_radius=0.78, length=50
+        ...     position, Axis.X, inner_radius=0.5, outer_radius=0.8, diel_radius=0.78, length=50
         ... )
 
         """
@@ -691,7 +693,7 @@ class Modeler3D(Primitives3D):
             List of ``[x, y, z]`` coordinates for the original position.
         wg_direction_axis : int
             Coordinate system axis (integer ``0`` for X, ``1`` for Y, ``2`` for Z) or
-            the :class:`Application.AXIS` enumerator.
+            the :class:`ansys.aedt.core.generic.constants.Axis` enumerator.
         wgmodel : str, optional
             Waveguide model. The default is ``"WG0"``.
         wg_length : float, optional
@@ -726,10 +728,10 @@ class Modeler3D(Primitives3D):
         This example shows how to create a WG9 waveguide.
 
         >>> from ansys.aedt.core import Hfss
+        >>> from ansys.aedt.core.generic.constants import Axis
         >>> app = Hfss()
         >>> position = [0, 0, 0]
-        >>> wg1 = app.modeler.create_waveguide(position, app.AXIS.,
-        ...                                    wgmodel="WG9", wg_length=2000)
+        >>> wg1 = app.modeler.create_waveguide(position, Axis.X, wgmodel="WG9", wg_length=2000)
 
 
         """
@@ -798,7 +800,7 @@ class Modeler3D(Primitives3D):
             else:
                 w = self._app.value_with_units(wgwidth)
                 wb = self._app.value_with_units(wgwidth) + " + 2*" + self._app.value_with_units(wg_thickness)
-            if wg_direction_axis == self._app.AXIS.Z:
+            if wg_direction_axis == Axis.Z:
                 airbox = self.create_box(origin, [w, h, wg_length])
 
                 if isinstance(wg_thickness, str):
@@ -808,7 +810,7 @@ class Modeler3D(Primitives3D):
                     origin[0] -= wg_thickness
                     origin[1] -= wg_thickness
 
-            elif wg_direction_axis == self._app.AXIS.Y:
+            elif wg_direction_axis == Axis.Y:
                 airbox = self.create_box(origin, [w, wg_length, h])
 
                 if isinstance(wg_thickness, str):
@@ -835,9 +837,9 @@ class Modeler3D(Primitives3D):
                 p2 = self.create_object_from_face(airbox.faces[maxi].id)
             if not name:
                 name = generate_unique_name(wgmodel)
-            if wg_direction_axis == self._app.AXIS.Z:
+            if wg_direction_axis == Axis.Z:
                 wgbox = self.create_box(origin, [wb, hb, wg_length], name=name)
-            elif wg_direction_axis == self._app.AXIS.Y:
+            elif wg_direction_axis == Axis.Y:
                 wgbox = self.create_box(origin, [wb, wg_length, hb], name=name)
             else:
                 wgbox = self.create_box(origin, [wg_length, wb, hb], name=name)

--- a/src/ansys/aedt/core/modules/boundary/common.py
+++ b/src/ansys/aedt/core/modules/boundary/common.py
@@ -209,9 +209,10 @@ class BoundaryObject(BoundaryCommon, BinaryTreeNode):
     operation and coat will return a ``ansys.aedt.core.modules.boundary.common.BoundaryObject``
 
     >>> from ansys.aedt.core import Hfss
+    >>> from ansys.aedt.core.generic.constants import Plane
     >>> hfss = Hfss()
     >>> origin = hfss.modeler.Position(0, 0, 0)
-    >>> inner = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 3, 200, 0, "inner")
+    >>> inner = hfss.modeler.create_cylinder(Plane.XY, origin, 3, 200, 0, "inner")
     >>> inner_id = hfss.modeler.get_obj_id(
     ...     "inner",
     ... )

--- a/src/ansys/aedt/core/modules/boundary/q3d_boundary.py
+++ b/src/ansys/aedt/core/modules/boundary/q3d_boundary.py
@@ -22,7 +22,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import warnings
+
 from ansys.aedt.core.generic.constants import CATEGORIESQ3D
+from ansys.aedt.core.generic.constants import PlotCategoriesQ3D
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.general_methods import filter_tuple
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
@@ -47,7 +50,18 @@ class Matrix(object):
                 self._operations = operations
             else:
                 self._operations = [operations]
-        self.CATEGORIES = CATEGORIESQ3D()
+
+    # TODO: Remove for release 1.0.0
+    @property
+    def CATEGORIES(self):
+        """Deprecated: Use a plot category from ``ansys.aedt.core.generic.constants`` instead."""
+        warnings.warn(
+            "Usage of CATEGORIES is deprecated. "
+            "Use a plot category defined in ansys.aedt.core.generic.constants instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return CATEGORIESQ3D
 
     @pyaedt_function_handler()
     def sources(self, is_gc_sources=True):
@@ -111,7 +125,7 @@ class Matrix(object):
         if not second_element_filter:
             second_element_filter = "*"
         is_cg = False
-        if category in [self.CATEGORIES.Q3D.C, self.CATEGORIES.Q3D.G]:
+        if category in [PlotCategoriesQ3D.C, PlotCategoriesQ3D.G]:
             is_cg = True
         list_output = []
         if get_self_terms:

--- a/src/ansys/aedt/core/modules/solve_setup.py
+++ b/src/ansys/aedt/core/modules/solve_setup.py
@@ -3667,8 +3667,9 @@ class SetupMaxwell(Setup, object):
         Example
         -------
         >>> import ansys.aedt.core
+        >>> from ansys.aedt.core.generic.constants import SolutionsMaxwell2D
         >>> m2d = ansys.aedt.core.Maxwell2d(version="2025.1")
-        >>> m2d.solution_type = SOLUTIONS.Maxwell2d.EddyCurrentXY
+        >>> m2d.solution_type = SolutionsMaxwell2D.EddyCurrentXY
         >>> setup = m2d.create_setup()
         >>> sweep = setup.add_eddy_current_sweep(
         ...     sweep_type="LinearStep", start_frequency=1, stop_frequency=20, step_size=2, units="Hz", clear=False

--- a/src/ansys/aedt/core/q3d.py
+++ b/src/ansys/aedt/core/q3d.py
@@ -29,8 +29,8 @@ import re
 import warnings
 
 from ansys.aedt.core.application.analysis_3d import FieldAnalysis3D
-from ansys.aedt.core.generic.constants import MATRIXOPERATIONSQ2D
-from ansys.aedt.core.generic.constants import MATRIXOPERATIONSQ3D
+from ansys.aedt.core.generic.constants import MatrixOperationsQ2D
+from ansys.aedt.core.generic.constants import MatrixOperationsQ3D
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.general_methods import deprecate_argument
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
@@ -1309,7 +1309,18 @@ class Q3d(QExtractor, CreateBoundaryMixin):
             aedt_process_id,
             remove_lock=remove_lock,
         )
-        self.MATRIXOPERATIONS = MATRIXOPERATIONSQ3D()
+
+    # TODO: Remove for release 1.0.0
+    @property
+    def MATRIXOPERATIONS(self):
+        """Deprecated: Use ``ansys.aedt.core.generic.constants.MatrixOperationsQ3D`` instead."""
+        warnings.warn(
+            "Usage of MATRIXOPERATIONS is deprecated. "
+            "Use ansys.aedt.core.generic.constants.MatrixOperationsQ3D instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return MatrixOperationsQ3D
 
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)
@@ -2406,7 +2417,18 @@ class Q2d(QExtractor, CreateBoundaryMixin):
             aedt_process_id,
             remove_lock=remove_lock,
         )
-        self.MATRIXOPERATIONS = MATRIXOPERATIONSQ2D()
+
+    # TODO: Remove for release 1.0.0
+    @property
+    def MATRIXOPERATIONS(self):
+        """Deprecated: Use ``ansys.aedt.core.generic.constants.MatrixOperationsQ2D`` instead."""
+        warnings.warn(
+            "Usage of MATRIXOPERATIONS is deprecated. "
+            "Use ansys.aedt.core.generic.constants.MatrixOperationsQ2D instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return MatrixOperationsQ2D
 
     def _init_from_design(self, *args, **kwargs):
         self.__init__(*args, **kwargs)

--- a/src/ansys/aedt/core/visualization/post/monitor_icepak.py
+++ b/src/ansys/aedt/core/visualization/post/monitor_icepak.py
@@ -422,7 +422,8 @@ class Monitor:
         --------
         Create a rectangle named ``"Surface1"`` and assign a temperature monitor to that surface.
 
-        >>> surface = icepak.modeler.create_rectangle(icepak.PLANE.XY, [0, 0, 0], [10, 20], name="Surface1")
+        >>> from ansys.aedt.core.generic.constants import Plane
+        >>> surface = icepak.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 20], name="Surface1")
         >>> icepak.assign_surface_monitor("Surface1", monitor_name="monitor")
         'monitor'
         """

--- a/tests/system/general/test_01_GeometryOperators.py
+++ b/tests/system/general/test_01_GeometryOperators.py
@@ -26,9 +26,9 @@ import math
 
 import pytest
 
-from ansys.aedt.core.generic.constants import AXIS
-from ansys.aedt.core.generic.constants import PLANE
-from ansys.aedt.core.generic.constants import SWEEPDRAFT
+from ansys.aedt.core.generic.constants import Axis
+from ansys.aedt.core.generic.constants import Plane
+from ansys.aedt.core.generic.constants import SweepDraft
 from ansys.aedt.core.generic.constants import unit_converter
 from ansys.aedt.core.modeler.calculators import StandardWaveguide as wg
 from ansys.aedt.core.modeler.calculators import TransmissionLine as tl
@@ -84,23 +84,23 @@ class TestClass:
         assert go.parse_dim_arg("1m_per_h") == 3600.0
 
     def test_cs_plane_str(self):
-        assert go.cs_plane_to_axis_str(PLANE.XY) == "Z"
-        assert go.cs_plane_to_axis_str(PLANE.YZ) == "X"
-        assert go.cs_plane_to_axis_str(PLANE.ZX) == "Y"
-        assert go.cs_plane_to_plane_str(PLANE.XY) == "XY"
-        assert go.cs_plane_to_plane_str(PLANE.YZ) == "YZ"
-        assert go.cs_plane_to_plane_str(PLANE.ZX) == "ZX"
+        assert go.cs_plane_to_axis_str(Plane.XY) == "Z"
+        assert go.cs_plane_to_axis_str(Plane.YZ) == "X"
+        assert go.cs_plane_to_axis_str(Plane.ZX) == "Y"
+        assert go.cs_plane_to_plane_str(Plane.XY) == "XY"
+        assert go.cs_plane_to_plane_str(Plane.YZ) == "YZ"
+        assert go.cs_plane_to_plane_str(Plane.ZX) == "ZX"
 
     def test_cs_axis_str(self):
-        assert go.cs_axis_str(AXIS.X) == "X"
-        assert go.cs_axis_str(AXIS.Y) == "Y"
-        assert go.cs_axis_str(AXIS.Z) == "Z"
+        assert go.cs_axis_str(Axis.X) == "X"
+        assert go.cs_axis_str(Axis.Y) == "Y"
+        assert go.cs_axis_str(Axis.Z) == "Z"
 
     def test_draft_type_str(self):
-        assert go.draft_type_str(SWEEPDRAFT.Extended) == "Extended"
-        assert go.draft_type_str(SWEEPDRAFT.Round) == "Round"
-        assert go.draft_type_str(SWEEPDRAFT.Natural) == "Natural"
-        assert go.draft_type_str(SWEEPDRAFT.Mixed) == "Natural"
+        assert go.draft_type_str(SweepDraft.Extended) == "Extended"
+        assert go.draft_type_str(SweepDraft.Round) == "Round"
+        assert go.draft_type_str(SweepDraft.Natural) == "Natural"
+        assert go.draft_type_str(SweepDraft.Mixed) == "Natural"
 
     def test_get_mid_point(self):
         p1 = [0.0, 0.0, 0.0]

--- a/tests/system/general/test_02_2D_modeler.py
+++ b/tests/system/general/test_02_2D_modeler.py
@@ -30,6 +30,7 @@ import sys
 
 import pytest
 
+from ansys.aedt.core.generic.constants import Plane
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.generic.numbers import is_close
 from ansys.aedt.core.maxwell import Maxwell2d
@@ -270,7 +271,7 @@ class TestClass:
         rect1 = self.aedtapp.modeler.create_rectangle([0, -2, 0], [3, 8])
         poly1 = self.aedtapp.modeler.create_polyline(points=[[-2, 2, 0], [1, 5, 0], [5, 3, 0]], segment_type="Arc")
         assert not self.aedtapp.modeler.split(assignment=rect1)
-        split = self.aedtapp.modeler.split(assignment=rect1, plane=self.aedtapp.PLANE.ZX)
+        split = self.aedtapp.modeler.split(assignment=rect1, plane=Plane.ZX)
         assert isinstance(split, list)
         assert isinstance(split[0], str)
         obj_split = [obj for obj in self.aedtapp.modeler.object_list if obj.name == split[1]][0]

--- a/tests/system/general/test_02_3D_modeler.py
+++ b/tests/system/general/test_02_3D_modeler.py
@@ -26,6 +26,8 @@ import secrets
 
 import pytest
 
+from ansys.aedt.core.generic.constants import Axis
+from ansys.aedt.core.generic.constants import Plane
 from ansys.aedt.core.generic.math_utils import MathUtils
 from ansys.aedt.core.generic.numbers import decompose_variable_value
 from ansys.aedt.core.generic.quaternion import Quaternion
@@ -116,7 +118,7 @@ class TestClass:
         box3 = self.aedtapp.modeler.create_box([10, 10, 10], [20, 20, 20], "box_to_split3", display_wireframe=True)
         assert box3.display_wireframe
         rect1 = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [10, 8, 20], [20, 30], name="rect1", transparency=0.5, display_wireframe=True
+            Plane.XY, [10, 8, 20], [20, 30], name="rect1", transparency=0.5, display_wireframe=True
         )
         assert rect1.transparency == 0.5
         assert rect1.display_wireframe
@@ -125,12 +127,12 @@ class TestClass:
         assert isinstance(split, list)
         assert isinstance(split[0], str)
         obj_split = [obj for obj in self.aedtapp.modeler.object_list if obj.name == split[1]][0]
-        rect2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [10, 8, 14], [20, 30], name="rect2")
+        rect2 = self.aedtapp.modeler.create_rectangle(Plane.XY, [10, 8, 14], [20, 30], name="rect2")
         split = self.aedtapp.modeler.split(assignment=obj_split, sides="Both", tool=rect2.faces[0])
         assert isinstance(split, list)
         assert isinstance(split[0], str)
         obj_split = [obj for obj in self.aedtapp.modeler.object_list if obj.name == split[1]][0]
-        self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [10, 8, 12], [20, 30], name="rect3")
+        self.aedtapp.modeler.create_rectangle(Plane.XY, [10, 8, 12], [20, 30], name="rect3")
         split = self.aedtapp.modeler.split(assignment=obj_split, sides="Both", tool="rect3")
         assert isinstance(split, list)
         assert isinstance(split[0], str)
@@ -189,9 +191,9 @@ class TestClass:
 
     def test_09_thicken_sheet(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
-        id5 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.XY, udp, 10, name="sheet1")
+        id5 = self.aedtapp.modeler.create_circle(Plane.XY, udp, 10, name="sheet1")
         udp = self.aedtapp.modeler.Position(100, 100, 100)
-        id6 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.XY, udp, 10, name="sheet2")
+        id6 = self.aedtapp.modeler.create_circle(Plane.XY, udp, 10, name="sheet2")
         status = self.aedtapp.modeler.thicken_sheet(id5, 3)
         assert status
         status = self.aedtapp.modeler.automatic_thicken_sheets(id6, 3, False)
@@ -203,7 +205,7 @@ class TestClass:
 
     def test_11_split(self):
         self.restore_model()
-        assert self.aedtapp.modeler.split("Poly1", self.aedtapp.PLANE.XY)
+        assert self.aedtapp.modeler.split("Poly1", Plane.XY)
 
     def test_12_separate_bodies(self):
         self.aedtapp.modeler.create_cylinder(
@@ -219,7 +221,7 @@ class TestClass:
         assert len(object_list) == 2
 
     def test_13_rotate(self):
-        assert self.aedtapp.modeler.rotate("Poly1", self.aedtapp.AXIS.X, 30)
+        assert self.aedtapp.modeler.rotate("Poly1", Axis.X, 30)
 
     def test_14_subtract(self):
         o1 = self.aedtapp.modeler["outer"].clone()
@@ -260,8 +262,8 @@ class TestClass:
 
     def test_20_intersect(self):
         udp = [0, 0, 0]
-        o1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [5, 10], name="Rect1")
-        o2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [3, 12], name="Rect2")
+        o1 = self.aedtapp.modeler.create_rectangle(Plane.XY, udp, [5, 10], name="Rect1")
+        o2 = self.aedtapp.modeler.create_rectangle(Plane.XY, udp, [3, 12], name="Rect2")
         assert (
             self.aedtapp.modeler.intersect(
                 [o1, o2],
@@ -271,9 +273,9 @@ class TestClass:
 
     def test_21_connect(self):
         udp = [0, 0, 0]
-        id1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [5, 10])
+        id1 = self.aedtapp.modeler.create_rectangle(Plane.XY, udp, [5, 10])
         udp = self.aedtapp.modeler.Position(0, 0, 10)
-        id2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [-3, 10])
+        id2 = self.aedtapp.modeler.create_rectangle(Plane.XY, udp, [-3, 10])
         objects_after_connection = self.aedtapp.modeler.connect([id1, id2])
         assert isinstance(objects_after_connection, list)
         assert id1.name == objects_after_connection[0].name
@@ -281,8 +283,8 @@ class TestClass:
 
     def test_22_translate(self):
         udp = [0, 0, 0]
-        id1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [5, 10])
-        id2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [3, 12])
+        id1 = self.aedtapp.modeler.create_rectangle(Plane.XY, udp, [5, 10])
+        id2 = self.aedtapp.modeler.create_rectangle(Plane.XY, udp, [3, 12])
         udp2 = self.aedtapp.modeler.Position(0, 20, 5)
         assert self.aedtapp.modeler.move([id1, id2], udp2)
 
@@ -358,12 +360,12 @@ class TestClass:
 
     def test_30_create_waveguide(self):
         position = self.aedtapp.modeler.Position(0, 0, 0)
-        wg1 = self.aedtapp.modeler.create_waveguide(position, self.aedtapp.AXIS.X, wg_length=2000)
+        wg1 = self.aedtapp.modeler.create_waveguide(position, Axis.X, wg_length=2000)
         assert isinstance(wg1, tuple)
         position = self.aedtapp.modeler.Position(0, 0, 0)
         wg9 = self.aedtapp.modeler.create_waveguide(
             position,
-            self.aedtapp.AXIS.Z,
+            Axis.Z,
             wgmodel="WG9",
             wg_length=1500,
             parametrize_h=True,
@@ -373,7 +375,7 @@ class TestClass:
         assert wg9[1].id > 0
         assert wg9[2].id > 0
         wgfail = self.aedtapp.modeler.create_waveguide(
-            position, self.aedtapp.AXIS.Z, wgmodel="MYMODEL", wg_length=2000, parametrize_h=True
+            position, Axis.Z, wgmodel="MYMODEL", wg_length=2000, parametrize_h=True
         )
         assert not wgfail
 
@@ -382,9 +384,9 @@ class TestClass:
         assert self.aedtapp.modeler.set_object_model_state(["Second_airbox", "AirBox_Auto"], False)
 
     def test_32_find_port_faces(self):
-        self.aedtapp.modeler.create_waveguide([0, 5000, 0], self.aedtapp.AXIS.Y, wg_length=1000, wg_thickness=40)
-        port1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.ZX, [-40, 5000, -40], [346.7, 613.4])
-        port2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.ZX, [-40, 6000, -40], [346.7, 613.4])
+        self.aedtapp.modeler.create_waveguide([0, 5000, 0], Axis.Y, wg_length=1000, wg_thickness=40)
+        port1 = self.aedtapp.modeler.create_rectangle(Plane.ZX, [-40, 5000, -40], [346.7, 613.4])
+        port2 = self.aedtapp.modeler.create_rectangle(Plane.ZX, [-40, 6000, -40], [346.7, 613.4])
         faces_created = self.aedtapp.modeler.find_port_faces([port1.name, port2.name])
         assert len(faces_created) == 4
         assert "_Face1Vacuum" in faces_created[1]
@@ -392,7 +394,7 @@ class TestClass:
 
     def test_33_duplicate_around_axis(self):
         id1 = self.aedtapp.modeler.create_box([10, 10, 10], [4, 5, 5])
-        axis = self.aedtapp.AXIS.X
+        axis = Axis.X
         _, obj_list = self.aedtapp.modeler.duplicate_around_axis(
             id1, axis=axis, angle="180deg", clones=2, create_new_objects=False
         )
@@ -427,7 +429,7 @@ class TestClass:
         assert self.aedtapp.deactivate_variable_statistical("test_opti")
 
     def test_39_create_coaxial(self):
-        coax = self.aedtapp.modeler.create_coaxial([0, 0, 0], self.aedtapp.AXIS.X)
+        coax = self.aedtapp.modeler.create_coaxial([0, 0, 0], Axis.X)
         assert isinstance(coax[0].id, int)
         assert isinstance(coax[1].id, int)
         assert isinstance(coax[2].id, int)
@@ -721,14 +723,14 @@ class TestClass:
         assert self.aedtapp.modeler.get_working_coordinate_system() == fcs.name
 
     def test_44_sweep_around_axis(self):
-        rect1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, 0, 0], [20, 20], "rectangle_to_split")
+        rect1 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, 0, 0], [20, 20], "rectangle_to_split")
         assert rect1.sweep_around_axis("Z", sweep_angle=360, draft_angle=0)
 
     def test_45_sweep_along_path(self):
         udp1 = [0, 0, 0]
         udp2 = [5, 0, 0]
         path = self.aedtapp.modeler.create_polyline([udp1, udp2], name="Poly1")
-        rect1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, 0, 0], [20, 20], "rectangle_to_sweep")
+        rect1 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, 0, 0], [20, 20], "rectangle_to_sweep")
         assert rect1.sweep_along_path(path)
 
     def test_46_section_object(self):
@@ -737,14 +739,10 @@ class TestClass:
 
     def test_47_sweep_along_vector(self):
         sweep_vector = [5, 0, 0]
-        rect1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, 0, 0], [20, 20], "rectangle_to_vector")
+        rect1 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, 0, 0], [20, 20], "rectangle_to_vector")
         assert rect1.sweep_along_vector(sweep_vector)
-        rect2 = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.YZ, [0, 40, 0], [20, 20], "rectangle_to_vector2"
-        )
-        rect3 = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.YZ, [0, 80, 0], [20, 20], "rectangle_to_vector3"
-        )
+        rect2 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, 40, 0], [20, 20], "rectangle_to_vector2")
+        rect3 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, 80, 0], [20, 20], "rectangle_to_vector3")
         rect_list = [rect2, rect3]
         assert self.aedtapp.modeler.sweep_along_vector(assignment=rect_list, sweep_vector=sweep_vector)
 
@@ -849,20 +847,20 @@ class TestClass:
     def test_50_move_edge(self):
         box1 = self.aedtapp.modeler.create_box([-10, -10, -10], [20, 20, 20], "edge_movements")
         assert not box1.faces[0].edges[0].move_along_normal(1)
-        rect = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [0, 10, 10], [20, 20], "edge_movements2")
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 10, 10], [20, 20], "edge_movements2")
         assert self.aedtapp.modeler.move_edge([rect.edges[0], rect.edges[2]])
         assert rect.faces[0].bottom_edge_x.move_along_normal()
 
     def test_51_imprint(self):
-        rect = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [0, 10, 10], [20, 20], "imprint1")
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 10, 10], [20, 20], "imprint1")
         box1 = self.aedtapp.modeler.create_box([-10, -10, -10], [20, 20, 20], "imprint2")
         assert self.aedtapp.modeler.imprint(rect, box1)
 
     def test_51_imprint_projection(self):
-        rect = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [0, 0, 10], [5, 20], "imprintn1")
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 10], [5, 20], "imprintn1")
         box1 = self.aedtapp.modeler.create_box([-10, -10, -10], [20, 20, 20], "imprintn2")
         assert self.aedtapp.modeler.imprint_normal_projection([rect, box1])
-        rect = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [0, 0, 10], [6, 18], "imprintn3")
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 10], [6, 18], "imprintn3")
         box1 = self.aedtapp.modeler.create_box([-10, -10, -10], [20, 20, 20], "imprintn3")
         assert self.aedtapp.modeler.imprint_vector_projection([rect, box1], [0.2, -0.8, -5], 1)
 
@@ -880,7 +878,7 @@ class TestClass:
             self.aedtapp.modeler.objects_in_bounding_box(bounding_box)
 
     def test_53_wrap_sheet(self):
-        rect = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [2.5, 0, 10], [5, 15], "wrap")
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [2.5, 0, 10], [5, 15], "wrap")
         box1 = self.aedtapp.modeler.create_box([-10, -10, -10], [20, 20, 20], "wrp2")
         box2 = self.aedtapp.modeler.create_box([-10, -10, -10], [20, 20, 20], "wrp3")
         assert self.aedtapp.modeler.wrap_sheet(rect, box1)

--- a/tests/system/general/test_05_Mesh.py
+++ b/tests/system/general/test_05_Mesh.py
@@ -25,6 +25,7 @@
 import pytest
 
 from ansys.aedt.core import Maxwell3d
+from ansys.aedt.core.generic.constants import Plane
 from tests.system.general.conftest import config
 from tests.system.general.conftest import desktop_version
 
@@ -44,7 +45,7 @@ class TestClass:
     def test_01_assign_model_resolution(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 200
-        o = self.aedtapp.modeler.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "inner")
+        o = self.aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "inner")
         mr1 = self.aedtapp.mesh.assign_model_resolution(o, 1e-4, "ModelRes1")
         assert mr1.name in self.aedtapp.odesign.GetChildObject("Mesh").GetChildNames()
         mr1.name = "resolution_test"
@@ -65,7 +66,7 @@ class TestClass:
         mr1.auto_update = True
         mr1.props["UseAutoLength"] = True
         assert self.aedtapp.odesign.GetChildObject("Mesh").GetChildObject(mr1.name).GetPropValue("Use Auto Simplify")
-        o2 = self.aedtapp.modeler.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "inner")
+        o2 = self.aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "inner")
         mr1.props["Objects"] = [o2.name, o]
         if desktop_version >= "2023.1":
             assert len(self.aedtapp.mesh.omeshmodule.GetMeshOpAssignment(mr1.name)) == 2
@@ -76,7 +77,7 @@ class TestClass:
     def test_02_assign_surface_mesh(self):
         udp = self.aedtapp.modeler.Position(10, 10, 0)
         coax_dimension = 200
-        o = self.aedtapp.modeler.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "surface")
+        o = self.aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "surface")
         surface = self.aedtapp.mesh.assign_surface_mesh(o.id, 3, "Surface")
         assert "Surface" in [i.name for i in self.aedtapp.mesh.meshoperations]
         assert surface.props["SliderMeshSettings"] == 3
@@ -84,7 +85,7 @@ class TestClass:
     def test_03_assign_surface_mesh_manual(self):
         udp = self.aedtapp.modeler.Position(20, 20, 0)
         coax_dimension = 200
-        o = self.aedtapp.modeler.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "surface_manual")
+        o = self.aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "surface_manual")
         surface = self.aedtapp.mesh.assign_surface_mesh_manual(o.id, 1e-6, aspect_ratio=3, name="Surface_Manual")
         assert "Surface_Manual" in [i.name for i in self.aedtapp.mesh.meshoperations]
         assert surface.props["SurfDev"] == 1e-6
@@ -100,9 +101,7 @@ class TestClass:
             == "20"
         )
 
-        cylinder_zx = self.aedtapp.modeler.create_cylinder(
-            self.aedtapp.PLANE.ZX, udp, 3, coax_dimension, 0, "surface_manual"
-        )
+        cylinder_zx = self.aedtapp.modeler.create_cylinder(Plane.ZX, udp, 3, coax_dimension, 0, "surface_manual")
         surface_default_value = self.aedtapp.mesh.assign_surface_mesh_manual(cylinder_zx.id)
         assert surface_default_value.name in [i.name for i in self.aedtapp.mesh.meshoperations]
         assert surface_default_value.props["SurfDevChoice"] == 0

--- a/tests/system/general/test_08_Primitives3D.py
+++ b/tests/system/general/test_08_Primitives3D.py
@@ -30,7 +30,8 @@ import pytest
 
 from ansys.aedt.core import Icepak
 from ansys.aedt.core import Q2d
-from ansys.aedt.core.generic.constants import AXIS
+from ansys.aedt.core.generic.constants import Axis
+from ansys.aedt.core.generic.constants import Plane
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.settings import is_linux
 from ansys.aedt.core.modeler.cad.components_3d import UserDefinedComponent
@@ -143,7 +144,7 @@ class TestClass:
             name = "MyRectangle"
         if self.aedtapp.modeler[name]:
             self.aedtapp.modeler.delete(name)
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         return self.aedtapp.modeler.create_rectangle(plane, [5, 3, 8], [4, 5], name=name)
 
     def create_copper_torus(self, name=None):
@@ -216,7 +217,7 @@ class TestClass:
         assert o1.solve_inside
 
         o2 = self.aedtapp.modeler.create_polyhedron(
-            orientation=AXIS.Z,
+            orientation=Axis.Z,
             center=[0, 0, 0],
             origin=[0, 1, 0],
             height=2.0,
@@ -235,7 +236,7 @@ class TestClass:
         assert len(self.aedtapp.modeler.object_names) == len(self.aedtapp.modeler.objects)
 
         assert not self.aedtapp.modeler.create_polyhedron(
-            orientation=AXIS.Z,
+            orientation=Axis.Z,
             center=[0, 0],
             origin=[0, 1, 0],
             height=2.0,
@@ -245,7 +246,7 @@ class TestClass:
         )
 
         assert not self.aedtapp.modeler.create_polyhedron(
-            orientation=AXIS.Z,
+            orientation=Axis.Z,
             center=[0, 0, 0],
             origin=[0, 1],
             height=2.0,
@@ -255,7 +256,7 @@ class TestClass:
         )
 
         assert not self.aedtapp.modeler.create_polyhedron(
-            orientation=AXIS.Z,
+            orientation=Axis.Z,
             center=[0, 0, 0],
             origin=[0, 0, 0],
             height=2.0,
@@ -323,7 +324,7 @@ class TestClass:
 
     def test_13_create_circle(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         o = self.aedtapp.modeler.create_circle(plane, udp, 2, name="MyCircle", material="Copper")
         assert o.id > 0
         assert o.name.startswith("MyCircle")
@@ -344,7 +345,7 @@ class TestClass:
 
     def test_15_create_cylinder(self):
         udp = self.aedtapp.modeler.Position(20, 20, 0)
-        axis = self.aedtapp.AXIS.Y
+        axis = self.aedtapp.Axis.Y
         radius = 5
         height = 50
         o = self.aedtapp.modeler.create_cylinder(axis, udp, radius, height, 8, "MyCyl", "Copper")
@@ -357,7 +358,7 @@ class TestClass:
 
     def test_16_create_ellipse(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         o1 = self.aedtapp.modeler.create_ellipse(plane, udp, 5, 1.5, True, name="MyEllpise01", material="Copper")
         assert o1.id > 0
         assert o1.name.startswith("MyEllpise01")
@@ -467,9 +468,9 @@ class TestClass:
         path1 = self.aedtapp.modeler.create_polyline(arrofpos, name="poly_vector1")
         path2 = self.aedtapp.modeler.create_polyline(arrofpos, name="poly_vector2")
 
-        rect1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, -2, -4], [4, 3], name="rect_1")
-        rect2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, -2, 2], [4, 3], name="rect_2")
-        rect3 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, -2, 8], [4, 3], name="rect_3")
+        rect1 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, -2, -4], [4, 3], name="rect_1")
+        rect2 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, -2, 2], [4, 3], name="rect_2")
+        rect3 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, -2, 8], [4, 3], name="rect_3")
         assert self.aedtapp.modeler.sweep_along_path(rect1, path1)
         assert self.aedtapp.modeler.sweep_along_path([rect2, rect3], path2)
         assert rect1.name in self.aedtapp.modeler.solid_names
@@ -477,9 +478,9 @@ class TestClass:
         assert rect3.name in self.aedtapp.modeler.solid_names
 
     def test_22_sweep_along_vector(self):
-        rect1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, -2, -2], [4, 3], name="rect_1")
-        rect2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, -2, 2], [4, 3], name="rect_2")
-        rect3 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, -2, 4], [4, 3], name="rect_3")
+        rect1 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, -2, -2], [4, 3], name="rect_1")
+        rect2 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, -2, 2], [4, 3], name="rect_2")
+        rect3 = self.aedtapp.modeler.create_rectangle(Plane.YZ, [0, -2, 4], [4, 3], name="rect_3")
         assert self.aedtapp.modeler.sweep_along_vector(rect1, [10, 20, 20])
         assert self.aedtapp.modeler.sweep_along_vector([rect2, rect3], [10, 20, 20])
         assert rect1.name in self.aedtapp.modeler.solid_names
@@ -488,7 +489,7 @@ class TestClass:
 
     def test_23_create_rectangle(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         o = self.aedtapp.modeler.create_rectangle(plane, udp, [4, 5], name="MyRectangle", material="Copper")
         assert o.id > 0
         assert o.name.startswith("MyRectangle")
@@ -498,7 +499,7 @@ class TestClass:
 
     def test_24_create_cone(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
-        axis = self.aedtapp.AXIS.Z
+        axis = self.aedtapp.Axis.Z
         o = self.aedtapp.modeler.create_cone(axis, udp, 20, 10, 5, name="MyCone", material="Copper")
         assert o.id > 0
         assert o.name.startswith("MyCone")
@@ -511,7 +512,7 @@ class TestClass:
 
     def test_25_get_object_id(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         o = self.aedtapp.modeler.create_rectangle(plane, udp, [4, 5], name="MyRectangle5")
         assert (
             self.aedtapp.modeler.get_obj_id(
@@ -611,7 +612,7 @@ class TestClass:
         assert "MyRectangle" not in self.aedtapp.modeler.object_names
 
     def test_32_get_face_vertices(self):
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         self.aedtapp.modeler.create_rectangle(plane, [1, 2, 3], [7, 13], name="rect_for_get")
         listfaces = self.aedtapp.modeler.get_object_faces("rect_for_get")
         vertices = self.aedtapp.modeler.get_face_vertices(listfaces[0])
@@ -639,7 +640,7 @@ class TestClass:
 
     @pytest.mark.skipif(config["desktopVersion"] < "2023.1" and config["use_grpc"], reason="Not working in 2022.2 gRPC")
     def test_36_get_face_center(self):
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         self.aedtapp.modeler.create_rectangle(plane, [1, 2, 3], [7, 13], name="rect_for_get2")
         listfaces = self.aedtapp.modeler.get_object_faces("rect_for_get2")
         center = self.aedtapp.modeler.get_face_center(listfaces[0])
@@ -666,7 +667,7 @@ class TestClass:
         spherename = self.aedtapp.modeler.get_bodynames_from_position(center)
         assert "fred" in spherename
 
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         self.aedtapp.modeler.create_rectangle(plane, [-50, -50, -50], [2, 2], name="bob")
         rectname = self.aedtapp.modeler.get_bodynames_from_position([-49.0, -49.0, -50.0])
         assert "bob" in rectname
@@ -712,7 +713,7 @@ class TestClass:
 
     def test_41c_get_edges_for_circuit_port(self):
         udp = self.aedtapp.modeler.Position(0, 0, 8)
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         o = self.aedtapp.modeler.create_rectangle(plane, udp, [3, 10], name="MyGND", material="Copper")
         face_id = o.faces[0].id
         self.aedtapp.modeler.get_edges_for_circuit_port(
@@ -2099,14 +2100,14 @@ class TestClass:
     def test_97_uncover_faces(self):
         o1 = self.aedtapp.modeler.create_circle(cs_plane=0, position=[0, 0, 0], radius=10)
         assert self.aedtapp.modeler.uncover_faces([o1.faces[0]])
-        c1 = self.aedtapp.modeler.create_circle(orientation=AXIS.X, origin=[0, 10, 20], radius="3", name="Circle1")
+        c1 = self.aedtapp.modeler.create_circle(orientation=Axis.X, origin=[0, 10, 20], radius="3", name="Circle1")
         b1 = self.aedtapp.modeler.create_box(origin=[-13.9, 0, 0], sizes=[27.8, -40, 25.4], name="Box1")
         assert self.aedtapp.modeler.uncover_faces([c1.faces[0], b1.faces[0], b1.faces[2]])
         assert len(b1.faces) == 4
-        c2 = self.aedtapp.modeler.create_circle(orientation=AXIS.X, origin=[0, 10, 20], radius="3", name="Circle2")
+        c2 = self.aedtapp.modeler.create_circle(orientation=Axis.X, origin=[0, 10, 20], radius="3", name="Circle2")
         b2 = self.aedtapp.modeler.create_box(origin=[-13.9, 0, 0], sizes=[27.8, -40, 25.4], name="Box2")
         assert self.aedtapp.modeler.uncover_faces([c2.faces, b2.faces])
-        c3 = self.aedtapp.modeler.create_circle(orientation=AXIS.X, origin=[0, 10, 20], radius="3", name="Circle3")
+        c3 = self.aedtapp.modeler.create_circle(orientation=Axis.X, origin=[0, 10, 20], radius="3", name="Circle3")
         b3 = self.aedtapp.modeler.create_box(origin=[-13.9, 0, 0], sizes=[27.8, -40, 25.4], name="Box3")
         assert self.aedtapp.modeler.uncover_faces([c3.faces[0], b3.faces])
         assert len(b3.faces) == 0

--- a/tests/system/general/test_11_Setup.py
+++ b/tests/system/general/test_11_Setup.py
@@ -27,6 +27,7 @@ import os
 import pytest
 
 from ansys.aedt.core import Circuit
+from ansys.aedt.core.generic.constants import Setups
 from tests.system.general.conftest import desktop_version
 
 test_subfolder = "T11"
@@ -49,7 +50,7 @@ class TestClass:
         self.local_scratch = local_scratch
 
     def test_01_create_hfss_setup(self):
-        setup1 = self.aedtapp.create_setup("My_HFSS_Setup", self.aedtapp.SETUPS.HFSSDrivenDefault)
+        setup1 = self.aedtapp.create_setup("My_HFSS_Setup", Setups.HFSSDrivenDefault)
         assert setup1.name == "My_HFSS_Setup"
         assert self.aedtapp.setups[0].name == setup1.name
         assert "SaveRadFieldsOnly" in setup1.props
@@ -160,7 +161,7 @@ class TestClass:
 
     def test_02_create_circuit_setup(self):
         circuit = Circuit(version=desktop_version)
-        setup1 = circuit.create_setup("circuit", self.aedtapp.SETUPS.NexximLNA)
+        setup1 = circuit.create_setup("circuit", Setups.NexximLNA)
         assert setup1.name == "circuit"
         setup1.props["SweepDefinition"]["Data"] = "LINC 0GHz 4GHz 501"
         setup1["SaveRadFieldsonly"] = True
@@ -175,7 +176,7 @@ class TestClass:
     def test_03_non_valid_setup(self):
         self.aedtapp.set_active_design("HFSSDesign")
         self.aedtapp.duplicate_design("non_valid")
-        setup1 = self.aedtapp.create_setup("My_HFSS_Setup2", self.aedtapp.SETUPS.HFSSDrivenAuto)
+        setup1 = self.aedtapp.create_setup("My_HFSS_Setup2", Setups.HFSSDrivenAuto)
         assert not setup1.enable_adaptive_setup_multifrequency([1, 2, 3])
         assert not setup1.enable_adaptive_setup_broadband(1, 2.5, 10, 0.01)
         assert not setup1.enable_adaptive_setup_single(3.5)
@@ -188,7 +189,7 @@ class TestClass:
 
     def test_04_delete_setup(self):
         self.aedtapp.insert_design("delete_setups")
-        setup1 = self.aedtapp.create_setup("My_HFSS_Setup2", self.aedtapp.SETUPS.HFSSDrivenAuto)
+        setup1 = self.aedtapp.create_setup("My_HFSS_Setup2", Setups.HFSSDrivenAuto)
         assert len(self.aedtapp.setups) == 1
         assert setup1.delete()
         assert len(self.aedtapp.setups) == 0
@@ -196,12 +197,12 @@ class TestClass:
 
     def test_05_sweep_auto(self):
         self.aedtapp.insert_design("sweep")
-        setup1 = self.aedtapp.create_setup("My_HFSS_Setup4", self.aedtapp.SETUPS.HFSSDrivenAuto)
+        setup1 = self.aedtapp.create_setup("My_HFSS_Setup4", Setups.HFSSDrivenAuto)
         assert setup1.add_subrange("LinearStep", 1, 10, 0.1, clear=False)
         assert setup1.add_subrange("LinearCount", 10, 20, 10, clear=True)
 
     def test_05a_delete_sweep(self):
-        setup1 = self.aedtapp.create_setup("My_HFSS_Setup5", self.aedtapp.SETUPS.HFSSDrivenDefault)
+        setup1 = self.aedtapp.create_setup("My_HFSS_Setup5", Setups.HFSSDrivenDefault)
         setup1.create_frequency_sweep("GHz", 24, 24.25, 26, "My_Sweep1", sweep_type="Fast")
         sweeps = setup1.get_sweep_names()
         assert len(sweeps) == 1
@@ -214,7 +215,7 @@ class TestClass:
         self.aedtapp.insert_design("sweepsbr")
         self.aedtapp.solution_type = "SBR+"
         self.aedtapp.insert_infinite_sphere()
-        setup1 = self.aedtapp.create_setup("My_HFSS_Setup4", self.aedtapp.SETUPS.HFSSSBR)
+        setup1 = self.aedtapp.create_setup("My_HFSS_Setup4", Setups.HFSSSBR)
         assert setup1.add_subrange("LinearStep", 1, 10, 0.1, clear=False)
         assert setup1.add_subrange("LinearCount", 10, 20, 10, clear=True)
 

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -29,6 +29,8 @@ import shutil
 
 import pytest
 
+from ansys.aedt.core.generic.constants import Axis
+from ansys.aedt.core.generic.constants import Plane
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from ansys.aedt.core.visualization.advanced.misc import convert_nearfield_data
 from tests import TESTS_GENERAL_PATH
@@ -92,17 +94,17 @@ class TestClass:
         coax1_origin = self.aedtapp.modeler.Position(0, 0, 0)  # Thru coax origin.
         coax2_origin = self.aedtapp.modeler.Position(125, 0, -coax2_len)  # Perpendicular coax 1.
 
-        inner_1 = self.aedtapp.modeler.create_cylinder(self.aedtapp.AXIS.X, coax1_origin, r1, coax1_len, 0, "inner_1")
+        inner_1 = self.aedtapp.modeler.create_cylinder(Axis.X, coax1_origin, r1, coax1_len, 0, "inner_1")
         assert isinstance(inner_1.id, int)
         inner_2 = self.aedtapp.modeler.create_cylinder(
-            self.aedtapp.AXIS.Z, coax2_origin, r1, coax2_len, 0, "inner_2", material="copper"
+            Axis.Z, coax2_origin, r1, coax2_len, 0, "inner_2", material="copper"
         )
         assert len(inner_2.faces) == 3  # Cylinder has 3 faces.
         # Check area of circular face.
         assert abs(min([f.area for f in inner_2.faces]) - math.pi * r1_sq) < small_number
-        outer_1 = self.aedtapp.modeler.create_cylinder(self.aedtapp.AXIS.X, coax1_origin, r2, coax1_len, 0, "outer_1")
+        outer_1 = self.aedtapp.modeler.create_cylinder(Axis.X, coax1_origin, r2, coax1_len, 0, "outer_1")
         assert isinstance(outer_1.id, int)
-        outer_2 = self.aedtapp.modeler.create_cylinder(self.aedtapp.AXIS.Z, coax2_origin, r2, coax2_len, 0, "outer_2")
+        outer_2 = self.aedtapp.modeler.create_cylinder(Axis.Z, coax2_origin, r2, coax2_len, 0, "outer_2")
 
         # Check the area of the outer surface of the cylinder "outer_2".
         assert abs(max([f.area for f in outer_2.faces]) - 2 * coax2_len * r2 * math.pi) < small_number
@@ -119,7 +121,7 @@ class TestClass:
     def test_03_2_assign_material(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_length = 80
-        cyl_1 = self.aedtapp.modeler.create_cylinder(self.aedtapp.AXIS.X, udp, 10, coax_length, 0, "insulator")
+        cyl_1 = self.aedtapp.modeler.create_cylinder(Axis.X, udp, 10, coax_length, 0, "insulator")
         self.aedtapp.modeler.subtract(cyl_1, "inner_1", keep_originals=True)
         self.aedtapp.modeler["inner_1"].material_name = "Copper"
         cyl_1.material_name = "teflon_based"
@@ -128,7 +130,7 @@ class TestClass:
 
     def test_05_create_wave_port_from_sheets(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
-        o5 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet1")
+        o5 = self.aedtapp.modeler.create_circle(Plane.YZ, udp, 10, name="sheet1")
         self.aedtapp.solution_type = "Terminal"
         outer_1 = self.aedtapp.modeler["outer_1"]
         # TODO: Consider allowing a TEM port to be created.
@@ -153,7 +155,7 @@ class TestClass:
         assert port.props["RenormalizeAllTerminals"] is False
 
         udp = self.aedtapp.modeler.Position(80, 0, 0)
-        o6 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet1a")
+        o6 = self.aedtapp.modeler.create_circle(Plane.YZ, udp, 10, name="sheet1a")
         self.aedtapp.modeler.subtract(o6, "inner_1", keep_originals=True)
 
         self.aedtapp.assign_finite_conductivity(material="aluminum", assignment="inner_1")
@@ -184,7 +186,7 @@ class TestClass:
         self.aedtapp.solution_type = "Modal"
         assert len(self.aedtapp.boundaries) == 4
         udp = self.aedtapp.modeler.Position(200, 0, 0)
-        o6 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet2")
+        o6 = self.aedtapp.modeler.create_circle(Plane.YZ, udp, 10, name="sheet2")
         port = self.aedtapp.wave_port(
             assignment=o6,
             integration_line=self.aedtapp.AxisDir.XPos,
@@ -200,7 +202,7 @@ class TestClass:
 
         self.aedtapp.modeler.create_box([20, 20, 20], [10, 10, 2], name="My_Box", material="Copper")
         self.aedtapp.modeler.create_box([20, 25, 30], [10, 2, 2], material="Copper")
-        rect = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [20, 25, 20], [2, 10])
+        rect = self.aedtapp.modeler.create_rectangle(Plane.YZ, [20, 25, 20], [2, 10])
         port3 = self.aedtapp.wave_port(
             assignment=rect,
             integration_line=self.aedtapp.AxisDir.ZNeg,
@@ -478,7 +480,7 @@ class TestClass:
         )
 
     def test_08_create_circuit_port_from_edges(self):
-        plane = self.aedtapp.PLANE.XY
+        plane = Plane.XY
         rect_1 = self.aedtapp.modeler.create_rectangle(plane, [10, 10, 10], [10, 10], name="rect1_for_port")
         edges1 = self.aedtapp.modeler.get_object_edges(rect_1.id)
         e1 = edges1[0]
@@ -585,7 +587,7 @@ class TestClass:
         )
 
     def test_09a_create_waveport_on_true_surface_objects(self):
-        cs = self.aedtapp.PLANE.XY
+        cs = Plane.XY
         o1 = self.aedtapp.modeler.create_cylinder(
             cs, [0, 0, 0], radius=5, height=100, num_sides=0, name="inner", material="Copper"
         )
@@ -713,9 +715,7 @@ class TestClass:
         assert lumped_rlc2.update()
 
     def test_15_create_perfects_on_sheets(self):
-        rect = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="RectBound", material="Copper"
-        )
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 2], name="RectBound", material="Copper")
         pe = self.aedtapp.assign_perfecte_to_sheets(rect.name)
         assert pe.name in self.aedtapp.modeler.get_boundaries_name()
         ph = self.aedtapp.assign_perfecth_to_sheets(rect.name)
@@ -734,9 +734,7 @@ class TestClass:
         self.aedtapp.solution_type = solution_type
 
     def test_16_a_create_impedance_on_sheets(self):
-        rect = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="ImpBound", material="Copper"
-        )
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 2], name="ImpBound", material="Copper")
         imp1 = self.aedtapp.assign_impedance_to_sheet(rect.name, "TL2", 50, 25)
         assert imp1.name in self.aedtapp.modeler.get_boundaries_name()
         assert imp1.update()
@@ -748,7 +746,7 @@ class TestClass:
         assert imp2.name in self.aedtapp.modeler.get_boundaries_name()
 
         rect2 = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="AniImpBound", material="Copper"
+            Plane.XY, [0, 0, 0], [10, 2], name="AniImpBound", material="Copper"
         )
         with pytest.raises(AEDTRuntimeError, match="Number of elements in resistance and reactance must be four."):
             self.aedtapp.assign_impedance_to_sheet(rect2.name, "TL3", [50, 20, 0, 0], [25, 0, 5])
@@ -760,25 +758,19 @@ class TestClass:
 
     def test_16_b_create_impedance_on_sheets_eigenmode(self, add_app):
         aedtapp = add_app(solution_type="Eigenmode", project_name="test_16_b")
-        rect = aedtapp.modeler.create_rectangle(
-            aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="ImpBound", material="Copper"
-        )
+        rect = aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 2], name="ImpBound", material="Copper")
         imp1 = aedtapp.assign_impedance_to_sheet(rect.name, "TL2", 50, 25)
         assert imp1.name in aedtapp.modeler.get_boundaries_name()
 
     def test_17_create_lumpedrlc_on_sheets(self):
-        rect = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="rlcBound", material="Copper"
-        )
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 2], name="rlcBound", material="Copper")
         imp = self.aedtapp.assign_lumped_rlc_to_sheet(
             rect.name, self.aedtapp.AxisDir.XPos, resistance=50, inductance=1e-9
         )
         self.aedtapp.modeler.get_boundaries_name()
         assert imp.name in self.aedtapp.modeler.get_boundaries_name()
 
-        self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [0, 0, 10], [10, 2], name="rlcBound2", material="Copper"
-        )
+        self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 10], [10, 2], name="rlcBound2", material="Copper")
         imp = self.aedtapp.assign_lumped_rlc_to_sheet(
             rect.name, self.aedtapp.AxisDir.XPos, rlc_type="Serial", resistance=50, inductance=1e-9
         )
@@ -807,9 +799,7 @@ class TestClass:
         assert port.name in self.aedtapp.excitation_names
 
     def test_19_create_lumped_on_sheet(self):
-        rect = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="lump_port", material="Copper"
-        )
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 2], name="lump_port", material="Copper")
         port = self.aedtapp.lumped_port(
             assignment=rect.name,
             create_port_sheet=False,
@@ -854,9 +844,7 @@ class TestClass:
             )
 
     def test_20_create_voltage_on_sheet(self):
-        rect = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="lump_volt", material="Copper"
-        )
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 2], name="lump_volt", material="Copper")
         port = self.aedtapp.assign_voltage_source_to_sheet(rect.name, self.aedtapp.AxisDir.XNeg, "LumpVolt1")
         assert port.name in self.aedtapp.excitation_names
         assert self.aedtapp.get_property_value("BoundarySetup:LumpVolt1", "VoltageMag", "Excitation") == "1V"
@@ -973,9 +961,7 @@ class TestClass:
         )
 
     def test_32_get_property_value(self):
-        rect = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="RectProp", material="Copper"
-        )
+        rect = self.aedtapp.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 2], name="RectProp", material="Copper")
         self.aedtapp.assign_perfecte_to_sheets(rect.name, "PerfectE_1")
         setup = self.aedtapp.create_setup("MySetup2")
         setup.props["Frequency"] = "1GHz"
@@ -1022,7 +1008,7 @@ class TestClass:
 
     def test_40_assign_current_source_to_sheet(self):
         sheet = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [0, 0, 0], [5, 1], name="RectangleForSource", material="Copper"
+            Plane.XY, [0, 0, 0], [5, 1], name="RectangleForSource", material="Copper"
         )
         assert self.aedtapp.assign_current_source_to_sheet(sheet.name)
         assert self.aedtapp.assign_current_source_to_sheet(
@@ -1049,7 +1035,7 @@ class TestClass:
             box1.faces[1], modes=7, deembed_distance=1, reporter_filter=[False, True, False, False, False, False, False]
         )
         sheet = self.aedtapp.modeler.create_rectangle(
-            self.aedtapp.PLANE.XY, [-100, -100, -100], [200, 200], name="RectangleForSource", material="Copper"
+            Plane.XY, [-100, -100, -100], [200, 200], name="RectangleForSource", material="Copper"
         )
         bound = self.aedtapp.create_floquet_port(sheet, modes=4, deembed_distance=1, reporter_filter=False)
         assert bound
@@ -1128,7 +1114,7 @@ class TestClass:
         self.aedtapp.solution_type = "Terminal"
         box1 = self.aedtapp.modeler.create_box([-100, -100, 0], [200, 200, 5], name="gnd", material="copper")
         box2 = self.aedtapp.modeler.create_box([-100, -100, 20], [200, 200, 25], name="sig", material="copper")
-        sheet = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [-100, -100, 5], [200, 15], "port")
+        sheet = self.aedtapp.modeler.create_rectangle(Plane.YZ, [-100, -100, 5], [200, 15], "port")
         self.aedtapp.lumped_port(
             assignment=box1,
             reference=box2.name,
@@ -1336,8 +1322,8 @@ class TestClass:
         aedtapp = add_app(project_name="test_52")
         udp = aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 200
-        aedtapp.modeler.create_cylinder(aedtapp.AXIS.X, udp, 3, coax_dimension, 0, "inner")
-        aedtapp.modeler.create_cylinder(aedtapp.AXIS.X, udp, 10, coax_dimension, 0, "outer")
+        aedtapp.modeler.create_cylinder(Axis.X, udp, 3, coax_dimension, 0, "inner")
+        aedtapp.modeler.create_cylinder(Axis.X, udp, 10, coax_dimension, 0, "outer")
         aedtapp.hybrid = True
         assert aedtapp.assign_hybrid_region(["inner"])
         bound = aedtapp.assign_hybrid_region("outer", name="new_hybrid", hybrid_region="IE")
@@ -1700,8 +1686,8 @@ class TestClass:
         aedtapp = add_app(project_name="test_66")
         udp = aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 200
-        aedtapp.modeler.create_cylinder(aedtapp.AXIS.X, udp, 3, coax_dimension, 0, "inner")
-        aedtapp.modeler.create_cylinder(aedtapp.AXIS.X, udp, 10, coax_dimension, 0, "outer")
+        aedtapp.modeler.create_cylinder(Axis.X, udp, 3, coax_dimension, 0, "inner")
+        aedtapp.modeler.create_cylinder(Axis.X, udp, 10, coax_dimension, 0, "outer")
         aedtapp.hybrid = True
         assert aedtapp.assign_febi(["inner"])
         assert len(aedtapp.boundaries) == 1

--- a/tests/system/general/test_21_Circuit.py
+++ b/tests/system/general/test_21_Circuit.py
@@ -29,6 +29,7 @@ import pytest
 
 from ansys.aedt.core import Circuit
 from ansys.aedt.core import generate_unique_name
+from ansys.aedt.core.generic.constants import Setups
 from ansys.aedt.core.generic.settings import is_linux
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from tests import TESTS_GENERAL_PATH
@@ -521,7 +522,7 @@ class TestClass:
         aedtapp.modeler.components.create_interface_port("net_0", (0, 0))
         aedtapp.modeler.components.create_interface_port("net_10", (0.01, 0))
 
-        lna = aedtapp.create_setup("mylna", aedtapp.SETUPS.NexximLNA)
+        lna = aedtapp.create_setup("mylna", Setups.NexximLNA)
         lna.props["SweepDefinition"]["Data"] = "LINC 0Hz 1GHz 101"
         assert aedtapp.analyze()
 
@@ -540,7 +541,7 @@ class TestClass:
                 f.write(f"C{i} net_{i + 1} 0 5e-12\n")
         aedtapp.modeler.components.create_interface_port("net_0", (0, 0), angle=90)
         aedtapp.modeler.components.create_interface_port("net_10", (0.01, 0))
-        lna = aedtapp.create_setup("mylna", aedtapp.SETUPS.NexximLNA)
+        lna = aedtapp.create_setup("mylna", Setups.NexximLNA)
         lna.props["SweepDefinition"]["Data"] = "LINC 0Hz 1GHz 101"
         assert not aedtapp.browse_log_file()
         aedtapp.analyze()

--- a/tests/system/general/test_27_Maxwell2D.py
+++ b/tests/system/general/test_27_Maxwell2D.py
@@ -30,7 +30,7 @@ import shutil
 import pytest
 
 import ansys.aedt.core
-from ansys.aedt.core.generic.constants import SOLUTIONS
+from ansys.aedt.core.generic.constants import SolutionsMaxwell2D
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from tests import TESTS_GENERAL_PATH
 from tests.system.general.conftest import config
@@ -271,7 +271,7 @@ class TestClass:
         assert bound.props["InductanceValue"] == "5H"
         with pytest.raises(AEDTRuntimeError, match="At least 2 objects are needed."):
             aedtapp.assign_end_connection([rect])
-        aedtapp.solution_type = SOLUTIONS.Maxwell2d.MagnetostaticXY
+        aedtapp.solution_type = SolutionsMaxwell2D.MagnetostaticXY
         with pytest.raises(AEDTRuntimeError):
             aedtapp.assign_end_connection([rect, rect2])
 
@@ -434,7 +434,7 @@ class TestClass:
         )
         invalid_ctrl_prg_path = os.path.join(TESTS_GENERAL_PATH, "example_models", test_subfolder, "invalid.py")
         assert not m2d_ctrl_prg.setups[0].enable_control_program(control_program_path=invalid_ctrl_prg_path)
-        m2d_ctrl_prg.solution_type = SOLUTIONS.Maxwell2d.EddyCurrentXY
+        m2d_ctrl_prg.solution_type = SolutionsMaxwell2D.EddyCurrentXY
         assert not m2d_ctrl_prg.setups[0].enable_control_program(control_program_path=ctrl_prg_path)
         if os.path.exists(user_ctl_path):
             os.unlink(user_ctl_path)
@@ -449,14 +449,14 @@ class TestClass:
         assert not m2d_app.import_dxf(dxf_file, dxf_layers)
 
     def test_assign_floating(self, m2d_app):
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.ElectroStaticXY
+        m2d_app.solution_type = SolutionsMaxwell2D.ElectroStaticXY
         rect = m2d_app.modeler.create_rectangle([0, 0, 0], [3, 1])
         floating = m2d_app.assign_floating(assignment=rect, charge_value=3, name="floating_test")
         assert floating
         assert floating.name == "floating_test"
         assert floating.props["Objects"][0] == rect.name
         assert floating.props["Value"] == "3"
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.MagnetostaticXY
+        m2d_app.solution_type = SolutionsMaxwell2D.MagnetostaticXY
         with pytest.raises(
             AEDTRuntimeError,
             match="Assign floating excitation is only valid for electrostatic or electric transient solvers.",
@@ -464,7 +464,7 @@ class TestClass:
             m2d_app.assign_floating(assignment=rect, charge_value=3, name="floating_test1")
 
     def test_matrix(self, m2d_app):
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.MagnetostaticXY
+        m2d_app.solution_type = SolutionsMaxwell2D.MagnetostaticXY
         m2d_app.modeler.create_rectangle([0, 1.5, 0], [8, 3], is_covered=True, name="Coil_1", material="vacuum")
         m2d_app.modeler.create_rectangle([8.5, 1.5, 0], [8, 3], is_covered=True, name="Coil_2", material="vacuum")
         m2d_app.modeler.create_rectangle([16, 1.5, 0], [8, 3], is_covered=True, name="Coil_3", material="vacuum")
@@ -551,57 +551,57 @@ class TestClass:
             assert val["ReturnPath"] == "infinite"
 
     def test_solution_types_setup(self, m2d_app):
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.TransientXY
+        m2d_app.solution_type = SolutionsMaxwell2D.TransientXY
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.TransientZ
+        m2d_app.solution_type = SolutionsMaxwell2D.TransientZ
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.MagnetostaticXY
+        m2d_app.solution_type = SolutionsMaxwell2D.MagnetostaticXY
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.MagnetostaticZ
+        m2d_app.solution_type = SolutionsMaxwell2D.MagnetostaticZ
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.EddyCurrentXY
+        m2d_app.solution_type = SolutionsMaxwell2D.EddyCurrentXY
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.EddyCurrentZ
+        m2d_app.solution_type = SolutionsMaxwell2D.EddyCurrentZ
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.ElectroStaticXY
+        m2d_app.solution_type = SolutionsMaxwell2D.ElectroStaticXY
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.ElectroStaticZ
+        m2d_app.solution_type = SolutionsMaxwell2D.ElectroStaticZ
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.DCConductionXY
+        m2d_app.solution_type = SolutionsMaxwell2D.DCConductionXY
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.DCConductionZ
+        m2d_app.solution_type = SolutionsMaxwell2D.DCConductionZ
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.ACConductionXY
+        m2d_app.solution_type = SolutionsMaxwell2D.ACConductionXY
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.ACConductionZ
+        m2d_app.solution_type = SolutionsMaxwell2D.ACConductionZ
         setup = m2d_app.create_setup(setup_type=m2d_app.solution_type)
         assert setup
         setup.delete()
 
     def test_create_external_circuit(self, local_scratch, m2d_app):
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.EddyCurrentXY
+        m2d_app.solution_type = SolutionsMaxwell2D.EddyCurrentXY
         m2d_app.modeler.create_circle([0, 0, 0], 10, name="Coil1")
         m2d_app.modeler.create_circle([20, 0, 0], 10, name="Coil2")
 
@@ -613,10 +613,10 @@ class TestClass:
 
         assert m2d_app.create_external_circuit()
         assert m2d_app.create_external_circuit(circuit_design="test_cir")
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.MagnetostaticXY
+        m2d_app.solution_type = SolutionsMaxwell2D.MagnetostaticXY
         with pytest.raises(AEDTRuntimeError):
             m2d_app.create_external_circuit()
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.EddyCurrentXY
+        m2d_app.solution_type = SolutionsMaxwell2D.EddyCurrentXY
         for w in m2d_app.excitations_by_type["Winding"]:
             w.delete()
         m2d_app.save_project()
@@ -627,7 +627,7 @@ class TestClass:
             m2d_app.create_external_circuit()
 
     def test_assign_voltage(self, local_scratch, m2d_app):
-        m2d_app.solution_type = SOLUTIONS.Maxwell2d.ElectroStaticZ
+        m2d_app.solution_type = SolutionsMaxwell2D.ElectroStaticZ
 
         region_id = m2d_app.modeler.create_region(pad_value=[500, 50, 50])
         v1 = m2d_app.assign_voltage(assignment=region_id, amplitude=0, name="GRD1")
@@ -682,7 +682,7 @@ class TestClass:
         assert setup.set_save_fields(enable=False)
         assert not setup.set_save_fields(enable=True, range_type="invalid")
 
-        m2d_setup.solution_type = SOLUTIONS.Maxwell2d.MagnetostaticXY
+        m2d_setup.solution_type = SolutionsMaxwell2D.MagnetostaticXY
 
         setup = m2d_setup.create_setup()
         assert setup.set_save_fields(enable=True)

--- a/tests/system/general/test_28_Maxwell3D.py
+++ b/tests/system/general/test_28_Maxwell3D.py
@@ -29,7 +29,9 @@ import shutil
 import pytest
 
 from ansys.aedt.core import Maxwell3d
-from ansys.aedt.core.generic.constants import SOLUTIONS
+from ansys.aedt.core.generic.constants import Axis
+from ansys.aedt.core.generic.constants import Plane
+from ansys.aedt.core.generic.constants import SolutionsMaxwell3D
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
@@ -112,7 +114,7 @@ class TestClass:
         coil = m3d_app.modeler.create_box([-100, -100, 0], [200, 200, 100], name="Coil")
         m3d_app.modeler.subtract([coil], [coil_hole])
 
-        m3d_app.modeler.section(["Coil"], m3d_app.PLANE.ZX)
+        m3d_app.modeler.section(["Coil"], Plane.ZX)
         m3d_app.modeler.separate_bodies(["Coil_Section1"])
         face_id = m3d_app.modeler["Coil_Section1"].faces[0].id
         assert m3d_app.assign_winding(face_id)
@@ -134,7 +136,7 @@ class TestClass:
         coil_hole = m3d_app.modeler.create_box([-50, -50, 0], [100, 100, 100], name="Coil_Hole")
         coil = m3d_app.modeler.create_box([-100, -100, 0], [200, 200, 100], name="Coil")
         m3d_app.modeler.subtract([coil], [coil_hole])
-        m3d_app.modeler.section(["Coil"], m3d_app.PLANE.ZX)
+        m3d_app.modeler.section(["Coil"], Plane.ZX)
         m3d_app.modeler.separate_bodies(["Coil_Section1"])
         face_id = m3d_app.modeler["Coil_Section1"].faces[0].id
         bound = m3d_app.assign_coil(assignment=face_id)
@@ -155,7 +157,7 @@ class TestClass:
         assert region.material_name == "air"
 
     def test_eddy_effects_on(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
         plate_vacuum = m3d_app.modeler.create_box([-3, -3, 0], [1.5, 1.5, 0.4], name="Plate_vaccum")
         with pytest.raises(AEDTRuntimeError, match="No conductors defined in active design."):
             m3d_app.eddy_effects_on(plate_vacuum, enable_eddy_effects=True)
@@ -380,7 +382,7 @@ class TestClass:
         assert not force.props["Is Virtual"]
 
     def test_assign_translate_motion(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Transient
+        m3d_app.solution_type = SolutionsMaxwell3D.Transient
         m3d_app.modeler.create_box([0, 0, 0], [10, 10, 10], name="Inner_Box")
         m3d_app.modeler.create_box([0, 0, 0], [30, 20, 20], name="Outer_Box")
         bound = m3d_app.assign_translate_motion("Outer_Box", velocity=1, mechanical_transient=True)
@@ -388,13 +390,13 @@ class TestClass:
         assert bound.props["Velocity"] == "1m_per_sec"
 
     def test_set_core_losses(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
         m3d_app.modeler.create_box([0, 0, 0], [10, 10, 10], name="my_box", material="Material_3F3")
         assert m3d_app.set_core_losses(["my_box"])
         assert m3d_app.set_core_losses(["my_box"], True)
 
     def test_assign_matrix(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.ElectroStatic
+        m3d_app.solution_type = SolutionsMaxwell3D.ElectroStatic
 
         rectangle1 = m3d_app.modeler.create_rectangle(0, [0.5, 1.5, 0], [2.5, 5], name="Sheet1")
         rectangle2 = m3d_app.modeler.create_rectangle(0, [9, 1.5, 0], [2.5, 5], name="Sheet2")
@@ -415,13 +417,13 @@ class TestClass:
         )
         assert matrix.props["MatrixEntry"]["MatrixEntry"][1]["Source"] == "Voltage3"
         assert matrix.props["MatrixEntry"]["MatrixEntry"][1]["NumberOfTurns"] == "1"
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Transient
+        m3d_app.solution_type = SolutionsMaxwell3D.Transient
         m3d_app.assign_winding("Sheet1", name="Current1")
         with pytest.raises(AEDTRuntimeError, match="Solution type does not have matrix parameters"):
             m3d_app.assign_matrix(assignment="Current1")
 
     def test_available_quantities_categories(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.ElectroStatic
+        m3d_app.solution_type = SolutionsMaxwell3D.ElectroStatic
 
         rectangle1 = m3d_app.modeler.create_rectangle(0, [0.5, 1.5, 0], [2.5, 5], name="Sheet1")
 
@@ -438,7 +440,7 @@ class TestClass:
         assert "C" in cat
 
     def test_available_report_quantities(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.ElectroStatic
+        m3d_app.solution_type = SolutionsMaxwell3D.ElectroStatic
 
         rectangle1 = m3d_app.modeler.create_rectangle(0, [0.5, 1.5, 0], [2.5, 5], name="Sheet1")
 
@@ -466,7 +468,7 @@ class TestClass:
         assert matrix.delete()
 
     def test_reduced_matrix(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
 
         m3d_app.modeler.create_box([0, 1.5, 0], [1, 2.5, 5], name="Coil_1", material="aluminum")
         m3d_app.modeler.create_box([8.5, 1.5, 0], [1, 2.5, 5], name="Coil_2", material="aluminum")
@@ -483,11 +485,11 @@ class TestClass:
 
         matrix = m3d_app.assign_matrix(assignment=["Cur1", "Cur2", "Cur3"], matrix_name="Matrix1")
         assert not matrix.reduced_matrices
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Magnetostatic
+        m3d_app.solution_type = SolutionsMaxwell3D.Magnetostatic
         out = matrix.join_series(sources=["Cur1", "Cur2"], matrix_name="ReducedMatrix3")
         assert not out[0]
         assert not out[1]
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
         out = matrix.join_series(sources=["Cur1", "Cur2"], matrix_name="ReducedMatrix1")
         assert matrix.reduced_matrices
         assert matrix.reduced_matrices[0].name == "ReducedMatrix1"
@@ -517,7 +519,7 @@ class TestClass:
         assert m3d_app.mesh.initial_mesh_settings.props
 
     def test_assign_voltage_drop(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Magnetostatic
+        m3d_app.solution_type = SolutionsMaxwell3D.Magnetostatic
 
         circle = m3d_app.modeler.create_circle(position=[10, 10, 0], radius=5, cs_plane="XY")
         v_drop = m3d_app.assign_voltage_drop([circle.faces[0]])
@@ -576,7 +578,7 @@ class TestClass:
         assert bound.props["CoordinateSystem Name"] == "Global"
         assert bound.props["CoordinateSystem Type"] == "Cartesian"
 
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
         bound = m3d_app.assign_current_density(
             box.name, "current_density_1", "40deg", current_density_x="3", current_density_y="4"
         )
@@ -610,12 +612,12 @@ class TestClass:
         with pytest.raises(AEDTRuntimeError):
             m3d_app.assign_current_density_terminal(box.faces[0], density_name)
         assert m3d_app.assign_current_density_terminal([box.faces[0], box.faces[1]], "current_density_t_2")
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Transient
+        m3d_app.solution_type = SolutionsMaxwell3D.Transient
         with pytest.raises(AEDTRuntimeError):
             m3d_app.assign_current_density_terminal(box.faces[0], "current_density_t_3")
 
     def test_assign_impedance(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Transient
+        m3d_app.solution_type = SolutionsMaxwell3D.Transient
 
         impedance_box = m3d_app.modeler.create_box([-50, -50, -50], [294, 294, 19], name="impedance_box")
         assert m3d_app.assign_impedance(impedance_box.faces, "copper")
@@ -726,7 +728,7 @@ class TestClass:
             )
 
     def test_add_mesh_link(self, m3d_app, local_scratch):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Transient
+        m3d_app.solution_type = SolutionsMaxwell3D.Transient
         m3d_app.create_setup()
         m3d_app.duplicate_design(m3d_app.design_name)
         m3d_app.set_active_design(m3d_app.design_list[1])
@@ -755,8 +757,8 @@ class TestClass:
         assert m3d_app.variable_manager.design_variables["var_test"].expression == "234"
 
     def test_cylindrical_gap(self, m3d_app):
-        inner_cylinder = m3d_app.modeler.create_cylinder(m3d_app.AXIS.Z, [0, 0, 0], 5, 10, 0, "inner")
-        outer_cylinder = m3d_app.modeler.create_cylinder(m3d_app.AXIS.Z, [0, 0, 0], 7, 12, 0, "outer")
+        inner_cylinder = m3d_app.modeler.create_cylinder(Axis.Z, [0, 0, 0], 5, 10, 0, "inner")
+        outer_cylinder = m3d_app.modeler.create_cylinder(Axis.Z, [0, 0, 0], 7, 12, 0, "outer")
         assert m3d_app.mesh.assign_cylindrical_gap(outer_cylinder.name, name="cyl_gap_test")
         assert not m3d_app.mesh.assign_cylindrical_gap([inner_cylinder.name, outer_cylinder.name])
         assert not m3d_app.mesh.assign_cylindrical_gap(outer_cylinder.name)
@@ -782,7 +784,7 @@ class TestClass:
         )
 
     def test_objects_segmentation(self, m3d_app):
-        cylinder = m3d_app.modeler.create_cylinder(m3d_app.AXIS.Z, [0, 0, 0], 5, 10, 0, "cyl")
+        cylinder = m3d_app.modeler.create_cylinder(Axis.Z, [0, 0, 0], 5, 10, 0, "cyl")
         segments_number = 5
         sheets = m3d_app.modeler.objects_segmentation(
             assignment=cylinder, segments=segments_number, apply_mesh_sheets=True
@@ -793,7 +795,7 @@ class TestClass:
         assert isinstance(sheets[0][cylinder.name], list)
         assert len(sheets[0][cylinder.name]) == segments_number - 1
 
-        cylinder = m3d_app.modeler.create_cylinder(m3d_app.AXIS.Z, [1, 0, 0], 5, 10, 0, "cyl")
+        cylinder = m3d_app.modeler.create_cylinder(Axis.Z, [1, 0, 0], 5, 10, 0, "cyl")
         segments_number = 4
         mesh_sheets_number = 3
         sheets = m3d_app.modeler.objects_segmentation(
@@ -805,7 +807,7 @@ class TestClass:
         assert isinstance(sheets[1][cylinder.name], list)
         assert len(sheets[1][cylinder.name]) == mesh_sheets_number
 
-        cylinder = m3d_app.modeler.create_cylinder(m3d_app.AXIS.Z, [2, 0, 0], 5, 10, 0, "cyl")
+        cylinder = m3d_app.modeler.create_cylinder(Axis.Z, [2, 0, 0], 5, 10, 0, "cyl")
         segmentation_thickness = 1
         sheets = m3d_app.modeler.objects_segmentation(
             cylinder, segmentation_thickness=segmentation_thickness, apply_mesh_sheets=True
@@ -822,7 +824,7 @@ class TestClass:
             cylinder.name, segmentation_thickness=segmentation_thickness, segments=segments_number
         )
 
-        cylinder = m3d_app.modeler.create_cylinder(m3d_app.AXIS.Z, [3, 0, 0], 5, 10, 0, "cyl")
+        cylinder = m3d_app.modeler.create_cylinder(Axis.Z, [3, 0, 0], 5, 10, 0, "cyl")
         segments_number = 10
         sheets = m3d_app.modeler.objects_segmentation(cylinder.name, segments=segments_number)
         assert isinstance(sheets, dict)
@@ -849,9 +851,9 @@ class TestClass:
         assert m3d_app.assign_tangential_h_field(box.bottom_face_x, 1, 0, 2, 0)
         rect = m3d_app.modeler.create_rectangle(2, [0, 0, 0], [5, 5])
         assert m3d_app.assign_tangential_h_field(rect.name, 1, 0, 1, 0, u_pos=["5mm", "0mm", "0mm"])
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
         assert m3d_app.assign_tangential_h_field(box.bottom_face_x, 1, 0, 2, 0)
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Transient
+        m3d_app.solution_type = SolutionsMaxwell3D.Transient
         with pytest.raises(AEDTRuntimeError, match="Tangential H Field is applicable only to Eddy Current."):
             m3d_app.assign_tangential_h_field(box.bottom_face_x, 1, 0, 2, 0)
 
@@ -859,7 +861,7 @@ class TestClass:
         box = m3d_app.modeler.create_box([0, 0, 0], [10, 10, 10])
         with pytest.raises(AEDTRuntimeError, match="Tangential H Field is applicable only to Eddy Current."):
             m3d_app.assign_zero_tangential_h_field(box.top_face_z)
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
         assert m3d_app.assign_zero_tangential_h_field(box.top_face_z)
 
     def test_assign_radiation(self, m3d_app):
@@ -869,7 +871,7 @@ class TestClass:
         box2 = m3d_app.modeler.create_box([150, 20, 0], [50, 5, 10], material="aluminum")
         with pytest.raises(AEDTRuntimeError, match="Excitation applicable only to Eddy Current."):
             m3d_app.assign_radiation([rect, rect2, box, box2.faces[0]])
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
         bound = m3d_app.assign_radiation([rect, rect2, box, box2.faces[0]])
         assert bound
         bound2 = m3d_app.assign_radiation([rect, rect2, box, box2.faces[0]], "my_rad")
@@ -881,41 +883,41 @@ class TestClass:
         setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
         assert setup
         setup.delete()
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Transient
+        m3d_app.solution_type = SolutionsMaxwell3D.Transient
         setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
         assert setup
         setup.delete()
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
         setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
         assert setup
         setup.delete()
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.ElectroStatic
+        m3d_app.solution_type = SolutionsMaxwell3D.ElectroStatic
         setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
         assert setup
         setup.delete()
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.DCConduction
+        m3d_app.solution_type = SolutionsMaxwell3D.DCConduction
         setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
         assert setup
         setup.delete()
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.ACConduction
-        setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
-        assert setup
-        setup.delete()
-        if desktop_version < "2025.2":
-            m3d_app.solution_type = SOLUTIONS.Maxwell3d.ElectroDCConduction
-        else:
-            m3d_app.solution_type = SOLUTIONS.Maxwell3d.ElectricDCConduction
-        setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
-        assert setup
-        setup.delete()
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.ElectricTransient
+        m3d_app.solution_type = SolutionsMaxwell3D.ACConduction
         setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
         assert setup
         setup.delete()
         if desktop_version < "2025.2":
-            m3d_app.solution_type = SOLUTIONS.Maxwell3d.TransientAPhiFormulation
+            m3d_app.solution_type = SolutionsMaxwell3D.ElectroDCConduction
         else:
-            m3d_app.solution_type = SOLUTIONS.Maxwell3d.TransientAPhi
+            m3d_app.solution_type = SolutionsMaxwell3D.ElectricDCConduction
+        setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
+        assert setup
+        setup.delete()
+        m3d_app.solution_type = SolutionsMaxwell3D.ElectricTransient
+        setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
+        assert setup
+        setup.delete()
+        if desktop_version < "2025.2":
+            m3d_app.solution_type = SolutionsMaxwell3D.TransientAPhiFormulation
+        else:
+            m3d_app.solution_type = SolutionsMaxwell3D.TransientAPhi
         setup = m3d_app.create_setup(setup_type=m3d_app.solution_type)
         assert setup
         setup.delete()
@@ -927,7 +929,7 @@ class TestClass:
             match="Assign floating excitation is only valid for electrostatic or electric transient solvers.",
         ):
             m3d_app.assign_floating(assignment=box, charge_value=3)
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.ElectroStatic
+        m3d_app.solution_type = SolutionsMaxwell3D.ElectroStatic
         floating = m3d_app.assign_floating(assignment=box, charge_value=3)
         assert floating
         assert floating.props["Objects"][0] == box.name
@@ -936,7 +938,7 @@ class TestClass:
         assert floating1
 
     def test_assign_resistive_sheet(self, m3d_app):
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.EddyCurrent
+        m3d_app.solution_type = SolutionsMaxwell3D.EddyCurrent
         m3d_app.modeler.create_box(origin=[0, 0, 0], sizes=[0.4, -1, 0.8], name="my_box", material="copper")
         my_rectangle = m3d_app.modeler.create_rectangle(
             orientation=1, origin=[0, 0, 0.8], sizes=[-1, 0.4], name="my_rect"
@@ -946,11 +948,11 @@ class TestClass:
         assert bound
         assert bound.props["Faces"][0] == my_rectangle.faces[0].id
         assert bound.props["Resistance"] == "3ohm"
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.Magnetostatic
+        m3d_app.solution_type = SolutionsMaxwell3D.Magnetostatic
         bound = m3d_app.assign_resistive_sheet(assignment=my_rectangle.name, non_linear=True)
         assert bound.props["Nonlinear"]
         assert bound.props["Objects"][0] == my_rectangle.name
-        m3d_app.solution_type = SOLUTIONS.Maxwell3d.ACConduction
+        m3d_app.solution_type = SolutionsMaxwell3D.ACConduction
         with pytest.raises(AEDTRuntimeError):
             m3d_app.assign_resistive_sheet(assignment=my_rectangle, resistance="3ohm")
 

--- a/tests/system/general/test_29_Mechanical.py
+++ b/tests/system/general/test_29_Mechanical.py
@@ -30,6 +30,7 @@ import pytest
 from ansys.aedt.core import Hfss
 from ansys.aedt.core import Icepak
 from ansys.aedt.core import Mechanical
+from ansys.aedt.core.generic.constants import Plane
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 
 
@@ -63,7 +64,7 @@ class TestClass:
     def test_create_primitive(self, aedtapp):
         udp = aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        o = aedtapp.modeler.create_cylinder(aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
+        o = aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
         assert isinstance(o.id, int)
 
     def test_assign_convection(self, aedtapp):
@@ -80,7 +81,7 @@ class TestClass:
     def test_assign_load(self, aedtapp, hfss):
         udp = aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        hfss.modeler.create_cylinder(aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
+        hfss.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
         setup = hfss.create_setup()
         freq = "1GHz"
         setup.props["Frequency"] = freq
@@ -97,12 +98,12 @@ class TestClass:
     def test_assign_thermal_loss(self, aedtapp, ipk):
         udp = aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        ipk.modeler.create_cylinder(ipk.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
+        ipk.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
         ipk.create_setup()
         aedtapp.oproject.InsertDesign("Mechanical", "MechanicalDesign1", "Structural", "")
         aedtapp.set_active_design("MechanicalDesign1")
         aedtapp.create_setup()
-        aedtapp.modeler.create_cylinder(aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
+        aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
         assert aedtapp.assign_thermal_map("MyCylinder", ipk.design_name)
 
     def test_assign_mechanical_boundaries(self, aedtapp):
@@ -110,13 +111,13 @@ class TestClass:
         coax_dimension = 30
         aedtapp.oproject.InsertDesign("Mechanical", "MechanicalDesign2", "Modal", "")
         aedtapp.set_active_design("MechanicalDesign2")
-        aedtapp.modeler.create_cylinder(aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
+        aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
         aedtapp.create_setup()
         assert aedtapp.assign_fixed_support(aedtapp.modeler["MyCylinder"].faces[0].id)
         assert aedtapp.assign_frictionless_support(aedtapp.modeler["MyCylinder"].faces[1].id)
         aedtapp.oproject.InsertDesign("Mechanical", "MechanicalDesign3", "Thermal", "")
         aedtapp.set_active_design("MechanicalDesign3")
-        aedtapp.modeler.create_cylinder(aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
+        aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
         with pytest.raises(AEDTRuntimeError, match="This method works only in a Mechanical Structural analysis."):
             aedtapp.assign_fixed_support(aedtapp.modeler["MyCylinder"].faces[0].id)
         with pytest.raises(AEDTRuntimeError, match="This method works only in a Mechanical Structural analysis."):

--- a/tests/system/general/test_30_Q2D.py
+++ b/tests/system/general/test_30_Q2D.py
@@ -28,6 +28,7 @@ import pytest
 
 import ansys.aedt.core
 from ansys.aedt.core import Q2d
+from ansys.aedt.core.generic.constants import MatrixOperationsQ2D
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from tests import TESTS_GENERAL_PATH
 from tests.system.general.conftest import config
@@ -131,18 +132,18 @@ class TestClass:
         assert q2d.matrices[0].name == "Original"
         assert len(q2d.matrices[0].sources()) > 0
         assert len(q2d.matrices[0].sources(False)) > 0
-        mm = q2d.insert_reduced_matrix(q2d.MATRIXOPERATIONS.Float, "Circle2", "Test1_m")
+        mm = q2d.insert_reduced_matrix(MatrixOperationsQ2D.Float, "Circle2", "Test1_m")
         assert mm.name == "Test1_m"
-        mm = q2d.insert_reduced_matrix(q2d.MATRIXOPERATIONS.AddGround, "Circle2", "Test2_m")
+        mm = q2d.insert_reduced_matrix(MatrixOperationsQ2D.AddGround, "Circle2", "Test2_m")
         assert mm.name == "Test2_m"
-        mm = q2d.insert_reduced_matrix(q2d.MATRIXOPERATIONS.SetReferenceGround, "Circle2", "Test3_m")
+        mm = q2d.insert_reduced_matrix(MatrixOperationsQ2D.SetReferenceGround, "Circle2", "Test3_m")
         assert mm.name == "Test3_m"
-        mm = q2d.insert_reduced_matrix(q2d.MATRIXOPERATIONS.Parallel, ["Circle2", "Circle3"], "Test4_m")
+        mm = q2d.insert_reduced_matrix(MatrixOperationsQ2D.Parallel, ["Circle2", "Circle3"], "Test4_m")
         assert mm.name == "Test4_m"
         mm.delete()
-        mm = q2d.insert_reduced_matrix(q2d.MATRIXOPERATIONS.Parallel, ["Circle2", "Circle3"], "Test4_m", "New_net")
+        mm = q2d.insert_reduced_matrix(MatrixOperationsQ2D.Parallel, ["Circle2", "Circle3"], "Test4_m", "New_net")
         assert mm.name == "Test4_m"
-        mm = q2d.insert_reduced_matrix(q2d.MATRIXOPERATIONS.DiffPair, ["Circle2", "Circle3"], "Test5_m", "New_net")
+        mm = q2d.insert_reduced_matrix(MatrixOperationsQ2D.DiffPair, ["Circle2", "Circle3"], "Test5_m", "New_net")
         assert mm.name == "Test5_m"
 
     def test_12_edit_sources(self, q2d_matrix):
@@ -223,7 +224,7 @@ class TestClass:
 
     def test_15_export_equivalent_circuit(self, q2d_solved):
         q2d = q2d_solved
-        q2d.insert_reduced_matrix(q2d.MATRIXOPERATIONS.Float, "Circle2", "Test4")
+        q2d.insert_reduced_matrix(MatrixOperationsQ2D.Float, "Circle2", "Test4")
         assert q2d.matrices[-1].name == "Test4"
         assert len(q2d.setups[0].sweeps[0].frequencies) > 0
         assert q2d.setups[0].sweeps[0].basis_frequencies == []

--- a/tests/system/general/test_35_MaxwellCircuit.py
+++ b/tests/system/general/test_35_MaxwellCircuit.py
@@ -28,7 +28,7 @@ import pytest
 
 from ansys.aedt.core import Maxwell2d
 from ansys.aedt.core import MaxwellCircuit
-from ansys.aedt.core.generic.constants import SOLUTIONS
+from ansys.aedt.core.generic.constants import SolutionsMaxwell2D
 from ansys.aedt.core.internal.checks import AEDTRuntimeError
 from tests import TESTS_GENERAL_PATH
 
@@ -105,7 +105,7 @@ class TestClass:
         netlist_file_invalid = os.path.join(self.local_scratch.path, "export_netlist.sh")
         assert not self.aedtapp.export_netlist_from_schematic(netlist_file_invalid)
         m2d = add_app(design_name="test", application=Maxwell2d)
-        m2d.solution_type = SOLUTIONS.Maxwell2d.TransientZ
+        m2d.solution_type = SolutionsMaxwell2D.TransientZ
         m2d.modeler.create_circle([0, 0, 0], 10, name="Circle_inner")
         m2d.modeler.create_circle([0, 0, 0], 30, name="Circle_outer")
         m2d.assign_coil(assignment=["Circle_inner"])

--- a/tests/system/general/test_98_Icepak.py
+++ b/tests/system/general/test_98_Icepak.py
@@ -28,6 +28,8 @@ import re
 import pytest
 
 from ansys.aedt.core import Icepak
+from ansys.aedt.core.generic.constants import Gravity
+from ansys.aedt.core.generic.constants import Plane
 from ansys.aedt.core.generic.settings import settings
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from ansys.aedt.core.modules.boundary.icepak_boundary import NetworkObject
@@ -500,7 +502,7 @@ class TestClass:
         ipk.modeler.create_box([1, 2, 3], [10, 10, 10], "network_box", "copper")
         ipk.modeler.create_box([4, 5, 6], [5, 5, 5], "network_box2", "copper")
         result = ipk.create_network_blocks(
-            [["network_box", 20, 10, 3], ["network_box2", 4, 10, 3]], ipk.GRAVITY.ZNeg, 1.05918, False
+            [["network_box", 20, 10, 3], ["network_box2", 4, 10, 3]], Gravity.ZNeg, 1.05918, False
         )
         assert (
             len(result[0].props["Nodes"]) == 3 and len(result[1].props["Nodes"]) == 3
@@ -698,7 +700,7 @@ class TestClass:
         #     vertical_separation=5.5,
         #     material="Copper",
         #     center=[10, 0, 0],
-        #     plane_enum=ipk.PLANE.XY,
+        #     plane_enum=Plane.XY,
         #     rotation=45,
         #     tolerance=0.005,
         # )
@@ -788,8 +790,8 @@ class TestClass:
 
     def test043__surface_monitor(self, ipk):
         ipk.insert_design("MonitorTests")
-        ipk.modeler.create_rectangle(ipk.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
-        ipk.modeler.create_rectangle(ipk.PLANE.XY, [0, 0, 0], [20, 20], name="surf2")
+        ipk.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 20], name="surf1")
+        ipk.modeler.create_rectangle(Plane.XY, [0, 0, 0], [20, 20], name="surf2")
         assert ipk.monitor.assign_surface_monitor("surf1", monitor_name="monitor_surf") == "monitor_surf"
         assert ipk.monitor.assign_surface_monitor(
             ["surf1", "surf2"], monitor_quantity=["Temperature", "HeatFlowRate"], monitor_name="monitor_surfs"
@@ -895,8 +897,8 @@ class TestClass:
 
     def test050__create_conduting_plate(self, ipk):
         box = ipk.modeler.create_box([0, 0, 0], [10, 20, 10], name="box1")
-        ipk.modeler.create_rectangle(ipk.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
-        ipk.modeler.create_rectangle(ipk.PLANE.YZ, [0, 0, 0], [10, 20], name="surf2")
+        ipk.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 20], name="surf1")
+        ipk.modeler.create_rectangle(Plane.YZ, [0, 0, 0], [10, 20], name="surf2")
         box_fc_ids = ipk.modeler.get_object_faces(box.name)
         assert ipk.create_conduting_plate(
             ipk.modeler.get_object_from_name(box.name).faces[0].id,
@@ -929,7 +931,7 @@ class TestClass:
         )
 
     def test051__assign_stationary_wall(self, ipk):
-        ipk.modeler.create_rectangle(ipk.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
+        ipk.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 20], name="surf1")
         box = ipk.modeler.create_box([0, 0, 0], [10, 20, 10], name="box1")
 
         assert ipk.assign_stationary_wall_with_htc(
@@ -1301,8 +1303,8 @@ class TestClass:
             )
 
     def test062__assign_symmetry_wall(self, ipk):
-        ipk.modeler.create_rectangle(ipk.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
-        ipk.modeler.create_rectangle(ipk.PLANE.YZ, [0, 0, 0], [10, 20], name="surf2")
+        ipk.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 20], name="surf1")
+        ipk.modeler.create_rectangle(Plane.YZ, [0, 0, 0], [10, 20], name="surf2")
         region_fc_ids = ipk.modeler.get_object_faces("Region")
         assert ipk.assign_symmetry_wall(
             geometry="surf1",
@@ -1325,7 +1327,7 @@ class TestClass:
     def test063__update_3d_component(self, ipk, local_scratch):
         file_path = local_scratch.path
         file_name = "3DComp.a3dcomp"
-        ipk.modeler.create_rectangle(ipk.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
+        ipk.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 20], name="surf1")
         ipk.modeler.create_3dcomponent(os.path.join(file_path, file_name))
         ipk.modeler.insert_3d_component(input_file=os.path.join(file_path, file_name), name="test")
         component_filepath = ipk.modeler.user_defined_components["test"].get_component_filepath()
@@ -1490,7 +1492,7 @@ class TestClass:
             box_face.id, total_power=1, high_side_rad_material="Steel-oxidised-surface"
         )
         assert ipk.assign_conducting_plate_with_resistance(box_face.id, low_side_rad_material="Steel-oxidised-surface")
-        ipk.modeler.create_rectangle(ipk.PLANE.XY, [0, 0, 0], [10, 20], name="surfPlateTest")
+        ipk.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 20], name="surfPlateTest")
         assert ipk.assign_conducting_plate_with_impedance("surfPlateTest")
         x = [1, 2, 3]
         y = [3, 4, 5]
@@ -1520,7 +1522,7 @@ class TestClass:
 
         ds_time = ipk.create_dataset("ds_time3", [1, 2, 3], [3, 2, 1], is_project_dataset=False, x_unit="s", y_unit="W")
         bc2 = ipk.create_dataset_transient_assignment(ds_time.name)
-        rect = ipk.modeler.create_rectangle(ipk.PLANE.XY, [0, 0, 0], [20, 10])
+        rect = ipk.modeler.create_rectangle(Plane.XY, [0, 0, 0], [20, 10])
         assert bc2
         assert ipk.assign_conducting_plate_with_resistance(rect.name, total_power=bc2)
 

--- a/tests/system/solvers/sequential/test_icepak_3d_component.py
+++ b/tests/system/solvers/sequential/test_icepak_3d_component.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pytest
 
 from ansys.aedt.core import Icepak
+from ansys.aedt.core.generic.constants import Plane
 from ansys.aedt.core.modules.boundary.layout_boundary import NativeComponentObject
 from tests.system.solvers.conftest import config
 
@@ -129,7 +130,7 @@ class TestClass:
 
     @pytest.mark.skipif(not config["use_grpc"], reason="Not running in COM mode")
     def test_advanced_3d_component_export(self, ipk, local_scratch):
-        surf1 = ipk.modeler.create_rectangle(ipk.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
+        surf1 = ipk.modeler.create_rectangle(Plane.XY, [0, 0, 0], [10, 20], name="surf1")
         box1 = ipk.modeler.create_box([20, 20, 2], [10, 10, 3], "box1", "copper")
         fan = ipk.create_fan("Fan", cross_section="YZ", radius="1mm", hub_radius="0mm")
         cs0 = ipk.modeler.create_coordinate_system(name="CS0")

--- a/tests/system/solvers/test_31_Q3D.py
+++ b/tests/system/solvers/test_31_Q3D.py
@@ -27,6 +27,10 @@ import os
 import pytest
 
 from ansys.aedt.core import Q3d
+from ansys.aedt.core.generic.constants import Axis
+from ansys.aedt.core.generic.constants import MatrixOperationsQ3D
+from ansys.aedt.core.generic.constants import Plane
+from ansys.aedt.core.generic.constants import PlotCategoriesQ3D
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 
 q3d_solved_file = "Q3d_solved"
@@ -88,9 +92,7 @@ class TestClass:
     def test_02_create_primitive(self, aedtapp):
         udp = aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        o = aedtapp.modeler.create_cylinder(
-            aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, name="MyCylinder", material="brass"
-        )
+        o = aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, name="MyCylinder", material="brass")
         assert isinstance(o.id, int)
 
     def test_03_get_properties(self, aedtapp):
@@ -207,9 +209,7 @@ class TestClass:
     def test_07_create_source_sinks(self, aedtapp):
         udp = aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        aedtapp.modeler.create_cylinder(
-            aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, name="MyCylinder", material="brass"
-        )
+        aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, name="MyCylinder", material="brass")
         source = aedtapp.source("MyCylinder", direction=0, name="Source1")
         sink = aedtapp.sink("MyCylinder", direction=3, name="Sink1")
         assert source.name == "Source1"
@@ -219,20 +219,18 @@ class TestClass:
     def test_07b_create_source_to_sheet(self, aedtapp):
         udp = aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        aedtapp.modeler.create_cylinder(
-            aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, name="MyCylinder", material="brass"
-        )
+        aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, name="MyCylinder", material="brass")
 
         udp = aedtapp.modeler.Position(10, 10, 0)
         coax_dimension = 30
-        aedtapp.modeler.create_cylinder(aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, name="GND", material="brass")
+        aedtapp.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, name="GND", material="brass")
 
         aedtapp.auto_identify_nets()
-        aedtapp.modeler.create_circle(aedtapp.PLANE.XY, [0, 0, 0], 4, name="Source1")
-        aedtapp.modeler.create_circle(aedtapp.PLANE.XY, [0, 0, coax_dimension], 4, name="Sink1")
+        aedtapp.modeler.create_circle(Plane.XY, [0, 0, 0], 4, name="Source1")
+        aedtapp.modeler.create_circle(Plane.XY, [0, 0, coax_dimension], 4, name="Sink1")
 
-        aedtapp.modeler.create_circle(aedtapp.PLANE.XY, [10, 10, 0], 4, name="Source2")
-        aedtapp.modeler.create_circle(aedtapp.PLANE.XY, [10, 10, coax_dimension], 4, name="Sink2")
+        aedtapp.modeler.create_circle(Plane.XY, [10, 10, 0], 4, name="Source2")
+        aedtapp.modeler.create_circle(Plane.XY, [10, 10, coax_dimension], 4, name="Sink2")
 
         source = aedtapp.source("Source1", name="Source3")
         sink = aedtapp.sink("Sink1", name="Sink3")
@@ -245,8 +243,8 @@ class TestClass:
         aedtapp.modeler.delete("Source1")
         aedtapp.modeler.delete("Sink1")
 
-        aedtapp.modeler.create_circle(aedtapp.PLANE.XY, [0, 0, 0], 4, name="Source1")
-        aedtapp.modeler.create_circle(aedtapp.PLANE.XY, [0, 0, coax_dimension], 4, name="Sink1")
+        aedtapp.modeler.create_circle(Plane.XY, [0, 0, 0], 4, name="Source1")
+        aedtapp.modeler.create_circle(Plane.XY, [0, 0, coax_dimension], 4, name="Sink1")
 
         source = aedtapp.source("Source1", name="Source3", terminal_type="current")
         sink = aedtapp.sink("Sink1", name="Sink3", terminal_type="current")
@@ -275,7 +273,7 @@ class TestClass:
 
     def test_08_create_faceted_bondwire(self, bond):
         test = bond.modeler.create_faceted_bondwire_from_true_surface(
-            "bondwire_example", bond.AXIS.Z, min_size=0.2, number_of_segments=8
+            "bondwire_example", Axis.Z, min_size=0.2, number_of_segments=8
         )
         assert test
 
@@ -330,24 +328,22 @@ class TestClass:
             "JoinParallel", ["Box1", "Box1_1"], "JointTest2", "New_net", "New_source", "New_sink"
         )
         assert "New_net" in mm.sources()
-        assert mm.add_operation(q3d.MATRIXOPERATIONS.JoinParallel, ["Box1_2", "New_net"])
+        assert mm.add_operation(MatrixOperationsQ3D.JoinParallel, ["Box1_2", "New_net"])
         assert len(mm.operations) == 2
         mm = q3d.insert_reduced_matrix("FloatInfinity", None, "JointTest3_mm")
         assert mm.name == "JointTest3_mm"
-        mm = q3d.insert_reduced_matrix(q3d.MATRIXOPERATIONS.MoveSink, "Source2", "JointTest4_mm")
+        mm = q3d.insert_reduced_matrix(MatrixOperationsQ3D.MoveSink, "Source2", "JointTest4_mm")
         assert mm.name == "JointTest4_mm"
-        mm = q3d.insert_reduced_matrix(q3d.MATRIXOPERATIONS.ReturnPath, "Source2", "JointTest5")
+        mm = q3d.insert_reduced_matrix(MatrixOperationsQ3D.ReturnPath, "Source2", "JointTest5")
         assert mm.name == "JointTest5"
-        mm = q3d.insert_reduced_matrix(q3d.MATRIXOPERATIONS.GroundNet, "Box1", "JointTest6")
+        mm = q3d.insert_reduced_matrix(MatrixOperationsQ3D.GroundNet, "Box1", "JointTest6")
         assert mm.name == "JointTest6"
-        assert mm.add_operation(q3d.MATRIXOPERATIONS.ReturnPath, "Source2")
-        mm = q3d.insert_reduced_matrix(q3d.MATRIXOPERATIONS.FloatTerminal, "Source2", "JointTest7")
+        assert mm.add_operation(MatrixOperationsQ3D.ReturnPath, "Source2")
+        mm = q3d.insert_reduced_matrix(MatrixOperationsQ3D.FloatTerminal, "Source2", "JointTest7")
         assert mm.name == "JointTest7"
         assert mm.delete()
         full_list = q3d.matrices[0].get_sources_for_plot()
-        mutual_list = q3d.matrices[0].get_sources_for_plot(
-            get_self_terms=False, category=q3d.matrices[0].CATEGORIES.Q3D.ACL
-        )
+        mutual_list = q3d.matrices[0].get_sources_for_plot(get_self_terms=False, category=PlotCategoriesQ3D.ACL)
         assert q3d.get_traces_for_plot() == q3d.matrices[0].get_sources_for_plot()
         assert len(full_list) > len(mutual_list)
         assert q3d.matrices[0].get_sources_for_plot(first_element_filter="Box?", second_element_filter="B*2") == [
@@ -593,7 +589,7 @@ class TestClass:
         app = add_app(application=Q3d, design_name="toggle_net")
         udp = app.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        app.modeler.create_cylinder(app.PLANE.XY, udp, 3, coax_dimension, 0, name="MyCylinder", material="brass")
+        app.modeler.create_cylinder(Plane.XY, udp, 3, coax_dimension, 0, name="MyCylinder", material="brass")
 
         _ = app.source("MyCylinder", direction=0, name="Source1")
         _ = app.sink("MyCylinder", direction=3, name="Sink1")


### PR DESCRIPTION
## Description
Refactoring of the constants class that behaved like `Enum` but where not implemented with it. There are a lot of places where the changes had an impact and to ensure backward compatibility, some classes have been added properties to remove unwanted attributes.

## Issue linked
Related to #5504 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
