### PR TITLE
FEAT: Assign wave port in Driven Terminal

### DIFF
--- a/doc/changelog.d/6358.added.md
+++ b/doc/changelog.d/6358.added.md
@@ -1,0 +1,1 @@
+Assign wave port in driven terminal

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -377,6 +377,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
     @pyaedt_function_handler(objectname="assignment", portname="port_name")
     def _create_lumped_driven(self, assignment, int_line_start, int_line_stop, impedance, port_name, renorm, deemb):
         assignment = self.modeler.convert_to_selections(assignment, True)
+        # TODO: Integration line should be consistent with _create_waveport_driven
         start = [str(i) + self.modeler.model_units for i in int_line_start]
         stop = [str(i) + self.modeler.model_units for i in int_line_stop]
         props = {}

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -6876,7 +6876,14 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
 
         name = self._get_unique_source_name(name, "Port")
 
-        if "Modal" in self.solution_type:
+        if (
+            self.solution_type == SolutionsHfss.DrivenModal
+            or (
+                self.solution_type in [SolutionsHfss.DrivenTerminal, SolutionsHfss.Transient]
+                and self.desktop_class.aedt_version_id >= "2024.1"
+            )
+            and not reference
+        ):
             return self._create_lumped_driven(sheet_name, point0, point1, impedance, name, renormalize, deembed)
         else:
             faces = self.modeler.get_object_faces(sheet_name)
@@ -7074,8 +7081,14 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
                 self._create_pec_cap(face, assignment, dist / 10)
         name = self._get_unique_source_name(name, "Port")
 
-        # From 2024.1, wave port excitation can be assigned in Driven Terminal and Transient
-        if self.solution_type == SolutionsHfss.DrivenModal or self.desktop_class.aedt_version_id >= "2024.1":
+        if (
+            self.solution_type == SolutionsHfss.DrivenModal
+            or (
+                self.solution_type in [SolutionsHfss.DrivenTerminal, SolutionsHfss.Transient]
+                and self.desktop_class.aedt_version_id >= "2024.1"
+            )
+            and not reference
+        ):
             if isinstance(characteristic_impedance, str):
                 characteristic_impedance = [characteristic_impedance] * modes
             elif modes != len(characteristic_impedance):
@@ -7104,6 +7117,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
                 impedance=impedance,
                 terminals_rename=terminals_rename,
             )
+
         else:  # pragma: no cover
             raise AEDTRuntimeError("Reference conductors are missing.")
 

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -7063,7 +7063,8 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
                 self._create_pec_cap(face, assignment, dist / 10)
         name = self._get_unique_source_name(name, "Port")
 
-        if self.solution_type == SOLUTIONS.Hfss.DrivenModal:
+        # From 2024.1, wave port excitation can be assigned in Driven Terminal and Transient
+        if self.solution_type == SOLUTIONS.Hfss.DrivenModal or self.desktop_class.aedt_version_id >= "2024.1":
             if isinstance(characteristic_impedance, str):
                 characteristic_impedance = [characteristic_impedance] * modes
             elif modes != len(characteristic_impedance):
@@ -7071,7 +7072,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
             return self._create_waveport_driven(
                 sheet_name, int_start, int_stop, impedance, name, renormalize, modes, deembed, characteristic_impedance
             )
-        elif reference:
+        elif reference:  # pragma: no cover
             if isinstance(sheet_name, int):
                 faces = [sheet_name]
             else:
@@ -7092,7 +7093,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin):
                 impedance=impedance,
                 terminals_rename=terminals_rename,
             )
-        else:
+        else:  # pragma: no cover
             raise AEDTRuntimeError("Reference conductors are missing.")
 
     @pyaedt_function_handler()

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -130,10 +130,19 @@ class TestClass:
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         o5 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet1")
         self.aedtapp.solution_type = "Terminal"
-        outer_1 = self.aedtapp.modeler["outer_1"]
-        # TODO: Consider allowing a TEM port to be created.
-        with pytest.raises(AEDTRuntimeError, match="Reference conductors are missing."):
-            self.aedtapp.wave_port(o5)
+        coax1_len = 200
+        r2 = 10.0
+        coax1_origin = self.aedtapp.modeler.Position(0, 0, 0)  # Thru coax origin.
+        outer_1 = self.aedtapp.modeler.create_cylinder(
+            self.aedtapp.AXIS.X, coax1_origin, r2, coax1_len, 0, "outer_1_05"
+        )
+        coax1_len = 200
+        r1 = 3.0
+        coax1_origin = self.aedtapp.modeler.Position(0, 0, 0)  # Thru coax origin.
+
+        inner_1 = self.aedtapp.modeler.create_cylinder(
+            self.aedtapp.AXIS.X, coax1_origin, r1, coax1_len, 0, "inner_1_05"
+        )
 
         port = self.aedtapp.wave_port(
             assignment=o5,
@@ -154,9 +163,9 @@ class TestClass:
 
         udp = self.aedtapp.modeler.Position(80, 0, 0)
         o6 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet1a")
-        self.aedtapp.modeler.subtract(o6, "inner_1", keep_originals=True)
+        self.aedtapp.modeler.subtract(o6, inner_1.name, keep_originals=True)
 
-        self.aedtapp.assign_finite_conductivity(material="aluminum", assignment="inner_1")
+        self.aedtapp.assign_finite_conductivity(material="aluminum", assignment=inner_1.name)
 
         port = self.aedtapp.wave_port(
             assignment=o6,
@@ -174,7 +183,6 @@ class TestClass:
         assert port.props["DoDeembed"] is False
 
         # Get the object for "outer_1".
-        outer_1 = self.aedtapp.modeler["outer_1"]
         bottom_port = self.aedtapp.wave_port(
             outer_1.bottom_face_z, reference=outer_1.name, create_pec_cap=True, name="bottom_probe_port"
         )

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -173,7 +173,6 @@ class TestClass:
         assert port.props["DoDeembed"] is False
 
         # Get the object for "outer_1".
-        outer_1 = self.aedtapp.modeler["outer_1"]
         bottom_port = self.aedtapp.wave_port(
             outer_1.bottom_face_z, reference=outer_1.name, create_pec_cap=True, name="bottom_probe_port"
         )
@@ -2019,3 +2018,27 @@ class TestClass:
 
         coat4 = self.aedtapp.assign_layered_impedance([b.id, b.name, b.faces[0]], **args)
         assert coat4.properties["Layer 2/Material"] == "vacuum"
+
+    def test_port_driven(self):
+        self.aedtapp.insert_design("hfss_wave_port")
+        circle = self.aedtapp.modeler.create_circle(Plane.YZ, [0, 0, 0], 10, name="sheet1")
+
+        self.aedtapp.solution_type = "Terminal"
+        port = self.aedtapp.wave_port(assignment=circle)
+        assert port.name in self.aedtapp.excitation_names
+        port.delete()
+
+        self.aedtapp.solution_type = "Eigenmode"
+        with pytest.raises(AEDTRuntimeError):
+            self.aedtapp.wave_port(assignment=circle)
+
+        self.aedtapp.solution_type = "Modal"
+        start = [0.0, -10.0, 0.0]
+        end = [0.0, 10.0, 0.0]
+        port = self.aedtapp.lumped_port(assignment=circle, integration_line=[start, end])
+        assert port.name in self.aedtapp.excitation_names
+        port.delete()
+
+        self.aedtapp.solution_type = "Eigenmode"
+        with pytest.raises(AEDTRuntimeError):
+            self.aedtapp.lumped_port(assignment=circle)

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -133,9 +133,6 @@ class TestClass:
         o5 = self.aedtapp.modeler.create_circle(Plane.YZ, udp, 10, name="sheet1")
         self.aedtapp.solution_type = "Terminal"
         outer_1 = self.aedtapp.modeler["outer_1"]
-        # TODO: Consider allowing a TEM port to be created.
-        with pytest.raises(AEDTRuntimeError, match="Reference conductors are missing."):
-            self.aedtapp.wave_port(o5)
 
         port = self.aedtapp.wave_port(
             assignment=o5,

--- a/tests/system/general/test_20_HFSS.py
+++ b/tests/system/general/test_20_HFSS.py
@@ -2025,7 +2025,7 @@ class TestClass:
 
         self.aedtapp.solution_type = "Terminal"
         port = self.aedtapp.wave_port(assignment=circle)
-        assert port.name in self.aedtapp.excitation_names
+        assert port.name in self.aedtapp.ports
         port.delete()
 
         self.aedtapp.solution_type = "Eigenmode"
@@ -2036,7 +2036,7 @@ class TestClass:
         start = [0.0, -10.0, 0.0]
         end = [0.0, 10.0, 0.0]
         port = self.aedtapp.lumped_port(assignment=circle, integration_line=[start, end])
-        assert port.name in self.aedtapp.excitation_names
+        assert port.name in self.aedtapp.ports
         port.delete()
 
         self.aedtapp.solution_type = "Eigenmode"


### PR DESCRIPTION
## Description
Assign wave port in driven terminal is available since 2024R1.

## Issue linked
Close #6357 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
