### PR TITLE
FIX: Handle zero-valued expression variables properly.

### DIFF
--- a/src/ansys/aedt/core/application/variables.py
+++ b/src/ansys/aedt/core/application/variables.py
@@ -1395,7 +1395,7 @@ class Variable(object):
         self._units = None
         self._expression = expression
         self._calculated_value, self._units = decompose_variable_value(expression, full_variables)
-        if si_value:
+        if si_value is not None:
             self._value = si_value
         else:
             self._value = self._calculated_value


### PR DESCRIPTION
## Description
I noticed the Hfss.evaluate_expression() method was incorrectly returning the symbolic value of an expression, instead of the float value, when the expression evaluated to zero.

For example, this code would print the string 'test - test' instead of 0.0 as expected:

    app = Hfss("ZeroVariableTest")
    app['x'] = '10 mm'
    app["test"] = 'x / 1mm'

    print(f'{app.evaluate_expression('test - test')=}') # should be 0.0

I tracked it down to the Variable class constructor, where `si_value` was being directly used as a truth value:

    if si_value:
        self._value = si_value
    else:
        self._value = self._calculated_value

Unfortunately, float(0.0) is a Falsy value in Python (`bool(0.0) == False`), so the above incorrectly treats a 0.0 float the same as None. The correct condition for None-ness is `if si_value is not None` instead of `if si_value`.

## Issue linked
N/A

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
