### PR TITLE
FIX: [insert_layout_component] Transient naming change in 2025R2

### DIFF
--- a/doc/changelog.d/6411.fixed.md
+++ b/doc/changelog.d/6411.fixed.md
@@ -1,0 +1,1 @@
+[insert_layout_component] transient naming change in 2025r2

--- a/src/ansys/aedt/core/modeler/cad/primitives_3d.py
+++ b/src/ansys/aedt/core/modeler/cad/primitives_3d.py
@@ -1776,7 +1776,8 @@ class Primitives3D(GeometryModeler):
         """
         if layout_coordinate_systems is None:
             layout_coordinate_systems = []
-        if self._app.solution_type != "Terminal" and self._app.solution_type != "TransientAPhiFormulation":
+        if (self._app.solution_type != "Terminal"
+                and self._app.solution_type not in ["TransientAPhiFormulation","Transient APhi"]):
             self.logger.warning("Solution type must be terminal in HFSS or APhi in Maxwell")
             return False
 


### PR DESCRIPTION
TransientAPhiFormulation naming has changed in 2025R2 to Transient APhi

Issue #6410 