### PR TITLE
FEAT: EM fields in Q3D

### DIFF
--- a/src/ansys/aedt/core/application/aedt_objects.py
+++ b/src/ansys/aedt/core/application/aedt_objects.py
@@ -107,6 +107,8 @@ class AedtObjects(object):
         """
         if self.design_type == "HFSS" and self._odesign.GetSolutionType() not in ["EigenMode", "Characteristic Mode"]:
             return self._odesign.GetModule("RadField")
+        if self.desktop_class.aedt_version_id >= "2025.1" and self.design_type == "Q3D Extractor":
+            return self._odesign.GetModule("RadField")
         return None
 
     @pyaedt_function_handler()

--- a/src/ansys/aedt/core/modules/boundary/hfss_boundary.py
+++ b/src/ansys/aedt/core/modules/boundary/hfss_boundary.py
@@ -65,11 +65,14 @@ class FieldSetup(BoundaryCommon, BinaryTreeNode):
         child_object = None
         design_childs = self._app.get_oo_name(self._app.odesign)
 
-        if "Radiation" in design_childs:
-            cc = self._app.get_oo_object(self._app.odesign, "Radiation")
-            cc_names = self._app.get_oo_name(cc)
-            if self._name in cc_names:
-                child_object = cc.GetChildObject(self._name)
+        for category in ["Radiation", "EM Fields"]:
+            if category in design_childs:
+                cc = self._app.get_oo_object(self._app.odesign, category)
+                cc_names = self._app.get_oo_name(cc)
+                if self._name in cc_names:
+                    child_object = cc.GetChildObject(self._name)
+                    break
+
         return child_object
 
     @property


### PR DESCRIPTION
## Description
Add Q3D new feature of EM Fields. This is equivalent to Near Field setup in HFSS, so it shares the same classes, showing the power of PyAEDT :)

## Issue linked
Close #6059 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
