### PR TITLE
FIX: Import CAD with None value in control file

### DIFF
--- a/doc/changelog.d/6436.fixed.md
+++ b/doc/changelog.d/6436.fixed.md
@@ -1,0 +1,1 @@
+Import cad with none value in control file

--- a/src/ansys/aedt/core/hfss3dlayout.py
+++ b/src/ansys/aedt/core/hfss3dlayout.py
@@ -1373,7 +1373,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout, ScatteringMethods):
             project_name = generate_unique_name(project_name)
             aedb_path = aedb_path.replace(old_name, project_name)
             self.logger.warning("aedb_exists. Renaming it to %s", project_name)
-        if not Path(xml_path):
+        if xml_path is None:
             xml_path = Path("")
         elif Path(xml_path).suffix == ".tech":
             xml_path = Path(tech_to_control_file(xml_path))


### PR DESCRIPTION
## Description
If the control file (xml_path) is None, then Path raises an exception. Now it is checking if the value is None.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
