### PR TITLE
FIX: Use regex to check installed ansysem versions

### DIFF
--- a/doc/changelog.d/6452.fixed.md
+++ b/doc/changelog.d/6452.fixed.md
@@ -1,0 +1,1 @@
+Use regex to identify installed AnsysEM versions.

--- a/doc/changelog.d/6452.fixed.md
+++ b/doc/changelog.d/6452.fixed.md
@@ -1,1 +1,0 @@
-Use regex to identify installed AnsysEM versions.

--- a/doc/changelog.d/6453.fixed.md
+++ b/doc/changelog.d/6453.fixed.md
@@ -1,0 +1,1 @@
+Use regex to check installed ansysem versions

--- a/src/ansys/aedt/core/internal/aedt_versions.py
+++ b/src/ansys/aedt/core/internal/aedt_versions.py
@@ -29,6 +29,7 @@ every time a new stable version is released.
 Ideally, it should be the same as ``conftest.default_version``"""
 
 import os
+import re
 import warnings
 
 from ansys.aedt.core.generic import settings
@@ -55,13 +56,8 @@ class AedtVersions:
 
         The list is ordered: first normal versions, then client versions, finally student versions."""
         if self._list_installed_ansysem is None:
-            aedt_env_var_prefix = "ANSYSEM_ROOT"
-            version_list = sorted([x for x in os.environ if x.startswith(aedt_env_var_prefix)], reverse=True)
-            aedt_env_var_prefix = "ANSYSEM_PY_CLIENT_ROOT"
-            version_list += sorted([x for x in os.environ if x.startswith(aedt_env_var_prefix)], reverse=True)
-            aedt_env_var_sv_prefix = "ANSYSEMSV_ROOT"
-            version_list += sorted([x for x in os.environ if x.startswith(aedt_env_var_sv_prefix)], reverse=True)
-
+            version_pattern = re.compile(r"^(ANSYSEM_ROOT|ANSYSEM_PY_CLIENT_ROOT|ANSYSEMSV_ROOT)\d{3}$")
+            version_list = sorted([x for x in os.environ if version_pattern.match(x)], reverse=True)
             if not version_list:
                 warnings.warn(
                     "No installed versions of AEDT are found in the system environment variables ``ANSYSEM_ROOTxxx``."

--- a/src/ansys/aedt/core/internal/aedt_versions.py
+++ b/src/ansys/aedt/core/internal/aedt_versions.py
@@ -32,7 +32,7 @@ import os
 import re
 import warnings
 
-from ansys.aedt.core.generic import settings
+from ansys.aedt.core.generic.settings import settings
 
 CURRENT_STABLE_AEDT_VERSION = 2025.1
 


### PR DESCRIPTION
Using regex to check for installed ansysem version will prevent unexpected issues.
For example, when an env var named ANSYSEM_ROOT_PATH is present, instantiating a Hfss3dLayout or a desktop object was failing. This is now fixed
Fixes #6452
Fixes #6430 
