### PR TITLE
FIX: Fix indentation when loading EMIT revision

### DIFF
--- a/doc/changelog.d/6454.fixed.md
+++ b/doc/changelog.d/6454.fixed.md
@@ -1,0 +1,1 @@
+Fix indentation when loading emit revision

--- a/src/ansys/aedt/core/emit_core/results/revision.py
+++ b/src/ansys/aedt/core/emit_core/results/revision.py
@@ -140,10 +140,10 @@ class Revision:
             self.timestamp = props["Timestamp"]
             """Unique timestamp for the revision"""
 
-            self.revision_loaded = False
-            """``True`` if the revision is loaded and ``False`` if it is not."""
+        self.revision_loaded = False
+        """``True`` if the revision is loaded and ``False`` if it is not."""
 
-            self._load_revision()
+        self._load_revision()
 
     @pyaedt_function_handler()
     def _load_revision(self):


### PR DESCRIPTION
## Description
Fix indentation typo in revision class constructor causing revisions to not be loaded after path is set

## Checklist
- [X] I have tested my changes locally.
- [X] I have added necessary documentation or updated existing documentation.
- [X] I have followed the coding style guidelines of this project.
- [X] I have added appropriate tests (unit, integration, system).
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have linked the issue or issues that are solved by the PR if any.
- [X] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
