### PR TITLE
Fix monitor documentation

### DIFF
--- a/doc/source/API/visualization/post.rst
+++ b/doc/source/API/visualization/post.rst
@@ -249,6 +249,9 @@ Methods and properties are accessible through the ``monitor`` property of the ``
    :nosignatures:
 
    Monitor
+   ObjectMonitor
+   PointMonitor
+   FaceMonitor
 
 
 The ``field_summary`` module includes the classes listed below to the ``Icepak`` field summary.

--- a/src/ansys/aedt/core/internal/checks.py
+++ b/src/ansys/aedt/core/internal/checks.py
@@ -28,6 +28,7 @@ import os
 import warnings
 
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
+from functools import wraps
 
 
 def install_message(target: str) -> str:
@@ -85,6 +86,7 @@ def min_aedt_version(min_version: str):
                 return desktop_class.odesktop
 
     def aedt_version_decorator(method):
+        @wraps(method)
         def wrapper(self, *args, **kwargs):
             odesktop = (
                 fetch_odesktop_from_common_attributes_names(self)


### PR DESCRIPTION
## Description
Some monitor classes were not included in the documentation. Also, the `min_aedt_version` decorator seems to be breaking Sphinx ability to retrieve the doc strings to add to the documentation.