### PR TITLE
FEAT: Add options to debug unit tests

### DIFF
--- a/tests/system/solvers/conftest.py
+++ b/tests/system/solvers/conftest.py
@@ -93,6 +93,8 @@ config = {
     "local": False,
     "use_grpc": True,
     "disable_sat_bounding_box": True,
+    "close_desktop": True,
+    "remove_lock": False,
 }
 
 # Check for the local config file, override defaults if found
@@ -110,6 +112,8 @@ settings.disable_bounding_box_sat = config["disable_sat_bounding_box"]
 desktop_version = config["desktopVersion"]
 new_thread = config["NewThread"]
 settings.use_grpc_api = config["use_grpc"]
+close_desktop = config["close_desktop"]
+remove_lock = config["remove_lock"]
 
 logger = pyaedt_logger
 
@@ -158,7 +162,7 @@ def desktop():
 
     yield d
 
-    d.release_desktop(True, True)
+    d.release_desktop(close_projects=True, close_on_exit=close_desktop)
 
 
 @pytest.fixture(scope="module")
@@ -190,6 +194,7 @@ def add_app(local_scratch):
             design=design_name,
             solution_type=solution_type,
             version=desktop_version,
+            remove_lock=remove_lock,
         )
 
     return _method

--- a/tests/system/visualization/conftest.py
+++ b/tests/system/visualization/conftest.py
@@ -95,6 +95,8 @@ config = {
     "local": False,
     "use_grpc": True,
     "disable_sat_bounding_box": True,
+    "close_desktop": True,
+    "remove_lock": False,
 }
 
 # Check for the local config file, override defaults if found
@@ -112,6 +114,8 @@ settings.disable_bounding_box_sat = config["disable_sat_bounding_box"]
 desktop_version = config["desktopVersion"]
 new_thread = config["NewThread"]
 settings.use_grpc_api = config["use_grpc"]
+close_desktop = config["close_desktop"]
+remove_lock = config["remove_lock"]
 
 logger = pyaedt_logger
 
@@ -160,7 +164,7 @@ def desktop():
 
     yield d
     try:
-        d.release_desktop(True, True)
+        d.release_desktop(close_projects=True, close_on_exit=close_desktop)
     except Exception:
         return False
 
@@ -194,6 +198,7 @@ def add_app(local_scratch):
             design=design_name,
             solution_type=solution_type,
             version=desktop_version,
+            remove_lock=remove_lock,
         )
 
     return _method


### PR DESCRIPTION
Add options to conftest.py:
- close_desktop
- remove_lock

## Description
Simplify local debugging by allowing developers to keep AEDT open when the debugger starts/stops.

## Issue linked
Resolve #6475 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
