### PR TITLE
FIX: configure layout test

### DIFF
--- a/doc/changelog.d/6577.fixed.md
+++ b/doc/changelog.d/6577.fixed.md
@@ -1,0 +1,1 @@
+Configure layout test

--- a/src/ansys/aedt/core/extensions/project/resources/configure_layout/template.py
+++ b/src/ansys/aedt/core/extensions/project/resources/configure_layout/template.py
@@ -135,21 +135,7 @@ SERDES_CONFIG = {
                 "hole_range": "upper_pad_to_lower_pad",
                 "hole_parameters": {"shape": "circle", "diameter": "0.25mm"},
             },
-        ],
-        "instances": [
-            {
-                "name": "Via313",
-                "backdrill_parameters": {
-                    "from_bottom": {"drill_to_layer": "Inner3", "diameter": "1mm", "stub_length": "0.2mm"}
-                },
-            },
-            {
-                "name": "Via314",
-                "backdrill_parameters": {
-                    "from_bottom": {"drill_to_layer": "Inner3", "diameter": "1mm", "stub_length": "0.2mm"}
-                },
-            },
-        ],
+        ]
     },
     "ports": [
         {

--- a/src/ansys/aedt/core/extensions/project/resources/configure_layout/template.py
+++ b/src/ansys/aedt/core/extensions/project/resources/configure_layout/template.py
@@ -135,7 +135,7 @@ SERDES_CONFIG = {
                 "hole_range": "upper_pad_to_lower_pad",
                 "hole_parameters": {"shape": "circle", "diameter": "0.25mm"},
             },
-        ]
+        ],
     },
     "ports": [
         {


### PR DESCRIPTION
Remove below content from configure file. 
```
        "instances": [
            {
                "name": "Via313",
                "backdrill_parameters": {
                    "from_bottom": {"drill_to_layer": "Inner3", "diameter": "1mm", "stub_length": "0.2mm"}
                },
            },
            {
                "name": "Via314",
                "backdrill_parameters": {
                    "from_bottom": {"drill_to_layer": "Inner3", "diameter": "1mm", "stub_length": "0.2mm"}
                },
            },
        ],
```

The the vias in a fresh EDB don't have names. When it is imported, pyedb will give them names by their IDs. However, the their IDs are not guaranteed the same on different machine. This leads to Via313 not found. 

