### PR TITLE
CI: Improve visualization failure handling

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -154,7 +154,7 @@ jobs:
           python -c "import ansys.aedt.core; from ansys.aedt.core import __version__"
 
   unit-tests:
-    name: Running unit tests
+    name: Unit tests
     needs: [smoke-tests]
     runs-on: ubuntu-latest
     steps:
@@ -182,7 +182,7 @@ jobs:
         if: ${{ always() }}
 
   integration-tests:
-    name: Running integration tests
+    name: Integration tests
     needs: [unit-tests]
     runs-on: ubuntu-latest
     steps:
@@ -213,7 +213,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-solvers-windows:
-    name: Testing solvers and coverage (Windows)
+    name: Solvers tests (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -271,7 +271,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-solvers-linux:
-    name: Testing solvers and coverage (Linux)
+    name: Solvers tests (linux)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Linux, pyaedt ]
@@ -326,7 +326,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-general-windows:
-    name: Testing and coverage (Windows)
+    name: General tests (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -389,7 +389,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-general-linux:
-    name: Testing and coverage (Linux)
+    name: General tests (linux)
     if: github.event.pull_request.draft == false
     needs: [integration-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
@@ -457,7 +457,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-visualization-windows:
-    name: Testing and coverage Visualization (Windows)
+    name: Visualization tests (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -522,7 +522,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-visualization-linux:
-    name: Testing and coverage visualization (Linux)
+    name: Visualization tests (linux)
     if: github.event.pull_request.draft == false
     needs: [integration-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
@@ -590,7 +590,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-extensions-windows:
-    name: Testing and coverage extensions (Windows)
+    name: Extensions tests (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -653,7 +653,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-extensions-linux:
-    name: Testing and coverage extensions (Linux)
+    name: Extensions tests (linux)
     if: github.event.pull_request.draft == false
     needs: [integration-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
@@ -725,7 +725,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-filter-windows:
-    name: Testing and coverage filter solutions (Windows)
+    name: Filter solutions tests (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -788,7 +788,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-emit-windows:
-    name: Testing and coverage EMIT (Windows)
+    name: EMIT tests (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -432,7 +432,7 @@ jobs:
         with:
           max_attempts: 2
           retry_on: error
-          timeout_minutes: 120
+          timeout_minutes: 40
           command: |
             export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT252 }}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
             source .venv/bin/activate
@@ -499,7 +499,7 @@ jobs:
         with:
           max_attempts: 2
           retry_on: error
-          timeout_minutes: 60
+          timeout_minutes: 40
           command: |
             .venv\Scripts\Activate.ps1
             pytest ${{ env.PYTEST_ARGUMENTS }} -n 4 --dist loadfile --timeout=600 -m visualization -x

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -499,10 +499,10 @@ jobs:
         with:
           max_attempts: 2
           retry_on: error
-          timeout_minutes: 120
+          timeout_minutes: 60
           command: |
             .venv\Scripts\Activate.ps1
-            pytest ${{ env.PYTEST_ARGUMENTS }} -n 4 --dist loadfile --timeout=600 -m visualization
+            pytest ${{ env.PYTEST_ARGUMENTS }} -n 4 --dist loadfile --timeout=600 -m visualization -x
 
       - uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
         with:
@@ -566,11 +566,11 @@ jobs:
         with:
           max_attempts: 2
           retry_on: error
-          timeout_minutes: 120
+          timeout_minutes: 60
           command: |
             export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT252 }}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
             source .venv/bin/activate
-            pytest ${{ env.PYTEST_ARGUMENTS }} -n 4 --dist loadfile --timeout=600 -m visualization
+            pytest ${{ env.PYTEST_ARGUMENTS }} -n 4 --dist loadfile --timeout=600 -m visualization -x
 
       - uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
         with:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -566,7 +566,7 @@ jobs:
         with:
           max_attempts: 2
           retry_on: error
-          timeout_minutes: 60
+          timeout_minutes: 40
           command: |
             export LD_LIBRARY_PATH=${{ env.ANSYSEM_ROOT252 }}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
             source .venv/bin/activate

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -213,7 +213,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-solvers-windows:
-    name: Solvers tests (windows)
+    name: Test solvers (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -271,7 +271,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-solvers-linux:
-    name: Solvers tests (linux)
+    name: Test solvers (linux)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Linux, pyaedt ]
@@ -326,7 +326,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-general-windows:
-    name: General tests (windows)
+    name: Test general (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -389,7 +389,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-general-linux:
-    name: General tests (linux)
+    name: Test general (linux)
     if: github.event.pull_request.draft == false
     needs: [integration-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
@@ -457,7 +457,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-visualization-windows:
-    name: Visualization tests (windows)
+    name: Test visualization (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -522,7 +522,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-visualization-linux:
-    name: Visualization tests (linux)
+    name: Test visualization (linux)
     if: github.event.pull_request.draft == false
     needs: [integration-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
@@ -590,7 +590,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-extensions-windows:
-    name: Extensions tests (windows)
+    name: Test extensions (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -653,7 +653,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-extensions-linux:
-    name: Extensions tests (linux)
+    name: Test extensions (linux)
     if: github.event.pull_request.draft == false
     needs: [integration-tests]
     runs-on: [ self-hosted, Linux, pyaedt ]
@@ -725,7 +725,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-filter-windows:
-    name: Filter solutions tests (windows)
+    name: Test filter solutions (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]
@@ -788,7 +788,7 @@ jobs:
 # # =================================================================================================
 
   system-tests-emit-windows:
-    name: EMIT tests (windows)
+    name: Test EMIT (windows)
     needs: [integration-tests]
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Windows, pyaedt ]

--- a/doc/changelog.d/6617.maintenance.md
+++ b/doc/changelog.d/6617.maintenance.md
@@ -1,0 +1,1 @@
+Improve visualization failure handling


### PR DESCRIPTION
## Description
Modification to improve how linux visualization tests can some time consuming a lot of CI time resource.
The PR marks the test step as failed as soon as a test is failing and reduce the timeout to 60 minutes.
The timeout could be reduced further but, since each suite test completion can get up to ~25-27 minutes, we should be clear with the retry ability.

## Issue linked
#5524 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
