### PR TITLE
FIX: moved fpdf2 and rpyc in optional dependencies

### DIFF
--- a/doc/changelog.d/6647.fixed.md
+++ b/doc/changelog.d/6647.fixed.md
@@ -1,0 +1,1 @@
+Moved fpdf2 and rpyc in optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
     "defusedxml>=0.7,<8.0",
     "numpy>=1.20.0,<2.3",
     "pydantic>=2.6.4,<2.12",
+    # Needed for extensions
+    "pillow>=10,<12"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "fpdf2",
     "grpcio>=1.50.0,<1.75",
     "jsonschema",
     "psutil",
     "pyedb>=0.24.0,!=0.28.0",
     "tomli; python_version < '3.11'",
     "tomli-w",
-    "rpyc>=6.0.0,<6.1",
     "pyyaml",
     "defusedxml>=0.7,<8.0",
     "numpy>=1.20.0,<2.3",
@@ -67,6 +65,8 @@ tests = [
     "pyvista[io]>=0.38.0,<0.47",
     "scikit-rf>=0.30.0,<1.9",
     "tables",
+    "fpdf2",
+    "rpyc>=6.0.0,<6.1",
 ]
 dotnet = [
     "ansys-pythonnet>=3.1.0rc3",
@@ -86,12 +86,15 @@ doc = [
     "sphinx_design>=0.4.0,<0.7",
     "pyvista[io]>=0.38.0,<0.47",
     "ansys-tools-visualization-interface",
+    "fpdf2",
+    "rpyc>=6.0.0,<6.1",
 ]
 graphics = [
     "ansys-tools-visualization-interface",
     "pyvista[io]>=0.38.0,<0.47",
     "matplotlib>=3.5.0,<3.11",
     "vtk>=9.0,<9.6",
+    "fpdf2",
 ]
 jupyter = [
     "jupyterlab>=3.6.0,<4.5",
@@ -109,6 +112,8 @@ all = [
     "scikit-rf>=0.30.0,<1.9",
     "pyaedt[jupyter]",
     "requests",
+    "fpdf2",
+    "rpyc>=6.0.0,<6.1",
 ]
 examples = [
     "imageio>=2.34.0,<2.38",
@@ -121,6 +126,8 @@ examples = [
     "joblib>=1.4.0,<1.6",
     "plotly>=6.0,<6.4",
     "scikit-rf>=0.30.0,<1.9",
+    "fpdf2",
+    "rpyc>=6.0.0,<6.1",
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,6 @@ dependencies = [
     "defusedxml>=0.7,<8.0",
     "numpy>=1.20.0,<2.3",
     "pydantic>=2.6.4,<2.12",
-    # Needed for extensions
-    "pillow>=10,<12"
 ]
 
 [project.optional-dependencies]
@@ -51,6 +49,7 @@ unit-tests = [
     "pytest>=7.4.0,<8.5",
     "pytest-cov>=4.0.0,<6.3",
     "mock>=5.1.0,<5.3",
+    "fpdf2",
 ]
 integration-tests = [
     "matplotlib>=3.5.0,<3.11",
@@ -67,7 +66,6 @@ tests = [
     "pyvista[io]>=0.38.0,<0.47",
     "scikit-rf>=0.30.0,<1.9",
     "tables",
-    "fpdf2",
     "rpyc>=6.0.0,<6.1",
 ]
 dotnet = [


### PR DESCRIPTION
## Description
fpdf2 and rpyc are two packages that are used only in a specific class of pyaedt.
Moved them to optional

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
