### PR TITLE
FIX: Add -- to uv to pass options to pip

### DIFF
--- a/doc/changelog.d/6696.fixed.md
+++ b/doc/changelog.d/6696.fixed.md
@@ -1,0 +1,1 @@
+Add -- to uv to pass options to pip

--- a/doc/source/Resources/pyaedt_installer_from_aedt.py
+++ b/doc/source/Resources/pyaedt_installer_from_aedt.py
@@ -357,18 +357,18 @@ def install_pyaedt():
             subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "uv"], check=True, env=env)  # nosec
 
             print("Installing PyAEDT using online sources with uv...")
-            subprocess.run([str(uv_exe), "pip", "install", "--upgrade", "pip"], check=True, env=env)  # nosec
+            subprocess.run([str(uv_exe), "pip", "install", "--", "--upgrade", "pip"], check=True, env=env)  # nosec
             subprocess.run([str(uv_exe), "pip", "install", "wheel"], check=True, env=env)  # nosec
             if args.version <= "231":
                 subprocess.run([str(uv_exe), "pip", "install", "pyaedt[all]=='0.9.0'"] , check=True, env=env)  # nosec
                 subprocess.run([str(uv_exe), "pip", "install", "jupyterlab"], check=True, env=env)  # nosec
-                subprocess.run([str(uv_exe), "pip", "install", "ipython", "-U"], check=True, env=env)  # nosec
+                subprocess.run([str(uv_exe), "pip", "install", "--", "ipython", "-U"], check=True, env=env)  # nosec
                 subprocess.run([str(uv_exe), "pip", "install", "ipyvtklink"], check=True, env=env)  # nosec
             else:
                 subprocess.run([str(uv_exe), "pip", "install", "pyaedt[all]"], check=True, env=env)  # nosec
 
         if args.version <= "231":
-            subprocess.run([str(uv_exe), "pip", "uninstall", "-y", "pywin32"], check=True, env=env)  # nosec
+            subprocess.run([str(uv_exe), "pip", "uninstall", "--", "-y", "pywin32"], check=True, env=env)  # nosec
 
     else:
         print("Using existing virtual environment in {}".format(venv_dir))
@@ -404,13 +404,13 @@ def install_pyaedt():
         else:
             # Ensure uv is installed in the venv
             subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "uv"], check=True, env=env)  # nosec
-            subprocess.run([str(uv_exe), "pip", "uninstall", "-y", "pyaedt"], check=True, env=env)  # nosec
+            subprocess.run([str(uv_exe), "pip", "uninstall", "--", "-y", "pyaedt"], check=True, env=env)  # nosec
             
             print("Installing PyAEDT using online sources with uv...")
             if args.version <= "231":
                 subprocess.run([str(uv_exe), "pip", "install", "pyaedt[all]=='0.9.0'"] , check=True, env=env)  # nosec
                 subprocess.run([str(uv_exe), "pip", "install", "jupyterlab"], check=True, env=env)  # nosec
-                subprocess.run([str(uv_exe), "pip", "install", "ipython", "-U"], check=True, env=env)  # nosec
+                subprocess.run([str(uv_exe), "pip", "install", "--", "ipython", "-U"], check=True, env=env)  # nosec
                 subprocess.run([str(uv_exe), "pip", "install", "ipyvtklink"], check=True, env=env)  # nosec
             else:
                 subprocess.run([str(uv_exe), "pip", "install", "pyaedt[all]"], check=True, env=env)  # nosec

--- a/doc/source/Resources/pyaedt_installer_from_aedt.py
+++ b/doc/source/Resources/pyaedt_installer_from_aedt.py
@@ -357,18 +357,18 @@ def install_pyaedt():
             subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "uv"], check=True, env=env)  # nosec
 
             print("Installing PyAEDT using online sources with uv...")
-            subprocess.run([str(uv_exe), "pip", "install", "--", "--upgrade", "pip"], check=True, env=env)  # nosec
+            subprocess.run([str(uv_exe), "pip", "install", "--upgrade", "pip"], check=True, env=env)  # nosec
             subprocess.run([str(uv_exe), "pip", "install", "wheel"], check=True, env=env)  # nosec
             if args.version <= "231":
                 subprocess.run([str(uv_exe), "pip", "install", "pyaedt[all]=='0.9.0'"] , check=True, env=env)  # nosec
                 subprocess.run([str(uv_exe), "pip", "install", "jupyterlab"], check=True, env=env)  # nosec
-                subprocess.run([str(uv_exe), "pip", "install", "--", "ipython", "-U"], check=True, env=env)  # nosec
+                subprocess.run([str(uv_exe), "pip", "install", "ipython", "-U"], check=True, env=env)  # nosec
                 subprocess.run([str(uv_exe), "pip", "install", "ipyvtklink"], check=True, env=env)  # nosec
             else:
                 subprocess.run([str(uv_exe), "pip", "install", "pyaedt[all]"], check=True, env=env)  # nosec
 
         if args.version <= "231":
-            subprocess.run([str(uv_exe), "pip", "uninstall", "--", "-y", "pywin32"], check=True, env=env)  # nosec
+            subprocess.run([str(uv_exe), "pip", "uninstall", "pywin32"], check=True, env=env)  # nosec
 
     else:
         print("Using existing virtual environment in {}".format(venv_dir))
@@ -404,13 +404,13 @@ def install_pyaedt():
         else:
             # Ensure uv is installed in the venv
             subprocess.run([str(pip_exe), "--default-timeout=1000", "install", "uv"], check=True, env=env)  # nosec
-            subprocess.run([str(uv_exe), "pip", "uninstall", "--", "-y", "pyaedt"], check=True, env=env)  # nosec
+            subprocess.run([str(uv_exe), "pip", "uninstall", "pyaedt"], check=True, env=env)  # nosec
             
             print("Installing PyAEDT using online sources with uv...")
             if args.version <= "231":
                 subprocess.run([str(uv_exe), "pip", "install", "pyaedt[all]=='0.9.0'"] , check=True, env=env)  # nosec
                 subprocess.run([str(uv_exe), "pip", "install", "jupyterlab"], check=True, env=env)  # nosec
-                subprocess.run([str(uv_exe), "pip", "install", "--", "ipython", "-U"], check=True, env=env)  # nosec
+                subprocess.run([str(uv_exe), "pip", "install", "ipython", "-U"], check=True, env=env)  # nosec
                 subprocess.run([str(uv_exe), "pip", "install", "ipyvtklink"], check=True, env=env)  # nosec
             else:
                 subprocess.run([str(uv_exe), "pip", "install", "pyaedt[all]"], check=True, env=env)  # nosec


### PR DESCRIPTION
## Description
~`uv` does not support the `-y` flag directly when running `pip` commands. To correctly pass options like `-y`, one need to separate them from the `uv pip ...` command using `--`. This PR handles those required changes.~

~> Note: everything after `--` is meant for the internal `pip` call, not for `uv` itself.~

The solution to the problem is that `uv` doesn't require an interactive confirmation and simply uninstalls

## Issue linked
Close #6695

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
