### PR TITLE
FIX: Use solution type instead of report type in CreateOutputVariable

### DIFF
--- a/src/ansys/aedt/core/application/analysis.py
+++ b/src/ansys/aedt/core/application/analysis.py
@@ -1637,11 +1637,13 @@ class Analysis(Design, object):
             solution = self.existing_analysis_sweeps[0]
         if variable in self.output_variables:
             oModule.EditOutputVariable(
-                variable, expression, variable, solution, self.design_solutions.report_type, context
+                variable, expression, variable, solution, self.design_solutions.solution_type, context
             )
         else:
             try:
-                oModule.CreateOutputVariable(variable, expression, solution, self.design_solutions.report_type, context)
+                oModule.CreateOutputVariable(
+                    variable, expression, solution, self.design_solutions.solution_type, context
+                )
             except Exception:
                 raise AEDTRuntimeError("Invalid commands.")
         return True


### PR DESCRIPTION
## Description
Use solution_type in create_output_variable method when calling the native API

## Issue linked
#6724 

