### PR TITLE
FIX: Enable to import the lib again from MacOS

### DIFF
--- a/src/ansys/aedt/core/generic/settings.py
+++ b/src/ansys/aedt/core/generic/settings.py
@@ -39,7 +39,6 @@ The second class is intended for internal use only and shouldn't be modified by 
 import logging
 import os
 from pathlib import Path
-import platform
 import time
 from typing import Any
 from typing import List
@@ -52,8 +51,7 @@ from ansys.aedt.core import pyaedt_path
 from ansys.aedt.core.generic.scheduler import DEFAULT_CUSTOM_SUBMISSION_STRING
 from ansys.aedt.core.generic.scheduler import DEFAULT_NUM_CORES
 
-system = platform.system()
-is_linux = system == "Linux"
+is_linux = os.name == "posix"
 
 # Settings allowed to be updated using a YAML configuration file.
 ALLOWED_LOG_SETTINGS = [

--- a/src/ansys/aedt/core/internal/grpc_plugin_dll_class.py
+++ b/src/ansys/aedt/core/internal/grpc_plugin_dll_class.py
@@ -103,7 +103,7 @@ class AedtObjWrapper:
         self.__dict__["objectID"] = objID  # avoid derive class overwrite __setattr__
         self.__dict__["__methodNames__"] = listFuncs
         self.dllapi = AedtAPI
-        self.is_linux = True if os.name == "posix" else False
+        self.is_linux = os.name == "posix"
 
     # print(self.objectID)
 


### PR DESCRIPTION
## Description
Because of a recent change in `settings.py`, when importing the lib from MacOS, it fails because it tries to get an env variable not defined on this OS.

## Issue linked
Fix #6704

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
