### PR TITLE
Update pyaedt_installer_from_aedt.py

### DIFF
--- a/doc/source/Resources/pyaedt_installer_from_aedt.py
+++ b/doc/source/Resources/pyaedt_installer_from_aedt.py
@@ -350,8 +350,6 @@ def install_pyaedt():
                 "uv",
             ]
             subprocess.run(command, check=True, env=env)  # nosec
-            print("Activating uv in the virtual environment...")
-            subprocess.run([str(activate_script)], check=True, env=env)  # nosec
             print("Installing PyAEDT using provided wheels argument")
             command = [
                 str(uv_exe),


### PR DESCRIPTION
Remove a call to a virtual environment activate script, which fails as called but is also a noop even if it were run as subsequent calls would not retain the same environment.

## Description
Addresses an issue observed in running the proposed script from #6803 

## Issue linked
Part of fix for #6792

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
