### PR TITLE
Fix typos

### DIFF
--- a/src/ansys/aedt/core/modules/solve_setup.py
+++ b/src/ansys/aedt/core/modules/solve_setup.py
@@ -3079,7 +3079,7 @@ class SetupHFSS(Setup, PyAedtBase):
         return self.update()
 
     @pyaedt_function_handler()
-    def enable_adaptive_setup_broadband(self, low_frequency, high_frquency, max_passes=6, max_delta_s=0.02):
+    def enable_adaptive_setup_broadband(self, low_frequency, high_frequency, max_passes=6, max_delta_s=0.02):
         """Enable HFSS broadband setup.
 
         Parameters
@@ -3108,10 +3108,10 @@ class SetupHFSS(Setup, PyAedtBase):
             del self.props["MultipleAdaptiveFreqsSetup"][el]
         if isinstance(low_frequency, (int, float)):
             low_frequency = f"{low_frequency}GHz"
-        if isinstance(high_frquency, (int, float)):
-            high_frquency = f"{high_frquency}GHz"
+        if isinstance(high_frequency, (int, float)):
+            high_frequency = f"{high_frequency}GHz"
         self.props["MultipleAdaptiveFreqsSetup"]["Low"] = low_frequency
-        self.props["MultipleAdaptiveFreqsSetup"]["High"] = high_frquency
+        self.props["MultipleAdaptiveFreqsSetup"]["High"] = high_frequency
         self.props["MaximumPasses"] = max_passes
         self.props["MaxDeltaS"] = max_delta_s
         self.auto_update = True


### PR DESCRIPTION
## Description
Fixed the spelling error of the parameter 'high_frequency' in the function 'enable_adaptive_setup_broadband' within SetupHFSS, which could cause issues during parameterized calls.

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
