### PR TITLE
FIX: Move test_osm.py and add import_from_open_street_map to sequential tests

### DIFF
--- a/doc/changelog.d/7528.fixed.md
+++ b/doc/changelog.d/7528.fixed.md
@@ -1,0 +1,1 @@
+Move test_osm.py and add import_from_open_street_map to sequential tests

--- a/tests/system/general/test_primitives_3d.py
+++ b/tests/system/general/test_primitives_3d.py
@@ -22,9 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import json
 import os
-from pathlib import Path
 import shutil
 
 import pytest
@@ -2562,44 +2560,3 @@ def test_delete_all_points(aedt_app) -> None:
 
     assert result
     assert [] == aedt_app.modeler.oeditor.GetPoints()
-
-
-@pytest.mark.skipif(is_linux, reason="Failing VTK in Linux runners")
-def test_import_from_open_street_map(add_app, test_tmp_dir):
-    hfss = add_app(application=Hfss, solution_type="SBR+")
-
-    result = hfss.modeler.import_from_openstreet_map(
-        latitude_longitude=[40.273726, -80.168269],
-        env_name="test_hfss_environment",
-        terrain_radius=50,
-        road_step=3,
-        plot_before_importing=False,
-        import_in_aedt=True,
-    )
-
-    # Verify the result structure
-    assert result is not None
-    assert result["name"] == "test_hfss_environment"
-    assert result["type"] == "environment"
-    assert "parts" in result
-    assert "terrain" in result["parts"]
-    assert "buildings" in result["parts"]
-    assert "roads" in result["parts"]
-
-    # Verify objects were imported to HFSS
-    assert len(hfss.modeler.object_names) > 0
-
-    # Verify JSON file was created
-    json_file = Path(hfss.working_directory) / "test_hfss_environment.json"
-    assert json_file.exists()
-
-    # Verify JSON content
-    with open(json_file, "r", encoding="utf-8") as f:
-        json_data = json.load(f)
-        assert json_data["name"] == "test_hfss_environment"
-        assert json_data["radius"] == 50
-
-    # Verify model units are set to meters
-    assert hfss.modeler.model_units == "meter"
-
-    hfss.close_project(save=False)

--- a/tests/system/general/test_sbr.py
+++ b/tests/system/general/test_sbr.py
@@ -258,17 +258,6 @@ def test_add_sbr_boundaries_in_hfss_solution(aedt_terminal) -> None:
         aedt_terminal.create_sbr_file_based_antenna(far_field_data=str(ffd_test_path))
 
 
-@pytest.mark.skipif(on_ci, reason="Map download takes too long for unit test.")
-@pytest.mark.skipif(is_linux, reason="Not supported.")
-def test_import_map(aedt_sbr) -> None:
-    ansys_home = [40.273726, -80.168269]
-    parts_dict = aedt_sbr.modeler.import_from_openstreet_map(
-        ansys_home, terrain_radius=200, road_step=3, plot_before_importing=False, import_in_aedt=True
-    )
-    for part in parts_dict["parts"]:
-        assert Path(parts_dict["parts"][part]["file_name"]).exists()
-
-
 def test_create_custom_array(aedt_sbr) -> None:
     output_file1 = aedt_sbr.create_sbr_custom_array_file()
     assert Path(output_file1).is_file()

--- a/tests/system/solvers/sequential/test_osm.py
+++ b/tests/system/solvers/sequential/test_osm.py
@@ -24,18 +24,17 @@
 
 """Test OpenStreetMap (OSM) module functionality with real pyvista and osmnx."""
 
+import json
+from pathlib import Path
+
 import numpy as np
 import pytest
 
+from ansys.aedt.core import Hfss
+from ansys.aedt.core.generic.settings import is_linux
 from ansys.aedt.core.modeler.advanced_cad.osm import BuildingsPrep
 from ansys.aedt.core.modeler.advanced_cad.osm import RoadPrep
 from ansys.aedt.core.modeler.advanced_cad.osm import TerrainPrep
-
-
-@pytest.fixture(scope="module", autouse=True)
-def desktop() -> None:
-    """Override the desktop fixture to DO NOT open the Desktop when running this test class."""
-    return
 
 
 @pytest.fixture
@@ -46,9 +45,48 @@ def temp_cad_path(tmp_path):
     return str(cad_dir)
 
 
+@pytest.mark.skipif(is_linux, reason="Failing VTK in Linux runners")
+def test_import_from_open_street_map(add_app, test_tmp_dir):
+    hfss = add_app(application=Hfss, solution_type="SBR+")
+
+    result = hfss.modeler.import_from_openstreet_map(
+        latitude_longitude=[40.273726, -80.168269],
+        env_name="test_hfss_environment",
+        terrain_radius=50,
+        road_step=3,
+        plot_before_importing=False,
+        import_in_aedt=True,
+    )
+
+    # Verify the result structure
+    assert result is not None
+    assert result["name"] == "test_hfss_environment"
+    assert result["type"] == "environment"
+    assert "parts" in result
+    assert "terrain" in result["parts"]
+    assert "buildings" in result["parts"]
+    assert "roads" in result["parts"]
+
+    # Verify objects were imported to HFSS
+    assert len(hfss.modeler.object_names) > 0
+
+    # Verify JSON file was created
+    json_file = Path(hfss.working_directory) / "test_hfss_environment.json"
+    assert json_file.exists()
+
+    # Verify JSON content
+    with open(json_file, "r", encoding="utf-8") as f:
+        json_data = json.load(f)
+        assert json_data["name"] == "test_hfss_environment"
+        assert json_data["radius"] == 50
+
+    # Verify model units are set to meters
+    assert hfss.modeler.model_units == "meter"
+
+    hfss.close_project(save=False)
+
+
 # BuildingsPrep tests
-
-
 def test_buildings_init(temp_cad_path):
     """Test BuildingsPrep initialization."""
     buildings_prep = BuildingsPrep(temp_cad_path)
@@ -67,8 +105,6 @@ def test_create_building_roof(temp_cad_path):
 
 
 # RoadPrep tests
-
-
 def test_road_init(temp_cad_path):
     """Test RoadPrep initialization."""
     road_prep = RoadPrep(temp_cad_path)
@@ -95,8 +131,6 @@ def test_create_roads(temp_cad_path):
 
 
 # TerrainPrep tests
-
-
 def test_terrain_init(temp_cad_path):
     """Test TerrainPrep initialization."""
     terrain_prep = TerrainPrep(temp_cad_path)
@@ -164,8 +198,6 @@ def test_terrain_get_elevation_different_grid_sizes():
 
 
 # File operations tests
-
-
 def test_buildings_path_handling(temp_cad_path):
     """Test that BuildingsPrep handles paths correctly."""
     buildings_prep = BuildingsPrep(temp_cad_path)


### PR DESCRIPTION
## Description

This pull request refactors and reorganizes the OpenStreetMap (OSM) related tests to improve test structure and maintainability. The main changes involve moving and consolidating OSM tests into a dedicated file, cleaning up imports, and removing duplicated or slow-running tests from other test suites.

**Test organization and cleanup:**

* Moved OSM-related tests from `tests/system/general/test_osm.py` to `tests/system/solvers/sequential/test_osm.py`, renaming the file and consolidating all OSM tests in one place.
* Added the `test_import_from_open_street_map` test to the new OSM test file and removed it from `test_primitives_3d.py`, ensuring it is only executed in the appropriate context.

These changes streamline OSM test coverage and reduce test suite complexity, making it easier to maintain and run tests efficiently.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
