### PR TITLE
FIX: Maintain ServiceManager connection

### DIFF
--- a/doc/changelog.d/7535.fixed.md
+++ b/doc/changelog.d/7535.fixed.md
@@ -1,0 +1,1 @@
+Maintain ServiceManager connection

--- a/src/ansys/aedt/core/common_rpc.py
+++ b/src/ansys/aedt/core/common_rpc.py
@@ -358,6 +358,12 @@ def create_session(
 
         cl = connect(host, port)
         logger.info("Created new session on port %s", port)
+        # NOTE: Keep the ServiceManager connection alive by attaching it to the
+        # GlobalService client object.  If this reference is dropped, Python's GC
+        # will close the ServiceManager connection which triggers on_disconnect and
+        # terminates every GlobalService subprocess it spawned – closing the stream
+        # underneath cl and making it unusable.
+        cl._service_manager_connection = client
         if "host" not in dir(cl):
             cl.host = host
         if "aedt_port" not in dir(cl):


### PR DESCRIPTION
This pull request introduces a safeguard to ensure the stability of the session management system by maintaining a persistent connection to the `ServiceManager`. The main change prevents the premature termination of subprocesses by keeping the `ServiceManager` connection alive for the duration of the session.

Session management stability:

* In `common_rpc.py`, the `create_session` function now attaches the `ServiceManager` connection to the `GlobalService` client object (`cl._service_manager_connection = client`) to prevent Python's garbage collector from closing the connection and inadvertently terminating all spawned subprocesses.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
