### PR TITLE
FIX: Export .tab format in Field Distribution Extension

### DIFF
--- a/doc/changelog.d/7536.fixed.md
+++ b/doc/changelog.d/7536.fixed.md
@@ -1,0 +1,1 @@
+Export .tab format in Field Distribution Extension

--- a/src/ansys/aedt/core/extensions/maxwell3d/fields_distribution.py
+++ b/src/ansys/aedt/core/extensions/maxwell3d/fields_distribution.py
@@ -511,13 +511,17 @@ def main(data: FieldsDistributionExtensionData) -> bool:
             if len(tmp) > 1:
                 csv_data.append(tmp)
 
-    if Path(export_file).suffix == ".csv" or Path(export_file).suffix == ".tab":
-        output_file = Path(export_file).with_suffix(Path(export_file).suffix)
-        write_csv(output_file, csv_data)
-    elif Path(export_file).suffix == ".npy":
-        output_file = Path(export_file).with_suffix(".npy")
-        array = np.array(csv_data)
-        np.save(output_file, array)
+    output_file = Path(export_file)
+    match output_file.suffix:
+        case ".csv":
+            write_csv(str(output_file), csv_data)
+        case ".tab":
+            write_csv(str(output_file), csv_data, delimiter="\t")
+        case ".npy":
+            array = np.array(csv_data)
+            np.save(output_file, array)
+        case _:
+            raise AEDTRuntimeError(f"{output_file.suffix} is not supported.")
 
     if "PYTEST_CURRENT_TEST" not in os.environ:  # pragma: no cover
         app.release_desktop(False, False)

--- a/tests/unit/extensions/test_fields_distribution.py
+++ b/tests/unit/extensions/test_fields_distribution.py
@@ -23,15 +23,18 @@
 
 import json
 import tkinter
+from pathlib import Path
 from unittest.mock import MagicMock
 from unittest.mock import mock_open
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 from ansys.aedt.core.extensions.maxwell3d.fields_distribution import EXTENSION_TITLE
 from ansys.aedt.core.extensions.maxwell3d.fields_distribution import FieldsDistributionExtension
 from ansys.aedt.core.extensions.maxwell3d.fields_distribution import FieldsDistributionExtensionData
+from ansys.aedt.core.extensions.maxwell3d.fields_distribution import main
 
 
 @pytest.mark.parametrize("mock_maxwell_3d_app", ["2026.1"], indirect=True)
@@ -698,3 +701,209 @@ def test_popup_destroy_called(mock_maxwell_3d_app) -> None:
             assert mock_popup.title.called
 
         extension.root.destroy()
+
+
+def test_main_export_tab_file(tmp_path):
+    """Test main function exports .tab file using write_csv with tab delimiter."""
+    # Create a fake .fld file that main() will read
+    fld_content = "Header line 1\nHeader line 2\n1.0 2.0 3.0\n4.0 5.0 6.0\n"
+    fld_path = tmp_path / "output.fld"
+    fld_path.write_text(fld_content)
+
+    tab_path = tmp_path / "output.tab"
+
+    data = FieldsDistributionExtensionData(
+        export_file=str(tab_path),
+        export_option="Ohmic loss",
+        objects_list=["Object1"],
+        solution_option="Setup1 : LastAdaptive",
+    )
+
+    # Mock Desktop and get_pyaedt_app
+    mock_desktop = MagicMock()
+    mock_project = MagicMock()
+    mock_project.GetName.return_value = "Project1"
+    mock_design = MagicMock()
+    mock_design.GetName.return_value = "Design1"
+    mock_desktop.active_project.return_value = mock_project
+    mock_desktop.active_design.return_value = mock_design
+
+    mock_aedtapp = MagicMock()
+    mock_aedtapp.design_type = "Maxwell 3D"
+
+    # Mock the setup so it appears solved
+    mock_setup = MagicMock()
+    mock_setup.name = "Setup1"
+    mock_setup.is_solved = True
+    mock_aedtapp.setups = [mock_setup]
+
+    with (
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.ansys.aedt.core.Desktop",
+            return_value=mock_desktop,
+        ),
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.get_pyaedt_app",
+            return_value=mock_aedtapp,
+        ),
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.write_csv"
+        ) as mock_write_csv,
+    ):
+        result = main(data)
+
+    assert result is True
+    mock_write_csv.assert_called_once_with(str(tab_path), [["1.0", "2.0", "3.0"], ["4.0", "5.0", "6.0"]], delimiter="\t")
+
+
+def test_main_export_csv_file(tmp_path):
+    """Test main function exports .csv file using write_csv with default comma delimiter."""
+    fld_content = "Header line 1\nHeader line 2\n1.0 2.0 3.0\n4.0 5.0 6.0\n"
+    fld_path = tmp_path / "output.fld"
+    fld_path.write_text(fld_content)
+
+    csv_path = tmp_path / "output.csv"
+
+    data = FieldsDistributionExtensionData(
+        export_file=str(csv_path),
+        export_option="Ohmic loss",
+        objects_list=["Object1"],
+        solution_option="Setup1 : LastAdaptive",
+    )
+
+    mock_desktop = MagicMock()
+    mock_project = MagicMock()
+    mock_project.GetName.return_value = "Project1"
+    mock_design = MagicMock()
+    mock_design.GetName.return_value = "Design1"
+    mock_desktop.active_project.return_value = mock_project
+    mock_desktop.active_design.return_value = mock_design
+
+    mock_aedtapp = MagicMock()
+    mock_aedtapp.design_type = "Maxwell 3D"
+
+    mock_setup = MagicMock()
+    mock_setup.name = "Setup1"
+    mock_setup.is_solved = True
+    mock_aedtapp.setups = [mock_setup]
+
+    with (
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.ansys.aedt.core.Desktop",
+            return_value=mock_desktop,
+        ),
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.get_pyaedt_app",
+            return_value=mock_aedtapp,
+        ),
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.write_csv"
+        ) as mock_write_csv,
+    ):
+        result = main(data)
+
+    assert result is True
+    mock_write_csv.assert_called_once_with(
+        str(csv_path), [["1.0", "2.0", "3.0"], ["4.0", "5.0", "6.0"]]
+    )
+
+
+def test_main_export_npy_file(tmp_path):
+    """Test main function exports .npy file using numpy save."""
+    fld_content = "Header line 1\nHeader line 2\n1.0 2.0 3.0\n4.0 5.0 6.0\n"
+    fld_path = tmp_path / "output.fld"
+    fld_path.write_text(fld_content)
+
+    npy_path = tmp_path / "output.npy"
+
+    data = FieldsDistributionExtensionData(
+        export_file=str(npy_path),
+        export_option="Ohmic loss",
+        objects_list=["Object1"],
+        solution_option="Setup1 : LastAdaptive",
+    )
+
+    mock_desktop = MagicMock()
+    mock_project = MagicMock()
+    mock_project.GetName.return_value = "Project1"
+    mock_design = MagicMock()
+    mock_design.GetName.return_value = "Design1"
+    mock_desktop.active_project.return_value = mock_project
+    mock_desktop.active_design.return_value = mock_design
+
+    mock_aedtapp = MagicMock()
+    mock_aedtapp.design_type = "Maxwell 3D"
+
+    mock_setup = MagicMock()
+    mock_setup.name = "Setup1"
+    mock_setup.is_solved = True
+    mock_aedtapp.setups = [mock_setup]
+
+    with (
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.ansys.aedt.core.Desktop",
+            return_value=mock_desktop,
+        ),
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.get_pyaedt_app",
+            return_value=mock_aedtapp,
+        ),
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.np.save"
+        ) as mock_np_save,
+    ):
+        result = main(data)
+
+    assert result is True
+    mock_np_save.assert_called_once()
+    saved_path = mock_np_save.call_args[0][0]
+    saved_array = mock_np_save.call_args[0][1]
+    assert saved_path == Path(str(npy_path))
+    expected = np.array([["1.0", "2.0", "3.0"], ["4.0", "5.0", "6.0"]])
+    np.testing.assert_array_equal(saved_array, expected)
+
+
+def test_main_export_unsupported_suffix(tmp_path):
+    """Test main function raises error for unsupported file extension."""
+    fld_content = "Header line 1\nHeader line 2\n1.0 2.0 3.0\n4.0 5.0 6.0\n"
+    fld_path = tmp_path / "output.fld"
+    fld_path.write_text(fld_content)
+
+    bad_path = tmp_path / "output.xyz"
+
+    data = FieldsDistributionExtensionData(
+        export_file=str(bad_path),
+        export_option="Ohmic loss",
+        objects_list=["Object1"],
+        solution_option="Setup1 : LastAdaptive",
+    )
+
+    mock_desktop = MagicMock()
+    mock_project = MagicMock()
+    mock_project.GetName.return_value = "Project1"
+    mock_design = MagicMock()
+    mock_design.GetName.return_value = "Design1"
+    mock_desktop.active_project.return_value = mock_project
+    mock_desktop.active_design.return_value = mock_design
+
+    mock_aedtapp = MagicMock()
+    mock_aedtapp.design_type = "Maxwell 3D"
+
+    mock_setup = MagicMock()
+    mock_setup.name = "Setup1"
+    mock_setup.is_solved = True
+    mock_aedtapp.setups = [mock_setup]
+
+    with (
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.ansys.aedt.core.Desktop",
+            return_value=mock_desktop,
+        ),
+        patch(
+            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.get_pyaedt_app",
+            return_value=mock_aedtapp,
+        ),
+        pytest.raises(Exception, match=r"\.xyz is not supported"),
+    ):
+        main(data)
+

--- a/tests/unit/extensions/test_fields_distribution.py
+++ b/tests/unit/extensions/test_fields_distribution.py
@@ -22,8 +22,8 @@
 # THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import json
-import tkinter
 from pathlib import Path
+import tkinter
 from unittest.mock import MagicMock
 from unittest.mock import mock_open
 from unittest.mock import patch
@@ -746,14 +746,14 @@ def test_main_export_tab_file(tmp_path):
             "ansys.aedt.core.extensions.maxwell3d.fields_distribution.get_pyaedt_app",
             return_value=mock_aedtapp,
         ),
-        patch(
-            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.write_csv"
-        ) as mock_write_csv,
+        patch("ansys.aedt.core.extensions.maxwell3d.fields_distribution.write_csv") as mock_write_csv,
     ):
         result = main(data)
 
     assert result is True
-    mock_write_csv.assert_called_once_with(str(tab_path), [["1.0", "2.0", "3.0"], ["4.0", "5.0", "6.0"]], delimiter="\t")
+    mock_write_csv.assert_called_once_with(
+        str(tab_path), [["1.0", "2.0", "3.0"], ["4.0", "5.0", "6.0"]], delimiter="\t"
+    )
 
 
 def test_main_export_csv_file(tmp_path):
@@ -796,16 +796,12 @@ def test_main_export_csv_file(tmp_path):
             "ansys.aedt.core.extensions.maxwell3d.fields_distribution.get_pyaedt_app",
             return_value=mock_aedtapp,
         ),
-        patch(
-            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.write_csv"
-        ) as mock_write_csv,
+        patch("ansys.aedt.core.extensions.maxwell3d.fields_distribution.write_csv") as mock_write_csv,
     ):
         result = main(data)
 
     assert result is True
-    mock_write_csv.assert_called_once_with(
-        str(csv_path), [["1.0", "2.0", "3.0"], ["4.0", "5.0", "6.0"]]
-    )
+    mock_write_csv.assert_called_once_with(str(csv_path), [["1.0", "2.0", "3.0"], ["4.0", "5.0", "6.0"]])
 
 
 def test_main_export_npy_file(tmp_path):
@@ -848,9 +844,7 @@ def test_main_export_npy_file(tmp_path):
             "ansys.aedt.core.extensions.maxwell3d.fields_distribution.get_pyaedt_app",
             return_value=mock_aedtapp,
         ),
-        patch(
-            "ansys.aedt.core.extensions.maxwell3d.fields_distribution.np.save"
-        ) as mock_np_save,
+        patch("ansys.aedt.core.extensions.maxwell3d.fields_distribution.np.save") as mock_np_save,
     ):
         result = main(data)
 
@@ -906,4 +900,3 @@ def test_main_export_unsupported_suffix(tmp_path):
         pytest.raises(Exception, match=r"\.xyz is not supported"),
     ):
         main(data)
-


### PR DESCRIPTION
## Description
The original output file used comma separated values as delimiter for both .csv and .tab files. 
- Fixed the issue by adding the delimiter to the write_csv method
- Refactored the code to make it easier to add future formats
- Wrote tests
- 
## Issue linked
#7480 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
