### PR TITLE
FIX: Handle exceptions when reading process command line arguments

### DIFF
--- a/doc/changelog.d/7550.fixed.md
+++ b/doc/changelog.d/7550.fixed.md
@@ -1,0 +1,1 @@
+Handle exceptions when reading process command line arguments

--- a/src/ansys/aedt/core/generic/general_methods.py
+++ b/src/ansys/aedt/core/generic/general_methods.py
@@ -868,11 +868,14 @@ def _get_target_processes(target_name: list[str]) -> list[tuple[int, list[str]]]
                 pids += subprocess.check_output(["pgrep", "-x", process_name]).decode().split()  # nosec
 
             for pid in pids:
-                if os.path.exists(f"/proc/{pid}/cmdline"):
+                try:
                     with open(f"/proc/{pid}/cmdline", "rb") as f:
                         # Command line arguments in /proc are null-byte separated
                         cmdline = f.read().decode().split("\0")
                         found_data.append((int(pid), [arg for arg in cmdline if arg]))
+                except (FileNotFoundError, ProcessLookupError, PermissionError):  # pragma: no cover
+                    # Process may have exited between pgrep and open/read.
+                    pyaedt_logger.debug(f"Process {pid} exited before its cmdline could be read.")
         except subprocess.CalledProcessError:
             pyaedt_logger.debug("No matching processes found.")
 


### PR DESCRIPTION
## Description

This pull request improves the robustness of the `_get_target_processes` function by handling cases where a process may exit between being found and reading its command line arguments. Now, if the process no longer exists or cannot be accessed, the function logs a debug message instead of raising an exception.

**Error handling improvements:**

* Updated `_get_target_processes` in `src/ansys/aedt/core/generic/general_methods.py` to wrap the process command line reading in a `try` block, catching `FileNotFoundError`, `ProcessLookupError`, and `PermissionError`, and logging a debug message if the process cannot be accessed.

## Issue linked
Close #7508

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
