### PR TITLE
FIX: Fix LSF issues

### DIFF
--- a/doc/changelog.d/7552.fixed.md
+++ b/doc/changelog.d/7552.fixed.md
@@ -1,0 +1,1 @@
+Fix LSF issues

--- a/doc/source/Getting_started/Installation.rst
+++ b/doc/source/Getting_started/Installation.rst
@@ -197,7 +197,8 @@ However, you must set up the following environment variables:
 
 .. code::
 
-    export ANSYSEM_ROOT261=/path/to/AedtRoot/AnsysEM/v261/Linux64
+    export ANSYSEM_ROOT261=/path/to/Ansys Inc/v261/AnsysEM
+    export LD_LIBRARY_PATH=/path/to/Ansys Inc/v261/AnsysEM
 
 
 Install offline from a wheelhouse

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -160,6 +160,8 @@ class _ServerArgs:
 
     @property
     def host_ip(self):
+        if self.__host in ["127.0.0.1", "localhost", "0.0.0.0"]:
+            return self.__host
         return get_local_ip(self.__host)
 
 

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -94,13 +94,11 @@ class TransportMode(str, Enum):
 
 
 def get_local_ip(host):
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         host = host if host else socket.gethostname()
-        s.connect((host, 80))
-        return s.getsockname()[0]
-    finally:
-        s.close()
+        return socket.gethostbyname(host)
+    except Exception:
+        return "127.0.0.1"
 
 
 class _ServerArgs:

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -96,6 +96,7 @@ class TransportMode(str, Enum):
 def get_local_ip(host):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
+        host = host if host else socket.gethostname()
         s.connect((host, 80))
         return s.getsockname()[0]
     finally:
@@ -144,10 +145,13 @@ class _ServerArgs:
             return f"{self.__port}" if self.__port is not None else ""
         if self.__mode not in (TransportMode.MTLS, TransportMode.INSECURE):
             raise ValueError(f"Invalid transport mode {self.__mode}.")
-        host = self.__host if not settings.grpc_listen_all else "0.0.0.0"  # nosec
+
+        host = self.__host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
 
         if host not in ["127.0.0.1", "localhost", "0.0.0.0"]:  # nosec
             self.__host = get_local_ip(self.__host)
+
+        host = self.__host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
 
         mode = (
             "SecureMode"
@@ -155,6 +159,10 @@ class _ServerArgs:
             else "InsecureMode"
         )
         return f"{host}:{self.__port}:{mode}" if self.__port is not None else f"{host}:{mode}"
+
+    @property
+    def host_ip(self):
+        return get_local_ip(self.__host)
 
 
 def _get_grpcsrv_args(host: str | None, port: int) -> _ServerArgs:
@@ -2662,7 +2670,7 @@ class Desktop(PyAedtBase):
             self.grpc_plugin = AEDT(os.environ["DesktopPluginPyAEDT"])
             server_args: _ServerArgs = _get_grpcsrv_args(self.machine, self.port)
             if str(server_args).endswith((":SecureMode", ":InsecureMode")):
-                self.machine = str(server_args).split(":")[0] + ":" + str(server_args).split(":")[-1]
+                self.machine = server_args.host_ip + ":" + str(server_args).split(":")[-1]
             # NOTE: When working locally, machine is updated to an empty string to work with UDS.
             # This is necessary when working with UDS and also works for WNUA.
             elif settings.grpc_local and settings.grpc_secure_mode and "ANSYS_GRPC_CERTIFICATES" not in os.environ:

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -129,6 +129,16 @@ class _ServerArgs:
         """Get transport mode."""
         return self.__mode
 
+    @property
+    def host(self):
+        """Get host."""
+        return self.__host
+
+    @property
+    def port(self):
+        """Get port."""
+        return self.__port
+
     def __check_settings(self):
         """Validate settings to ensure they are compatible with the transport mode."""
         if settings.grpc_local and settings.grpc_listen_all:
@@ -144,12 +154,12 @@ class _ServerArgs:
         if self.__mode not in (TransportMode.MTLS, TransportMode.INSECURE):
             raise ValueError(f"Invalid transport mode {self.__mode}.")
 
-        host = self.__host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
+        host = self.host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
 
         if host not in ["127.0.0.1", "localhost", "0.0.0.0"]:  # nosec
-            self.__host = get_local_ip(self.__host)
+            self.__host = get_local_ip(self.host)
 
-        host = self.__host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
+        host = self.host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
 
         mode = (
             "SecureMode"
@@ -160,9 +170,7 @@ class _ServerArgs:
 
     @property
     def host_ip(self):
-        if self.__host in ["127.0.0.1", "localhost", "0.0.0.0"]:
-            return self.__host
-        return get_local_ip(self.__host)
+        return get_local_ip(self.host)
 
 
 def _get_grpcsrv_args(host: str | None, port: int) -> _ServerArgs:
@@ -2670,7 +2678,10 @@ class Desktop(PyAedtBase):
             self.grpc_plugin = AEDT(os.environ["DesktopPluginPyAEDT"])
             server_args: _ServerArgs = _get_grpcsrv_args(self.machine, self.port)
             if str(server_args).endswith((":SecureMode", ":InsecureMode")):
-                self.machine = server_args.host_ip + ":" + str(server_args).split(":")[-1]
+                host_ip = server_args.host_ip
+                if server_args.host == "localhost":
+                    host_ip = "localhost"
+                self.machine = host_ip + ":" + str(server_args).split(":")[-1]
             # NOTE: When working locally, machine is updated to an empty string to work with UDS.
             # This is necessary when working with UDS and also works for WNUA.
             elif settings.grpc_local and settings.grpc_secure_mode and "ANSYS_GRPC_CERTIFICATES" not in os.environ:

--- a/src/ansys/aedt/core/extensions/customize_automation_tab.py
+++ b/src/ansys/aedt/core/extensions/customize_automation_tab.py
@@ -537,7 +537,6 @@ def add_custom_toolkit(
         os.environ[f"ANSYSEM_ROOT{version}"] = str(edt_root)
         ld_library_path_dirs_to_add = [
             f"{edt_root}/commonfiles/CPython/{python_version_new}/linx64/Release/python/lib",
-            f"{edt_root}/common/mono/Linux64/lib64",
             f"{edt_root}",
         ]
         if version < "232":

--- a/tests/unit/test_desktop.py
+++ b/tests/unit/test_desktop.py
@@ -212,6 +212,7 @@ def test_grpc_server_args_repr_with_mtls(mock_settings, port, monkeypatch) -> No
     monkeypatch.setenv("ANSYS_GRPC_CERTIFICATES", "dummy_path")
     mock_settings.grpc_local = True
     mock_settings.grpc_listen_all = False
+    mock_settings.use_lsf_scheduler = False
     host = "127.0.0.1"
 
     server_args = _ServerArgs(host=host, port=port, mode=TransportMode.MTLS)
@@ -224,6 +225,7 @@ def test_grpc_server_args_repr_with_insecure(mock_settings, port, monkeypatch) -
     """Test the string representation of _ServerArgs for Insecure mode."""
     mock_settings.grpc_local = True
     mock_settings.grpc_listen_all = False
+    mock_settings.use_lsf_scheduler = False
     host = "127.0.0.1"
 
     server_args = _ServerArgs(host=host, port=port, mode=TransportMode.INSECURE)


### PR DESCRIPTION
## Description
This pull request updates how the local IP address is determined and improves the handling of server arguments in the `desktop.py` module. The main focus is on making the IP resolution more robust and ensuring compatibility with different settings, such as LSF scheduler and listening modes. Below are the most important changes:

**IP Resolution and Host Handling:**

* Refactored the `get_local_ip` function to use `socket.gethostbyname` instead of creating a socket connection, with a fallback to `"127.0.0.1"` on failure. This simplifies and stabilizes IP resolution.
* Updated logic in the `__repr__` method of the `_ServerArgs` class to consider both `grpc_listen_all` and `use_lsf_scheduler` settings when determining the host to use, defaulting to `"0.0.0.0"` when appropriate.
* Added a new `host_ip` property to `_ServerArgs` to expose the resolved local IP address using the updated `get_local_ip` function.

**Server Initialization:**

* Modified the server initialization logic to use the new `host_ip` property when updating the `machine` attribute, ensuring the correct IP is used in server address strings.

## Issue linked
Close #7435 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
