### PR TITLE
FEAT: Improve desktop initialize

### DIFF
--- a/doc/changelog.d/7555.added.md
+++ b/doc/changelog.d/7555.added.md
@@ -1,0 +1,1 @@
+Improve desktop initialize

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -185,7 +185,7 @@ class _ServerArgs:
 
         mode = (
             "SecureMode"
-            if self.__mode == TransportMode.MTLS and os.environ.get("ANSYS_GRPC_CERTIFICATES", None)
+            if self.mode == TransportMode.MTLS and os.environ.get("ANSYS_GRPC_CERTIFICATES", None)
             else "InsecureMode"
         )
         return f"{host}:{self.port}:{mode}" if self.port is not None else f"{host}:{mode}"

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -108,7 +108,7 @@ class _ServerArgs:
     :func:`_get_grpcsrv_args<ansys.aedt.core.desktop._get_grpcsrv_args>` function instead.
     """
 
-    def __init__(self, mode, host=None, port=None) -> None:
+    def __init__(self, mode: "TransportMode", host: str | None = None, port: int | None = None) -> None:
         """Initialize server arguments.
 
         Parameters
@@ -125,27 +125,27 @@ class _ServerArgs:
         self.__port = port
 
     @property
-    def mode(self):
+    def mode(self) -> "TransportMode":
         """Get transport mode."""
         return self.__mode
 
     @property
-    def host(self):
+    def host(self) -> str:
         """Get host."""
         return self.__host
 
     @property
-    def port(self):
+    def port(self) -> int:
         """Get port."""
         return self.__port
 
     @property
-    def host_ip(self):
+    def host_ip(self) -> str:
         """Get host ip."""
         return get_local_ip(self.host)
 
     @property
-    def client_machine(self):
+    def client_machine(self) -> str:
         """Get client machine."""
         machine = self.host
         if str(self).endswith((":SecureMode", ":InsecureMode")):
@@ -165,7 +165,8 @@ class _ServerArgs:
             machine = self.host_ip
         return machine
 
-    def __check_settings(self):
+    @staticmethod
+    def __check_settings():
         """Validate settings to ensure they are compatible with the transport mode."""
         if settings.grpc_local and settings.grpc_listen_all:
             raise AEDTRuntimeError(
@@ -175,10 +176,10 @@ class _ServerArgs:
     def __repr__(self) -> str:
         self.__check_settings()
 
-        if self.__mode in (TransportMode.UDS, TransportMode.WNUA):
-            return f"{self.__port}" if self.__port is not None else ""
-        if self.__mode not in (TransportMode.MTLS, TransportMode.INSECURE):
-            raise ValueError(f"Invalid transport mode {self.__mode}.")
+        if self.mode in (TransportMode.UDS, TransportMode.WNUA):
+            return f"{self.port}" if self.port is not None else ""
+        if self.mode not in (TransportMode.MTLS, TransportMode.INSECURE):
+            raise ValueError(f"Invalid transport mode {self.mode}.")
 
         host = self.host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
 
@@ -187,7 +188,7 @@ class _ServerArgs:
             if self.__mode == TransportMode.MTLS and os.environ.get("ANSYS_GRPC_CERTIFICATES", None)
             else "InsecureMode"
         )
-        return f"{host}:{self.__port}:{mode}" if self.__port is not None else f"{host}:{mode}"
+        return f"{host}:{self.port}:{mode}" if self.port is not None else f"{host}:{mode}"
 
 
 def _get_grpcsrv_args(host: str | None, port: int) -> _ServerArgs:

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -145,9 +145,9 @@ class _ServerArgs:
 
     @property
     def client_machine(self):
-        machine = self.host_ip
+        machine = self.host
         if str(self).endswith((":SecureMode", ":InsecureMode")):
-            host_ip = self.host_ip
+            host_ip = self.host
             machine = host_ip + ":" + str(self).split(":")[-1]
 
         # NOTE: When working locally, machine is updated to an empty string to work with UDS.
@@ -178,7 +178,7 @@ class _ServerArgs:
         if self.__mode not in (TransportMode.MTLS, TransportMode.INSECURE):
             raise ValueError(f"Invalid transport mode {self.__mode}.")
 
-        host = self.host_ip if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
+        host = self.host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
 
         mode = (
             "SecureMode"

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -139,6 +139,30 @@ class _ServerArgs:
         """Get port."""
         return self.__port
 
+    @property
+    def host_ip(self):
+        return get_local_ip(self.host)
+
+    @property
+    def client_machine(self):
+        machine = self.host_ip
+        if str(self).endswith((":SecureMode", ":InsecureMode")):
+            host_ip = self.host_ip
+            machine = host_ip + ":" + str(self).split(":")[-1]
+
+        # NOTE: When working locally, machine is updated to an empty string to work with UDS.
+        # This is necessary when working with UDS and also works for WNUA.
+        elif settings.grpc_local and settings.grpc_secure_mode and "ANSYS_GRPC_CERTIFICATES" not in os.environ:
+            pyaedt_logger.debug("Setting machine to '' to work with UDS/WNUA connection mechanism.")
+            machine = ""
+
+        # NOTE: Update command if PYAEDT_USE_PRE_GRPC_ARGS is set to allow working
+        # with previous SP where grpc transport mode were not available
+        # This environment variable is not necessary for UDS and WNUA modes.
+        if os.environ.get("PYAEDT_USE_PRE_GRPC_ARGS", "False") == "True":
+            machine = self.host_ip
+        return machine
+
     def __check_settings(self):
         """Validate settings to ensure they are compatible with the transport mode."""
         if settings.grpc_local and settings.grpc_listen_all:
@@ -154,12 +178,7 @@ class _ServerArgs:
         if self.__mode not in (TransportMode.MTLS, TransportMode.INSECURE):
             raise ValueError(f"Invalid transport mode {self.__mode}.")
 
-        host = self.host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
-
-        if host not in ["127.0.0.1", "localhost", "0.0.0.0"]:  # nosec
-            self.__host = get_local_ip(self.host)
-
-        host = self.host if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
+        host = self.host_ip if not settings.grpc_listen_all and not settings.use_lsf_scheduler else "0.0.0.0"  # nosec
 
         mode = (
             "SecureMode"
@@ -167,10 +186,6 @@ class _ServerArgs:
             else "InsecureMode"
         )
         return f"{host}:{self.__port}:{mode}" if self.__port is not None else f"{host}:{mode}"
-
-    @property
-    def host_ip(self):
-        return get_local_ip(self.host)
 
 
 def _get_grpcsrv_args(host: str | None, port: int) -> _ServerArgs:
@@ -2677,23 +2692,10 @@ class Desktop(PyAedtBase):
                 )
             self.grpc_plugin = AEDT(os.environ["DesktopPluginPyAEDT"])
             server_args: _ServerArgs = _get_grpcsrv_args(self.machine, self.port)
-            if str(server_args).endswith((":SecureMode", ":InsecureMode")):
-                host_ip = server_args.host_ip
-                if server_args.host == "localhost":
-                    host_ip = "localhost"
-                self.machine = host_ip + ":" + str(server_args).split(":")[-1]
-            # NOTE: When working locally, machine is updated to an empty string to work with UDS.
-            # This is necessary when working with UDS and also works for WNUA.
-            elif settings.grpc_local and settings.grpc_secure_mode and "ANSYS_GRPC_CERTIFICATES" not in os.environ:
-                pyaedt_logger.debug("Setting machine to '' to work with UDS/WNUA connection mechanism.")
-                self.machine = ""
-            # NOTE: Update command if PYAEDT_USE_PRE_GRPC_ARGS is set to allow working
-            # with previous SP where grpc transport mode were not available
-            # This environment variable is not necessary for UDS and WNUA modes.
-            if os.environ.get("PYAEDT_USE_PRE_GRPC_ARGS", "False") == "True":
-                self.machine = self.machine.split(":")[0] if self.machine else self.machine
 
-            oapp = self.grpc_plugin.CreateAedtApplication(self.machine, self.port, self.non_graphical, self.new_desktop)
+            oapp = self.grpc_plugin.CreateAedtApplication(
+                server_args.client_machine, self.port, self.non_graphical, self.new_desktop
+            )
             self.port = self.grpc_plugin.port
             self.aedt_process_id = self.odesktop.GetProcessID()
             # NOTE: This is particularly necessary for rpyc connections where the version information is not available

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -141,10 +141,12 @@ class _ServerArgs:
 
     @property
     def host_ip(self):
+        """Get host ip."""
         return get_local_ip(self.host)
 
     @property
     def client_machine(self):
+        """Get client machine."""
         machine = self.host
         if str(self).endswith((":SecureMode", ":InsecureMode")):
             host_ip = self.host

--- a/src/ansys/aedt/core/generic/settings.py
+++ b/src/ansys/aedt/core/generic/settings.py
@@ -528,11 +528,17 @@ class Settings(PyAedtBase):
         """Whether to use LSF Scheduler.
 
         This attribute is valid only on Linux systems running LSF Scheduler.
+        The gRPC local property is automatically updated when setting this property.
+        If no certificates are available, then secure mode is automatically disabled.
         """
         return self.__use_lsf_scheduler
 
     @use_lsf_scheduler.setter
     def use_lsf_scheduler(self, value: bool) -> None:
+        self.__grpc_local = not value
+        if not os.environ.get("ANSYS_GRPC_CERTIFICATES"):  # pragma: no cover
+            # If no certificaded is available, then enable insecure mode
+            self.__grpc_secure_mode = not value
         self.__use_lsf_scheduler = value
 
     @property

--- a/src/ansys/aedt/core/generic/settings.py
+++ b/src/ansys/aedt/core/generic/settings.py
@@ -528,16 +528,12 @@ class Settings(PyAedtBase):
         """Whether to use LSF Scheduler.
 
         This attribute is valid only on Linux systems running LSF Scheduler.
+        When setting this property to ``True``, some gRPC properties are updated to align with the change.
         """
         return self.__use_lsf_scheduler
 
     @use_lsf_scheduler.setter
     def use_lsf_scheduler(self, value: bool) -> None:
-        """
-        LSF Scheduler setter.
-
-        When setting this property to ``True``, some gRPC properties are updated to align with the change.
-        """
         if value:
             self.__grpc_local = False
 

--- a/src/ansys/aedt/core/generic/settings.py
+++ b/src/ansys/aedt/core/generic/settings.py
@@ -533,7 +533,8 @@ class Settings(PyAedtBase):
 
     @use_lsf_scheduler.setter
     def use_lsf_scheduler(self, value: bool) -> None:
-        """LSF Scheduler setter.
+        """
+        LSF Scheduler setter.
 
         When setting this property to ``True``, some gRPC properties are updated to align with the change.
         """

--- a/src/ansys/aedt/core/generic/settings.py
+++ b/src/ansys/aedt/core/generic/settings.py
@@ -533,8 +533,7 @@ class Settings(PyAedtBase):
 
     @use_lsf_scheduler.setter
     def use_lsf_scheduler(self, value: bool) -> None:
-        """
-        LSF Scheduler setter.
+        """LSF Scheduler setter.
 
         When setting this property to ``True``, some gRPC properties are updated to align with the change.
         """

--- a/src/ansys/aedt/core/generic/settings.py
+++ b/src/ansys/aedt/core/generic/settings.py
@@ -535,15 +535,14 @@ class Settings(PyAedtBase):
     def use_lsf_scheduler(self, value: bool) -> None:
         """LSF Scheduler setter.
 
-        The gRPC local property is automatically updated when setting this property.
-        If no certificates are available, then secure mode is automatically disabled.
+        When setting this property to ``True``, some gRPC properties are updated to align with the change.
         """
         if value:
-            self.__grpc_local = not value
+            self.__grpc_local = False
 
-        if not os.environ.get("ANSYS_GRPC_CERTIFICATES") and value:  # pragma: no cover
-            # If no certificaded is available, then enable insecure mode
-            self.__grpc_secure_mode = not value
+            # Enable insecure mode when no certificates are defined
+            if not os.environ.get("ANSYS_GRPC_CERTIFICATES"):  # pragma: no cover
+                self.__grpc_secure_mode = False
         self.__use_lsf_scheduler = value
 
     @property

--- a/src/ansys/aedt/core/generic/settings.py
+++ b/src/ansys/aedt/core/generic/settings.py
@@ -528,15 +528,20 @@ class Settings(PyAedtBase):
         """Whether to use LSF Scheduler.
 
         This attribute is valid only on Linux systems running LSF Scheduler.
-        The gRPC local property is automatically updated when setting this property.
-        If no certificates are available, then secure mode is automatically disabled.
         """
         return self.__use_lsf_scheduler
 
     @use_lsf_scheduler.setter
     def use_lsf_scheduler(self, value: bool) -> None:
-        self.__grpc_local = not value
-        if not os.environ.get("ANSYS_GRPC_CERTIFICATES"):  # pragma: no cover
+        """LSF Scheduler setter.
+
+        The gRPC local property is automatically updated when setting this property.
+        If no certificates are available, then secure mode is automatically disabled.
+        """
+        if value:
+            self.__grpc_local = not value
+
+        if not os.environ.get("ANSYS_GRPC_CERTIFICATES") and value:  # pragma: no cover
             # If no certificaded is available, then enable insecure mode
             self.__grpc_secure_mode = not value
         self.__use_lsf_scheduler = value

--- a/tests/system/solvers/sequential/test_rpyc_service.py
+++ b/tests/system/solvers/sequential/test_rpyc_service.py
@@ -76,7 +76,7 @@ def rpc_server():
 
 
 @pytest.mark.skipif(
-    DESKTOP_VERSION < "2027.1",
+    DESKTOP_VERSION < "2026.1",
     reason="Not working in versions without grpc patch",
 )
 def test_remote_hfss_workflow_with_mtls(rpc_server, tmp_path, monkeypatch):

--- a/tests/system/solvers/sequential/test_rpyc_service.py
+++ b/tests/system/solvers/sequential/test_rpyc_service.py
@@ -72,6 +72,7 @@ def rpc_server():
     yield
     settings.remote_rpc_session = None
     settings.grpc_local = True
+
     settings.grpc_secure_mode = True
 
 
@@ -94,6 +95,7 @@ def test_remote_hfss_workflow_with_mtls(rpc_server, tmp_path, monkeypatch):
     box = hfss.modeler.create_box([0, 0, 0], [10, 10, 10], name="MyBox")
 
     assert box is not None
+
     settings.grpc_local = True
     # NOTE: This is required as each test creates a new desktop session.
     hfss.desktop_class.close_desktop()


### PR DESCRIPTION
## Description
This pull request refactors how the `client_machine` and host IP are determined and used in the `desktop.py` module, consolidating logic and improving maintainability. The key changes include introducing new `@property` methods for `host_ip` and `client_machine`, updating code to use these properties, and removing duplicated or redundant logic from other parts of the code.

**Refactoring and Consolidation of Host and Machine Logic:**

* Added `host_ip` and `client_machine` properties to centralize logic for determining the host IP and client machine string, including handling of UDS/WNUA and legacy gRPC arguments. (`src/ansys/aedt/core/desktop.py`)
* Updated the initialization routine to use `server_args.client_machine` instead of duplicating the logic for building the machine string, reducing code duplication and potential inconsistencies. (`src/ansys/aedt/core/desktop.py`)

**Code Cleanup:**

* Removed the old `host_ip` property and associated logic from the `__repr__` method, ensuring all host/machine string formatting is handled in one place. (`src/ansys/aedt/core/desktop.py`)

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
