### PR TITLE
DOCS: Update kernel conversion documentation and enforce AEDT version requirement

### DIFF
--- a/doc/changelog.d/7557.documentation.md
+++ b/doc/changelog.d/7557.documentation.md
@@ -1,0 +1,1 @@
+Update kernel conversion documentation and enforce AEDT version requirement

--- a/doc/source/User_guide/pyaedt_extensions_doc/project/kernel_convert.rst
+++ b/doc/source/User_guide/pyaedt_extensions_doc/project/kernel_convert.rst
@@ -7,6 +7,30 @@ with the use of a simple script.
 
 This script is compatible with AEDT files, as well as A3DCOMP files (including encrypted 3DComponents).
 
+.. warning::
+
+   This extension requires **AEDT 2022 R2** to be installed on the same machine alongside
+   the current AEDT release. AEDT 2022 R2 is launched automatically as a second, non-graphical
+   desktop to read project files that still use the legacy ACIS kernel. If this version is not
+   found, the extension raises an error listing all currently installed AEDT versions so you
+   know exactly what is missing.
+
+   If you need to use a different legacy version as the input kernel (for example because your
+   files were created with a specific intermediate release), you can override the default by
+   setting the ``PYAEDT_KERNEL_AEDT_VERSION`` environment variable before launching the
+   extension:
+
+   .. code-block:: bash
+
+      # Windows
+      set PYAEDT_KERNEL_AEDT_VERSION=2022.2
+
+      # Linux
+      export PYAEDT_KERNEL_AEDT_VERSION=2022.2
+
+   The value must match one of the version strings returned by the AEDT version discovery (for
+   example ``2022.2``, ``2023.1``).
+
 The following image shows the extension user interface:
 
 .. image:: ../../../_static/extensions/kernel_convert_ui.png

--- a/doc/source/User_guide/pyaedt_extensions_doc/project/kernel_convert.rst
+++ b/doc/source/User_guide/pyaedt_extensions_doc/project/kernel_convert.rst
@@ -22,7 +22,7 @@ This script is compatible with AEDT files, as well as A3DCOMP files (including e
 
    .. code-block:: bash
 
-      # Windows
+      # Windows - Command Prompt (cmd)
       set PYAEDT_KERNEL_AEDT_VERSION=2022.2
 
       # Linux

--- a/src/ansys/aedt/core/extensions/common/kernel_converter.py
+++ b/src/ansys/aedt/core/extensions/common/kernel_converter.py
@@ -38,7 +38,6 @@ from ansys.aedt.core import Q3d
 from ansys.aedt.core.extensions.misc import DEFAULT_PADDING
 from ansys.aedt.core.extensions.misc import ExtensionCommonData
 from ansys.aedt.core.extensions.misc import ExtensionProjectCommon
-from ansys.aedt.core.extensions.misc import aedt_versions
 from ansys.aedt.core.extensions.misc import get_aedt_version
 from ansys.aedt.core.extensions.misc import get_arguments
 from ansys.aedt.core.extensions.misc import get_port
@@ -48,6 +47,7 @@ from ansys.aedt.core.generic.aedt_constants import DesignType
 from ansys.aedt.core.generic.design_types import get_pyaedt_app
 from ansys.aedt.core.generic.file_utils import generate_unique_name
 from ansys.aedt.core.generic.settings import settings
+from ansys.aedt.core.internal.aedt_versions import aedt_versions
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from ansys.aedt.core.internal.filesystem import search_files
 

--- a/src/ansys/aedt/core/extensions/common/kernel_converter.py
+++ b/src/ansys/aedt/core/extensions/common/kernel_converter.py
@@ -38,6 +38,7 @@ from ansys.aedt.core import Q3d
 from ansys.aedt.core.extensions.misc import DEFAULT_PADDING
 from ansys.aedt.core.extensions.misc import ExtensionCommonData
 from ansys.aedt.core.extensions.misc import ExtensionProjectCommon
+from ansys.aedt.core.extensions.misc import aedt_versions
 from ansys.aedt.core.extensions.misc import get_aedt_version
 from ansys.aedt.core.extensions.misc import get_arguments
 from ansys.aedt.core.extensions.misc import get_port
@@ -52,6 +53,14 @@ from ansys.aedt.core.internal.filesystem import search_files
 
 settings.use_grpc_api = True
 settings.use_multi_desktop = True
+
+# The kernel conversion process requires AEDT 2022 R2 (or later legacy kernel) as the *input*
+# desktop so that older project/component files can be read and then re-saved by the current
+# version.  If this exact release is not present the extension raises an informative error
+# instead of failing silently deep inside the AEDT layer.
+# The default can be overridden by setting the ``PYAEDT_KERNEL_AEDT_VERSION`` environment
+# variable, e.g. ``set PYAEDT_KERNEL_AEDT_VERSION=2022.2`` on Windows.
+REQUIRED_INPUT_VERSION = os.getenv("PYAEDT_KERNEL_AEDT_VERSION", "2022.2")
 
 on_ci = os.getenv("ON_CI", "false")
 
@@ -402,7 +411,25 @@ def main(data: KernelConverterExtensionData) -> bool:  # pragma: no cover
         aedt_process_id=AEDT_PROCESS_ID,
         student_version=IS_STUDENT,
     )
-    input_desktop = Desktop(new_desktop=True, version=222, non_graphical=True)
+
+    # Verify that the required input version (AEDT 2022 R2) is installed before attempting to
+    # launch it.  Installed versions are discovered from the registry/file-system by
+    # ``aedt_versions``; if the required version is absent we release the output desktop that
+    # has already been started and raise a clear error rather than letting the Desktop
+    # constructor fail with a cryptic message.
+    if REQUIRED_INPUT_VERSION not in aedt_versions.installed_versions:
+        available = sorted(aedt_versions.installed_versions.keys())
+        available_str = ", ".join(available) if available else "none detected"
+        output_desktop.release_desktop(False, False)
+        raise AEDTRuntimeError(
+            f"The Kernel Converter extension requires AEDT {REQUIRED_INPUT_VERSION} to be "
+            f"installed on this machine. This version is used as the legacy kernel to read "
+            f"older project files before they are re-saved with the current release. "
+            f"Please install AEDT {REQUIRED_INPUT_VERSION} and re-run the extension. "
+            f"Currently installed AEDT versions: {available_str}."
+        )
+
+    input_desktop = Desktop(new_desktop=True, version=REQUIRED_INPUT_VERSION, non_graphical=True)
 
     for file in files_path:
         try:

--- a/src/ansys/aedt/core/extensions/common/kernel_converter.py
+++ b/src/ansys/aedt/core/extensions/common/kernel_converter.py
@@ -56,10 +56,10 @@ settings.use_multi_desktop = True
 
 # The kernel conversion process requires AEDT 2022 R2 (or later legacy kernel) as the *input*
 # desktop so that older project/component files can be read and then re-saved by the current
-# version.  If this exact release is not present the extension raises an informative error
+# version. If this exact release is not present, the extension raises an informative error
 # instead of failing silently deep inside the AEDT layer.
 # The default can be overridden by setting the ``PYAEDT_KERNEL_AEDT_VERSION`` environment
-# variable, e.g. ``set PYAEDT_KERNEL_AEDT_VERSION=2022.2`` on Windows.
+# variable, e.g. ``set PYAEDT_KERNEL_AEDT_VERSION=2022.2`` with Command Prompt (cmd) on Windows.
 REQUIRED_INPUT_VERSION = os.getenv("PYAEDT_KERNEL_AEDT_VERSION", "2022.2")
 
 on_ci = os.getenv("ON_CI", "false")

--- a/tests/unit/extensions/test_kernel_converter.py
+++ b/tests/unit/extensions/test_kernel_converter.py
@@ -208,8 +208,9 @@ def test_main_function_no_file_path() -> None:
 @patch("ansys.aedt.core.extensions.common.kernel_converter.Desktop")
 @patch("ansys.aedt.core.extensions.common.kernel_converter._convert_aedt")
 @patch("ansys.aedt.core.extensions.common.kernel_converter._convert_3d_component")
+@patch("ansys.aedt.core.extensions.common.kernel_converter.aedt_versions")
 def test_main_function_with_directory(
-    mock_convert_3d_component, mock_convert_aedt, mock_desktop_class, mock_search_files, mock_app
+    mock_aedt_versions, mock_convert_3d_component, mock_convert_aedt, mock_desktop_class, mock_search_files, mock_app
 ) -> None:
     """Test main function with directory path."""
     # Mock search_files to return test files
@@ -217,6 +218,8 @@ def test_main_function_with_directory(
         ["/path/to/test1.a3dcomp", "/path/to/test2.a3dcomp"],
         ["/path/to/test3.aedt", "/path/to/test4.aedt"],
     ]
+
+    mock_aedt_versions.installed_versions = {"2022.2": "dummy"}
 
     # Mock Desktop
     mock_desktop_instance = MagicMock()
@@ -233,13 +236,38 @@ def test_main_function_with_directory(
     mock_desktop_instance.release_desktop.assert_called()
 
 
+@patch("ansys.aedt.core.extensions.common.kernel_converter.search_files")
 @patch("ansys.aedt.core.extensions.common.kernel_converter.Desktop")
 @patch("ansys.aedt.core.extensions.common.kernel_converter._convert_aedt")
-def test_main_function_with_single_file(mock_convert_aedt, mock_desktop_class, mock_app) -> None:
+@patch("ansys.aedt.core.extensions.common.kernel_converter._convert_3d_component")
+@patch("ansys.aedt.core.extensions.common.kernel_converter.aedt_versions")
+def test_main_function_error(
+    mock_aedt_versions, mock_convert_3d_component, mock_convert_aedt, mock_desktop_class, mock_search_files, mock_app
+) -> None:
+    """Test main function with directory path."""
+    # Mock search_files to return test files
+    mock_search_files.side_effect = [
+        ["/path/to/test1.a3dcomp", "/path/to/test2.a3dcomp"],
+        ["/path/to/test3.aedt", "/path/to/test4.aedt"],
+    ]
+
+    mock_aedt_versions.installed_versions = {"1992.0": "dummy"}
+    data = KernelConverterExtensionData(file_path="/path/to/test.a3dcomp")
+
+    with patch("os.path.isdir", return_value=True):
+        with pytest.raises(AEDTRuntimeError):
+            main(data)
+
+
+@patch("ansys.aedt.core.extensions.common.kernel_converter.Desktop")
+@patch("ansys.aedt.core.extensions.common.kernel_converter._convert_aedt")
+@patch("ansys.aedt.core.extensions.common.kernel_converter.aedt_versions")
+def test_main_function_with_single_file(mock_aedt_versions, mock_convert_aedt, mock_desktop_class, mock_app) -> None:
     """Test main function with single file path."""
     # Mock Desktop
     mock_desktop_instance = MagicMock()
     mock_desktop_class.return_value = mock_desktop_instance
+    mock_aedt_versions.installed_versions = {"2022.2": "dummy"}
 
     data = KernelConverterExtensionData(file_path="/path/to/test.aedt")
 
@@ -254,11 +282,13 @@ def test_main_function_with_single_file(mock_convert_aedt, mock_desktop_class, m
 
 @patch("ansys.aedt.core.extensions.common.kernel_converter.Desktop")
 @patch("ansys.aedt.core.extensions.common.kernel_converter._convert_3d_component")
-def test_main_function_with_3d_component(mock_convert_3d, mock_desktop_class, mock_app) -> None:
+@patch("ansys.aedt.core.extensions.common.kernel_converter.aedt_versions")
+def test_main_function_with_3d_component(mock_aedt_versions, mock_convert_3d, mock_desktop_class, mock_app) -> None:
     """Test main function with 3D component file."""
     # Mock Desktop
     mock_desktop_instance = MagicMock()
     mock_desktop_class.return_value = mock_desktop_instance
+    mock_aedt_versions.installed_versions = {"2022.2": "dummy"}
 
     data = KernelConverterExtensionData(file_path="/path/to/test.a3dcomp")
 
@@ -272,11 +302,13 @@ def test_main_function_with_3d_component(mock_convert_3d, mock_desktop_class, mo
 
 
 @patch("ansys.aedt.core.extensions.common.kernel_converter.Desktop")
-def test_main_function_with_exception_handling(mock_desktop_class, caplog) -> None:
+@patch("ansys.aedt.core.extensions.common.kernel_converter.aedt_versions")
+def test_main_function_with_exception_handling(mock_aedt_versions, mock_desktop_class, caplog) -> None:
     """Test main function exception handling."""
     # Mock Desktop
     mock_desktop_instance = MagicMock()
     mock_desktop_class.return_value = mock_desktop_instance
+    mock_aedt_versions.installed_versions = {"2022.2": "dummy"}
 
     data = KernelConverterExtensionData(file_path="/path/to/test.aedt")
 


### PR DESCRIPTION
## Description
This pull request introduces a requirement for the AEDT Kernel Converter extension to have AEDT 2022 R2 (or a user-specified legacy version) installed on the machine, and improves error handling and documentation to make this requirement clear. The extension now checks for the required AEDT version before launching, and provides informative errors if the version is missing. Users can override the default required version via an environment variable.

**Documentation and user guidance:**

* Updated the documentation in `project/kernel_convert.rst` to clearly state that AEDT 2022 R2 must be installed for the extension to work, and added instructions for overriding the default version using the `PYAEDT_KERNEL_AEDT_VERSION` environment variable.

**Kernel converter logic and error handling:**

* Added import of `aedt_versions` to allow discovery of installed AEDT versions.
* Set the required input AEDT version using the `PYAEDT_KERNEL_AEDT_VERSION` environment variable, defaulting to `2022.2`.
* Before launching the legacy AEDT desktop, the extension now checks if the required version is installed. If not, it releases any already-started output desktop and raises a clear error listing all available AEDT versions.

## Issue linked
Close #7498 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
