### PR TITLE
FIX: Resolve script execution issue

### DIFF
--- a/doc/changelog.d/7559.fixed.md
+++ b/doc/changelog.d/7559.fixed.md
@@ -1,0 +1,1 @@
+Resolve script execution issue

--- a/src/ansys/aedt/core/extensions/installer/version_manager.py
+++ b/src/ansys/aedt/core/extensions/installer/version_manager.py
@@ -46,8 +46,6 @@ from ansys.aedt.core.extensions.misc import check_for_pyaedt_update_on_startup
 from ansys.aedt.core.extensions.misc import get_aedt_version
 from ansys.aedt.core.extensions.misc import get_aedt_theme
 from ansys.aedt.core.extensions.misc import get_latest_version
-from ansys.aedt.core.extensions.misc import get_port
-from ansys.aedt.core.extensions.misc import get_process_id
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.help import Help
 
@@ -62,6 +60,7 @@ DISCLAIMER = (
     "Do you want to proceed?\n"
 )
 UNKNOWN_VERSION = "Unknown"
+
 
 class VersionManager:
     TITLE = "Version Manager"
@@ -726,6 +725,7 @@ class VersionManager:
             self.pyaedt_info.set(f"PyAEDT: {pyaedt_installed} (Latest {latest_pyaedt})")
             self.pyedb_info.set(f"PyEDB: {pyedb_installed} (Latest {latest_pyedb})")
             messagebox.showinfo("Message", "Done")
+
     def _on_close(self) -> None:
         """Best-effort cleanup when the extension window is closed.
 
@@ -830,18 +830,9 @@ class VersionManager:
 
 
 def get_desktop():
-    port = get_port()
     aedt_version = get_aedt_version()
-    aedt_process_id = get_process_id()
 
-    if aedt_process_id is not None:
-        new_desktop = False
-        ng = False
-    else:
-        new_desktop = True
-        ng = True
-
-    aedtapp = ansys.aedt.core.Desktop(new_desktop=new_desktop, version=aedt_version, port=port, non_graphical=ng)
+    aedtapp = ansys.aedt.core.Desktop(new_desktop=False, version=aedt_version)
 
     return aedtapp
 

--- a/src/ansys/aedt/core/extensions/installer/version_manager.py
+++ b/src/ansys/aedt/core/extensions/installer/version_manager.py
@@ -46,6 +46,8 @@ from ansys.aedt.core.extensions.misc import check_for_pyaedt_update_on_startup
 from ansys.aedt.core.extensions.misc import get_aedt_version
 from ansys.aedt.core.extensions.misc import get_aedt_theme
 from ansys.aedt.core.extensions.misc import get_latest_version
+from ansys.aedt.core.extensions.misc import get_port
+from ansys.aedt.core.extensions.misc import get_process_id
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.help import Help
 
@@ -403,7 +405,7 @@ class VersionManager:
             # Fallback to the current environment to avoid breaking functionality
             self.activated_env = os.environ.copy()
 
-    def run_pip(self, pip_args: list, capture_output: bool=False, check: bool=True) -> str | None:
+    def run_pip(self, pip_args: list, capture_output: bool = False, check: bool = True) -> str | None:
         """Run pip using python -m pip.
 
         Arguments:
@@ -429,7 +431,7 @@ class VersionManager:
             self.loading_labels[key].config(text="")
             self.root.update_idletasks()
 
-    def update_and_reload(self, pip_args: list, loading_key: str | None = None): # pragma: no cover
+    def update_and_reload(self, pip_args: list, loading_key: str | None = None):  # pragma: no cover
         """Run pip install/upgrade and refresh the UI."""
         # Confirm action
         response = messagebox.askyesno(
@@ -449,7 +451,7 @@ class VersionManager:
             if loading_key:
                 self.hide_loading(loading_key)
             messagebox.showerror("Error: Installation Failed",
-                               f"Installation failed: {exc}")
+                                 f"Installation failed: {exc}")
             return
 
         # Refresh the UI to show updated version information
@@ -524,7 +526,7 @@ class VersionManager:
 
             self.update_and_reload(pip_args, loading_key="pyedb")
 
-    def update_all(self) -> None: # pragma: no cover
+    def update_all(self) -> None:  # pragma: no cover
         """Update both pyaedt and pyedb together.
         """
         response = messagebox.askyesno("Disclaimer", DISCLAIMER)
@@ -698,12 +700,12 @@ class VersionManager:
             except Exception:  # pragma: no cover
                 return "Please restart"
 
-    def clicked_refresh(self, need_restart: bool=False):
+    def clicked_refresh(self, need_restart: bool = False):
         msg = [f"Venv path: {self.venv_path}", f"Python version: {self.python_version}"]
         msg = "\n".join(msg)
         self.venv_information.set(msg)
 
-        if need_restart is False:
+        if not need_restart:
             self.pyaedt_info.set(f"PyAEDT: {self.pyaedt_version} (Latest {get_latest_version('pyaedt')})")
             self.pyedb_info.set(f"PyEDB: {self.pyedb_version} (Latest {get_latest_version('pyedb')})")
         else:
@@ -749,7 +751,7 @@ class VersionManager:
             except Exception:
                 logging.getLogger("Global").debug("Failed to destroy root window", exc_info=True)
 
-    def show_pyaedt_update_notification(self, latest_version: str, declined_file_path: Path): # pragma: no cover
+    def show_pyaedt_update_notification(self, latest_version: str, declined_file_path: Path):  # pragma: no cover
         """Display a notification dialog informing the user about a new PyAEDT version."""
         try:
             dlg = tkinter.Toplevel(self.root)
@@ -830,14 +832,23 @@ class VersionManager:
 
 
 def get_desktop():
+    port = get_port()
     aedt_version = get_aedt_version()
+    aedt_process_id = get_process_id()
 
-    aedtapp = ansys.aedt.core.Desktop(new_desktop=False, version=aedt_version)
+    if aedt_process_id is not None:
+        new_desktop = False
+        ng = False
+    else:
+        new_desktop = True
+        ng = True
+
+    aedtapp = ansys.aedt.core.Desktop(new_desktop=new_desktop, version=aedt_version, port=port, non_graphical=ng)
 
     return aedtapp
 
 
-if __name__ == "__main__": # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
     # Initialize tkinter root window and run the app
     personal_lib = os.getenv("PYAEDT_PERSONAL_LIB", "").strip()
     desktop = None if personal_lib else get_desktop()

--- a/src/ansys/aedt/core/extensions/templates/jupyter.py_build
+++ b/src/ansys/aedt/core/extensions/templates/jupyter.py_build
@@ -76,18 +76,21 @@ def main():
     # Add environment variables
     pyaedt_utils.environment_variables(oDesktop)
 
+    # Open extension manager
+    my_env = os.environ.copy()
+
     if is_linux:
         if notebook_dir:
             command = [jupyter_exe, "lab", target,"--notebook-dir",notebook_dir]
         else:
             command = [jupyter_exe, "lab", target]
-        subprocess.Popen(command)
+        subprocess.Popen(command, env=my_env)
     else:
         if notebook_dir:
             command = ['"{}"'.format(jupyter_exe), "lab", '"{}"'.format(target), "--notebook-dir", '"{0}"'.format(notebook_dir)]
         else:
             command = ['"{}"'.format(jupyter_exe), "lab", '"{}"'.format(target)]
-        subprocess.Popen(" ".join(command))
+        subprocess.Popen(" ".join(command), env=my_env)
 
 
 if __name__ == "__main__":

--- a/src/ansys/aedt/core/extensions/templates/pyaedt_cli.py_build
+++ b/src/ansys/aedt/core/extensions/templates/pyaedt_cli.py_build
@@ -64,8 +64,13 @@ def main():
     activate_script_flag = pyaedt_utils.check_file(activate_script, oDesktop)
     if not activate_script_flag:
         return
+
     # Add environment variables
     pyaedt_utils.environment_variables(oDesktop)
+
+    # Open extension manager
+    my_env = os.environ.copy()
+
     # Open terminal, activate environment, and run command
     if is_linux:
         command = pyaedt_utils.get_linux_terminal_command()
@@ -73,11 +78,11 @@ def main():
             pyaedt_utils.show_error("No terminal found on system.", oDesktop)
         terminal_command = "source \"{}\"; pyaedt --help; exec bash".format(activate_script)
         command.extend(["bash", "-c", terminal_command])
-        subprocess.Popen(command)
+        subprocess.Popen(command, env=my_env)
     else:
         terminal_command = '"{}" & pyaedt --help'.format(activate_script)
         command = ["cmd.exe", "/k", terminal_command]
-        subprocess.Popen(" ".join(command))
+        subprocess.Popen(" ".join(command), env=my_env)
 
 
 if __name__ == "__main__":

--- a/src/ansys/aedt/core/extensions/templates/pyaedt_console.py_build
+++ b/src/ansys/aedt/core/extensions/templates/pyaedt_console.py_build
@@ -61,18 +61,23 @@ def main():
     pyaedt_script_flag = pyaedt_utils.check_file(pyaedt_script, oDesktop)
     if not pyaedt_script_flag:
         return
+
     # Add environment variables
     pyaedt_utils.environment_variables(oDesktop)
+
+    # Open extension manager
+    my_env = os.environ.copy()
+
     # Call console script
     if is_linux:
         command = pyaedt_utils.get_linux_terminal_command()
         if not command:
             pyaedt_utils.show_error("No terminal found on system.", oDesktop)
         command.extend([python_exe, "-i", pyaedt_script])
-        subprocess.Popen(command)
+        subprocess.Popen(command, env=my_env)
     else:
         command = ['"{}"'.format(python_exe), "-i", '"{}"'.format(pyaedt_script)]
-        subprocess.Popen(" ".join(command))
+        subprocess.Popen(" ".join(command), env=my_env)
 
 
 if __name__ == "__main__":

--- a/src/ansys/aedt/core/extensions/templates/run_extension_manager.py_build
+++ b/src/ansys/aedt/core/extensions/templates/run_extension_manager.py_build
@@ -84,6 +84,7 @@ def main():
 
         # Open extension manager
         my_env = os.environ.copy()
+
         if pyaedt_path:
             site_packages_path = os.path.join(install_path, "commonfiles/CPython/3_10/{0}/Release/python/Lib/site-packages".format(folder))
             my_env["PYTHONPATH"] = os.pathsep.join([site_packages_path, pyaedt_path])

--- a/src/ansys/aedt/core/extensions/templates/run_pyaedt_script.py_build
+++ b/src/ansys/aedt/core/extensions/templates/run_pyaedt_script.py_build
@@ -213,8 +213,11 @@ def main():
         # Add environment variables
         pyaedt_utils.environment_variables(oDesktop)
 
-        # --- Run Script with Arguments ---
+        # Open extension manager
         my_env = os.environ.copy()
+
+        # --- Run Script with Arguments ---
+
         error_handler = os.path.normpath(os.path.join(r"##EXTENSION_TEMPLATES##", "extension_error_handler.py"))
 
         def run_selected_script(pyaedt_script, script_args, owner=None):

--- a/src/ansys/aedt/core/extensions/templates/run_pyaedt_script.py_build
+++ b/src/ansys/aedt/core/extensions/templates/run_pyaedt_script.py_build
@@ -166,7 +166,7 @@ def show_launcher_dialog(initial_dir, run_callback):
             return
 
         run_callback(file_path, script_arguments, f)
-        f.Activate()
+        f.Close()
 
     btn_run.Click += run_click
 

--- a/src/ansys/aedt/core/extensions/templates/run_pyaedt_toolkit_script.py_build
+++ b/src/ansys/aedt/core/extensions/templates/run_pyaedt_toolkit_script.py_build
@@ -83,8 +83,11 @@ def aedt_script():
             return
 
         # Add environment variables
-        my_env = dict(os.environ.copy())
         pyaedt_utils.environment_variables(oDesktop)
+
+        # Open extension manager
+        my_env = os.environ.copy()
+
         if pyaedt_path:
             site_packages_path = os.path.join(install_path,
                                               "commonfiles/CPython/3_10/{0}/Release/python/Lib/site-packages".format(


### PR DESCRIPTION
## Description
This pull request makes several updates to the extension installer and script runner in the AEDT core, primarily focused on simplifying the logic for launching the AEDT Desktop and improving dialog behavior. The most significant changes involve removing unused imports and parameters, streamlining the `get_desktop` function, and updating the script runner's dialog handling.

**Installer and Desktop Launching Improvements:**

* Removed unused imports (`get_port`, `get_process_id`) and related logic from `version_manager.py`, simplifying the code and reducing unnecessary dependencies.
* Refactored the `get_desktop` function to always launch the desktop with `new_desktop=False` and without passing `port` or `non_graphical` arguments, making the desktop initialization more straightforward.

**General Code Cleanup:**

* Added a blank line for readability and removed an unnecessary blank line in `version_manager.py`.

**Script Runner Dialog Update:**

* Changed the script runner dialog in `run_pyaedt_script.py_build` to close the dialog after running the script instead of activating it. It was hanging forever because AEDT can not have parallel calls.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
