### PR TITLE
FIX: Duplicated sweep object

### DIFF
--- a/doc/changelog.d/7582.fixed.md
+++ b/doc/changelog.d/7582.fixed.md
@@ -1,0 +1,1 @@
+Duplicated sweep object

--- a/src/ansys/aedt/core/modules/solve_setup.py
+++ b/src/ansys/aedt/core/modules/solve_setup.py
@@ -3015,10 +3015,6 @@ class SetupHFSS(Setup, PyAedtBase):
             sweep_n = SweepHFSS(self, name=name, sweep_type=sweep_type, props=props)
         sweep_n.create()
         self.sweeps.append(sweep_n)
-        for setup in self._app.setups:
-            if self.name == setup.name:
-                setup.sweeps.append(sweep_n)
-                break
         return sweep_n
 
     @pyaedt_function_handler()

--- a/tests/system/general/test_hfss.py
+++ b/tests/system/general/test_hfss.py
@@ -465,6 +465,7 @@ def test_sweep_add_subrange(aedt_app) -> None:
     setup = aedt_app.create_setup(name="MySetupForSweep")
     assert not setup.get_sweep()
     sweep = setup.add_sweep()
+    assert len(setup.sweeps) == 1
     sweep1 = setup.get_sweep(sweep.name)
     assert sweep1 == sweep
     sweep2 = setup.get_sweep()


### PR DESCRIPTION
## Description
This pull request simplifies the logic for adding sweeps to HFSS setups and improves test coverage to verify the correct behavior. The main changes focus on removing redundant code and strengthening assertions in the test suite.

**Core logic simplification:**
- Removed the loop that redundantly appended the new `SweepHFSS` object to matching setups in the application's setup list, since the sweep is already appended to the current setup. (`src/ansys/aedt/core/modules/solve_setup.py`)

**Test improvements:**
- Added an assertion to confirm that a sweep is correctly added to the `sweeps` list of a setup after calling `add_sweep`. (`tests/system/general/test_hfss.py`)

## Issue linked
Close #7558 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
