### PR TITLE
CHORE: Remove dotnetcore2 dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
 dotnet = [
     "ansys-pythonnet>=3.1.0rc3",
     "cffi>=1.16.0,<2.1; platform_system=='Linux'",
-    "dotnetcore2==3.1.23; platform_system=='Linux'",
     "pywin32>=303; platform_system=='Windows'",
 ]
 # NOTE: Any modification to graphics should be extended in internal checks (decorators)


### PR DESCRIPTION
## Description
This pull request makes a small change to the `pyproject.toml` file by removing the `dotnetcore2` dependency for Linux systems. This simplifies the dependency list and may help avoid potential conflicts or redundancies.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
