### PR TITLE
FIX: Extension manager launch pyaedt in aedt

### DIFF
--- a/doc/changelog.d/7630.fixed.md
+++ b/doc/changelog.d/7630.fixed.md
@@ -1,0 +1,1 @@
+Extension manager launch pyaedt in aedt

--- a/doc/source/Getting_started/Installation.rst
+++ b/doc/source/Getting_started/Installation.rst
@@ -57,8 +57,9 @@ You can watch the following video to see how to install PyAEDT:
 
 .. _pyaedt_bundled_aedt:
 
-PyAEDT bundled with AEDT (2026 R2 SP2)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PyAEDT bundled with AEDT (2026 R2 service pack 2)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Starting with AEDT 2026 R2 service pack 2, PyAEDT ships as part of the AEDT installation.
 This bundled PyAEDT only includes the main runtime dependencies (no optional extras).
 

--- a/doc/source/Getting_started/Installation.rst
+++ b/doc/source/Getting_started/Installation.rst
@@ -12,6 +12,8 @@ In addition to the runtime dependencies listed in the installation information, 
 requires Ansys Electronics Desktop (AEDT) 2022 R1 or later. The AEDT Student Version is also supported.
 
 
+.. _install-from-pyaedt-installer:
+
 Install from PyAEDT installer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The following Python script automatically installs PyAEDT from AEDT,
@@ -52,6 +54,33 @@ You can watch the following video to see how to install PyAEDT:
 
   <iframe width="560" height="315" src="https://www.youtube.com/embed/c-zl8iMjP4M?si=zpdREiZhzODW-kW1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
+
+.. _pyaedt_bundled_aedt:
+
+PyAEDT bundled with AEDT (2026 R2 SP2)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Starting with AEDT 2026 R2 service pack 2, PyAEDT ships as part of the AEDT installation.
+This bundled PyAEDT only includes the main runtime dependencies (no optional extras).
+
+If you need to update PyAEDT or install extra dependencies, install PyAEDT into your own
+virtual environment as described in the other sections of this page (for example,
+:ref:`Install on CPython from PyPI <install-on-cpython-from-pypi>`), or use the
+:ref:`PyAEDT installer script <install-from-pyaedt-installer>`.
+
+In addition, the **Extension Manager** can be installed using the bundled PyAEDT directly
+from the PyAEDT Console in AEDT by running:
+
+.. code:: python
+
+    from ansys.aedt.core.extensions.installer.pyaedt_installer import add_extension_manager
+
+    add_extension_manager("YourPersonalLibPath")
+
+Replace ``"YourPersonalLibPath"`` with the full path of your ``PersonalLib`` (or ``syslib``)
+as configured in AEDT.
+
+
+.. _extension_manager:
 
 Extension manager
 ~~~~~~~~~~~~~~~~~
@@ -139,6 +168,8 @@ There are several available options:
   :width: 800
   :alt: PyAEDT version manager
 
+
+.. _install-on-cpython-from-pypi:
 
 Install on CPython from PyPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -247,6 +278,7 @@ You can use `uv` to install PyAEDT into your own virtual environment. The
 steps below show how to create a virtual environment, activate it, install `uv`, and then
 install PyAEDT. Examples are provided for Windows (PowerShell) and Linux (bash).
 
+
 Create and activate a virtual environment (Windows - PowerShell)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. code:: powershell
@@ -257,8 +289,9 @@ Create and activate a virtual environment (Windows - PowerShell)
     pip install uv
     uv pip install pyaedt[all]
 
+
 Create and activate a virtual environment (Linux)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. code:: bash
 
     python3 -m venv ~/pyaedt_venv
@@ -269,6 +302,7 @@ Create and activate a virtual environment (Linux)
 
 .. note::
   Virtual environments should be created with `venv` and not directly with `uv` to avoid potential issues.
+
 
 Installing from a wheelhouse using uv
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -286,6 +320,7 @@ Example (Linux):
 
     pip install --no-cache-dir --no-index --find-links=file:///<path_to_wheelhouse> uv
     uv pip install --no-cache-dir --no-index --find-links=file:///<path_to_wheelhouse> pyaedt[all]
+
 
 After installation
 ~~~~~~~~~~~~~~~~~~

--- a/src/ansys/aedt/core/extensions/templates/run_extension_manager.py_build
+++ b/src/ansys/aedt/core/extensions/templates/run_extension_manager.py_build
@@ -35,10 +35,12 @@ if is_linux:
     import subprocessdotnet as subprocess
 
     folder = "linx64"
+    lib_python = "lib"
 else:
     import subprocess
 
     folder = "winx64"
+    lib_python = "Lib"
 
 # AEDT installation path
 install_path = os.path.abspath(os.path.join(oDesktop.GetExeDir(), ".."))
@@ -91,7 +93,7 @@ def main():
 
         if pyaedt_path:
             site_packages_path = os.path.join(
-                install_path, "AnsysEM", "commonfiles", "CPython", "3_10", folder, "Release", "python", "Lib", "site-packages"
+                install_path, "AnsysEM", "commonfiles", "CPython", "3_10", folder, "Release", "python", lib_python, "site-packages"
             )
             my_env["PYTHONPATH"] = os.pathsep.join([site_packages_path, pyaedt_path])
 

--- a/src/ansys/aedt/core/extensions/templates/run_extension_manager.py_build
+++ b/src/ansys/aedt/core/extensions/templates/run_extension_manager.py_build
@@ -41,14 +41,18 @@ else:
     folder = "winx64"
 
 # AEDT installation path
-install_path = os.path.abspath(oDesktop.GetExeDir() + "/../")
-
-sys.path.append(r"##EXTENSION_TEMPLATES##")
+install_path = os.path.abspath(os.path.join(oDesktop.GetExeDir(), ".."))
 
 # Check if the script is running using CPython interpreter from AEDT installation
 pyaedt_path = None
 if install_path in os.path.abspath(r"##EXTENSION_TEMPLATES##"):
-    pyaedt_path = os.path.join(install_path, r"commonfiles/CPython/3_10/{0}/Release/Ansys/PyAEDT".format(folder))
+    pyaedt_path = os.path.join(install_path, "AnsysEM", "commonfiles", "CPython", "3_10", folder, "Release",
+                               "Ansys", "PyAEDT")
+
+if pyaedt_path:
+    sys.path.append(pyaedt_path)
+
+sys.path.append(r"##EXTENSION_TEMPLATES##")
 
 import pyaedt_utils
 
@@ -86,7 +90,9 @@ def main():
         my_env = os.environ.copy()
 
         if pyaedt_path:
-            site_packages_path = os.path.join(install_path, "commonfiles/CPython/3_10/{0}/Release/python/Lib/site-packages".format(folder))
+            site_packages_path = os.path.join(
+                install_path, "AnsysEM", "commonfiles", "CPython", "3_10", folder, "Release", "python", "Lib", "site-packages"
+            )
             my_env["PYTHONPATH"] = os.pathsep.join([site_packages_path, pyaedt_path])
 
         if is_linux:


### PR DESCRIPTION
## Description
This pull request updates the PyAEDT installation documentation and the extension manager script to support the new AEDT 2026 R2 SP2 release, where PyAEDT is bundled with AEDT. The documentation has been reorganized for clarity, with new sections and improved instructions for managing environments and dependencies. The extension manager script is also updated to ensure compatibility with the new AEDT installation structure.

**Documentation updates:**

* Added a new section explaining that starting with AEDT 2026 R2 SP2, PyAEDT is bundled with AEDT, and provided instructions for updating or installing extra dependencies using a virtual environment or the installer script. Also included guidance on installing the Extension Manager using the bundled PyAEDT.
* Added and reorganized internal references and section headings to improve navigation and clarify installation options, including new anchors for installer and PyPI instructions.

* Improved instructions for creating and activating virtual environments on both Windows and Linux, and clarified best practices for using `venv` over `uv`.

* Added additional notes and formatting improvements for post-installation steps and offline installation using a wheelhouse.

**Extension manager script updates:**

* Updated `run_extension_manager.py_build` to support the new AEDT installation directory structure for PyAEDT and its dependencies, ensuring the correct paths are used for both the main package and `site-packages`

## Issue linked
No issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
