### PR TITLE
FIX: Speedup import config

### DIFF
--- a/doc/changelog.d/7631.fixed.md
+++ b/doc/changelog.d/7631.fixed.md
@@ -1,0 +1,1 @@
+Speedup import config

--- a/src/ansys/aedt/core/generic/configurations.py
+++ b/src/ansys/aedt/core/generic/configurations.py
@@ -41,6 +41,7 @@ from ansys.aedt.core.generic.file_utils import read_configuration_file
 from ansys.aedt.core.generic.file_utils import write_configuration_file
 from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
 from ansys.aedt.core.generic.numbers_utils import decompose_variable_value
+from ansys.aedt.core.generic.numbers_utils import is_number
 from ansys.aedt.core.internal.errors import GrpcApiError
 from ansys.aedt.core.internal.load_aedt_file import load_keyword_in_aedt_file
 from ansys.aedt.core.modeler.cad.modeler import CoordinateSystem
@@ -2556,9 +2557,34 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                     if j.get("mirror", False):
                         new_comp.mirror = True
                     new_comp_params = {i: k[1:-1] if k.startswith('"') else k for i, k in new_comp.parameters.items()}
-                    for name, parameter in j["properties"].items():
-                        if new_comp_params.get(name, None) != parameter:
-                            new_comp.parameters[name] = parameter
+                    params = {
+                        i: j
+                        for i, j in j["properties"].items()
+                        if i in new_comp_params and j != new_comp_params and j != f'"{new_comp_params}"'
+                    }
+                    if params:
+                        try:
+                            values = [
+                                i[1:-1] if isinstance(i, str) and i.startswith('"') and is_number(i[1:-1]) else i
+                                for i in list(params.values())
+                            ]
+                            self._app.change_properties(
+                                self._app.oeditor,
+                                "PassedParameterTab",
+                                new_comp.composed_name,
+                                list(params.keys()),
+                                values,
+                            )
+                        except Exception:  # pragma: no cover
+                            self._app.logger.warning(
+                                f"Failed to set one of the properties for component {new_comp.composed_name}"
+                            )
+                            for ppn, ppv in params.items():
+                                new_comp.parameters[ppn] = (
+                                    ppv[1:-1]
+                                    if isinstance(ppv, str) and ppv.startswith('"') and is_number(ppv[1:-1])
+                                    else ppv
+                                )
 
         comp_list = list(self._app.modeler.schematic.components.values())
         for i, j in data["pin_mapping"].items():

--- a/src/ansys/aedt/core/generic/configurations.py
+++ b/src/ansys/aedt/core/generic/configurations.py
@@ -2463,6 +2463,49 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                         self._app.modeler.rename_page(idx + 1, page)
                 else:
                     self._app.modeler.add_page(page)
+
+        comp_dict = {}
+        for i, j in data["instance"].items():
+            for key, value in data["models"].items():
+                if key == j["component"]:
+                    component_type = value["component_type"]
+                    if component_type in ["ibis", "ami"]:
+                        if component_type == "ami":
+                            ami = True
+                            ami_str = "ami"
+                        else:
+                            ami = False
+                            ami_str = "ibs"
+                        ibis_name = value["file_path"] + ami_str
+                        if ibis_name in comp_dict.keys():
+                            ibis = comp_dict[ibis_name]["object"]
+                        else:
+                            ibis = self._app.get_ibis_model_from_file(value["file_path"], ami)
+                            comp_dict[ibis_name] = {"object": ibis, "pins": [], "buffers": []}
+                        if value["file_path"] + "" in comp_dict.keys():
+                            comp_dict[ibis_name] = {"object": ibis, "pins": [], "buffers": []}
+                        comp = j["properties"]["comp_name"] if "comp_name" in j["properties"] else j["component"]
+                        if (
+                            "diff_pin_name" in j["properties"]
+                            and comp in ibis.components
+                            and j["properties"]["diff_pin_name"] in ibis.components[comp].differential_pins
+                        ):
+                            comp_dict[ibis_name]["pins"].append(
+                                ibis.components[comp].differential_pins[j["properties"]["diff_pin_name"]].name
+                            )
+                        elif (
+                            "pin_name" in j["properties"]
+                            and comp in ibis.components
+                            and j["properties"].get("pin_name") in ibis.components[comp].pins
+                        ):
+                            comp_dict[ibis_name]["pins"].append(
+                                ibis.components[comp].pins[j["properties"]["pin_name"]].name
+                            )
+                        elif comp in ibis.buffers:
+                            comp_dict[ibis_name]["buffers"].append(ibis.buffers[comp].name)
+        for cv in comp_dict.values():
+            cv["object"]._app.import_model_in_aedt(pins=cv["pins"], buffers=cv["buffers"])
+
         for i, j in data["instance"].items():
             for key, value in data["models"].items():
                 if key == j["component"]:
@@ -2479,12 +2522,17 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                         )
                     elif component_type in ["ibis", "ami"]:
                         if component_type == "ami":
-                            ami = True
+                            ami_str = "ami"
                         else:
-                            ami = False
-                        ibis = self._app.get_ibis_model_from_file(value["file_path"], ami)
+                            ami_str = "ibs"
+                        ibis_name = value["file_path"] + ami_str
+                        ibis = comp_dict[ibis_name]["object"]
                         comp = j["properties"]["comp_name"] if "comp_name" in j["properties"] else j["component"]
-                        if "diff_pin_name" in j["properties"] and comp in ibis.components:
+                        if (
+                            "diff_pin_name" in j["properties"]
+                            and comp in ibis.components
+                            and j["properties"]["diff_pin_name"] in ibis.components[comp].differential_pins
+                        ):
                             new_comp = (
                                 ibis.components[comp]
                                 .differential_pins[j["properties"]["diff_pin_name"]]
@@ -2495,7 +2543,11 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                                     page=j.get("page", 1),
                                 )
                             )
-                        elif comp in ibis.components and j["properties"].get("pin_name") in ibis.components[comp].pins:
+                        elif (
+                            "pin_name" in j["properties"]
+                            and comp in ibis.components
+                            and j["properties"].get("pin_name") in ibis.components[comp].pins
+                        ):
                             new_comp = (
                                 ibis.components[comp]
                                 .pins[j["properties"]["pin_name"]]
@@ -2562,6 +2614,15 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                         for i, j in j["properties"].items()
                         if i in new_comp_params and j != new_comp_params and j != f'"{new_comp_params}"'
                     }
+                    if "model" in params:
+                        new_comp.parameters["model"] = params["model"]
+                        params.pop("model")
+                    if "buffer" in params:
+                        new_comp.parameters["buffer"] = params["buffer"]
+                        params.pop("buffer")
+                    if "buffer_mode" in params:
+                        new_comp.parameters["buffer_mode"] = params["buffer_mode"]
+                        params.pop("buffer_mode")
                     if params:
                         try:
                             values = [

--- a/src/ansys/aedt/core/generic/configurations.py
+++ b/src/ansys/aedt/core/generic/configurations.py
@@ -2477,12 +2477,12 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                             ami = False
                             ami_str = "ibs"
                         ibis_name = value["file_path"] + ami_str
-                        if ibis_name in comp_dict.keys():
+                        if ibis_name in comp_dict:
                             ibis = comp_dict[ibis_name]["object"]
                         else:
                             ibis = self._app.get_ibis_model_from_file(value["file_path"], ami)
                             comp_dict[ibis_name] = {"object": ibis, "pins": [], "buffers": []}
-                        if value["file_path"] + "" in comp_dict.keys():
+                        if ibis_name in comp_dict:
                             comp_dict[ibis_name] = {"object": ibis, "pins": [], "buffers": []}
                         comp = j["properties"]["comp_name"] if "comp_name" in j["properties"] else j["component"]
                         if (
@@ -2732,13 +2732,13 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
         return data
 
     def _hide_circuit_ibis(self, params, comp):
-        input = False
-        output = False
+        input_buffer = False
+        output_buffer = False
         if params["buffer"] == "input":
-            input = True
+            input_buffer = True
             comp._change_property("buffer_mode", True, value_name="Hidden")
         if params["buffer"] == "output":
-            output = True
+            output_buffer = True
             comp._change_property("buffer_mode", True, value_name="Hidden")
         if params["buffer"] == "input_output":
             comp._change_property("buffer_mode", False, value_name="Hidden")
@@ -2749,24 +2749,24 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
             if params.get("buffer_mode"):
                 comp._change_property("buffer_mode", params["buffer_mode"])
 
-        comp._change_property("logic_in", True if input or output else False, value_name="Hidden")
-        comp._change_property("phase_delay", True if input else False, value_name="Hidden")
-        comp._change_property("UIorBPS", True if input else False, value_name="Hidden")
-        comp._change_property("UIorBPSValue", True if input else False, value_name="Hidden")
-        comp._change_property("repeat_count", True if input else False, value_name="Hidden")
-        comp._change_property("step_resp_num_ui", True if input else False, value_name="Hidden")
+        comp._change_property("logic_in", True if input_buffer or output_buffer else False, value_name="Hidden")
+        comp._change_property("phase_delay", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("UIorBPS", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("UIorBPSValue", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("repeat_count", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("step_resp_num_ui", True if input_buffer else False, value_name="Hidden")
         if self._app._aedt_version > "2025.2":
-            comp._change_property("DataPattern", True if input else False, value_name="Hidden")
-            comp._change_property("hold_last", True if input else False, value_name="Hidden")
-            comp._change_property("do_coding", True if input else False, value_name="Hidden")
+            comp._change_property("DataPattern", True if input_buffer else False, value_name="Hidden")
+            comp._change_property("hold_last", True if input_buffer else False, value_name="Hidden")
+            comp._change_property("do_coding", True if input_buffer else False, value_name="Hidden")
         else:
-            comp._change_property("BitPattern", True if input else False, value_name="Hidden")
-            comp._change_property("hold_last_bit", True if input else False, value_name="Hidden")
-            comp._change_property("do_encoding", True if input else False, value_name="Hidden")
-        comp._change_property("Disable_Tx_Jitter", True if input else False, value_name="Hidden")
-        comp._change_property("DCDFractionorTime", True if input else False, value_name="Hidden")
-        comp._change_property("dcd", True if input else False, value_name="Hidden")
-        comp._change_property("txrj", True if input else False, value_name="Hidden")
-        comp._change_property("txpj", True if input else False, value_name="Hidden")
-        comp._change_property("txuj", True if input else False, value_name="Hidden")
-        comp._change_property("txcj", True if input else False, value_name="Hidden")
+            comp._change_property("BitPattern", True if input_buffer else False, value_name="Hidden")
+            comp._change_property("hold_last_bit", True if input_buffer else False, value_name="Hidden")
+            comp._change_property("do_encoding", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("Disable_Tx_Jitter", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("DCDFractionorTime", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("dcd", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("txrj", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("txpj", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("txuj", True if input_buffer else False, value_name="Hidden")
+        comp._change_property("txcj", True if input_buffer else False, value_name="Hidden")

--- a/src/ansys/aedt/core/generic/configurations.py
+++ b/src/ansys/aedt/core/generic/configurations.py
@@ -2614,15 +2614,6 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                         for i, j in j["properties"].items()
                         if i in new_comp_params and j != new_comp_params and j != f'"{new_comp_params}"'
                     }
-                    if "model" in params:
-                        new_comp.parameters["model"] = params["model"]
-                        params.pop("model")
-                    if "buffer" in params:
-                        new_comp.parameters["buffer"] = params["buffer"]
-                        params.pop("buffer")
-                    if "buffer_mode" in params:
-                        new_comp.parameters["buffer_mode"] = params["buffer_mode"]
-                        params.pop("buffer_mode")
                     if params:
                         try:
                             values = [
@@ -2646,6 +2637,8 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                                     if isinstance(ppv, str) and ppv.startswith('"') and is_number(ppv[1:-1])
                                     else ppv
                                 )
+                    if "buffer" in params:
+                        self._hide_circuit_ibis(params, new_comp)
 
         comp_list = list(self._app.modeler.schematic.components.values())
         for i, j in data["pin_mapping"].items():
@@ -2737,3 +2730,43 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                     self.results.import_parametrics = False
 
         return data
+
+    def _hide_circuit_ibis(self, params, comp):
+        input = False
+        output = False
+        if params["buffer"] == "input":
+            input = True
+            comp._change_property("buffer_mode", True, value_name="Hidden")
+        if params["buffer"] == "output":
+            output = True
+            comp._change_property("buffer_mode", True, value_name="Hidden")
+        if params["buffer"] == "input_output":
+            comp._change_property("buffer_mode", False, value_name="Hidden")
+            if params.get("buffer_mode"):
+                comp._change_property("buffer_mode", params["buffer_mode"])
+        if params["buffer"] == "three_state":
+            comp._change_property("buffer_mode", False, value_name="Hidden")
+            if params.get("buffer_mode"):
+                comp._change_property("buffer_mode", params["buffer_mode"])
+
+        comp._change_property("logic_in", True if input or output else False, value_name="Hidden")
+        comp._change_property("phase_delay", True if input else False, value_name="Hidden")
+        comp._change_property("UIorBPS", True if input else False, value_name="Hidden")
+        comp._change_property("UIorBPSValue", True if input else False, value_name="Hidden")
+        comp._change_property("repeat_count", True if input else False, value_name="Hidden")
+        comp._change_property("step_resp_num_ui", True if input else False, value_name="Hidden")
+        if self._app._aedt_version > "2025.2":
+            comp._change_property("DataPattern", True if input else False, value_name="Hidden")
+            comp._change_property("hold_last", True if input else False, value_name="Hidden")
+            comp._change_property("do_coding", True if input else False, value_name="Hidden")
+        else:
+            comp._change_property("BitPattern", True if input else False, value_name="Hidden")
+            comp._change_property("hold_last_bit", True if input else False, value_name="Hidden")
+            comp._change_property("do_encoding", True if input else False, value_name="Hidden")
+        comp._change_property("Disable_Tx_Jitter", True if input else False, value_name="Hidden")
+        comp._change_property("DCDFractionorTime", True if input else False, value_name="Hidden")
+        comp._change_property("dcd", True if input else False, value_name="Hidden")
+        comp._change_property("txrj", True if input else False, value_name="Hidden")
+        comp._change_property("txpj", True if input else False, value_name="Hidden")
+        comp._change_property("txuj", True if input else False, value_name="Hidden")
+        comp._change_property("txcj", True if input else False, value_name="Hidden")


### PR DESCRIPTION
## Description
Actually the import_config for schematic suffers about performance issues especially due to sequential parameter assignments. I've changed the approach and now I set all the properties in one shot. Furthermore I moved the import of the ibis buffer model at the top of the importer to reduce redundant file load from AEDT. 
Finally I've added logic to hide and show parameters depending on buffer model

## Issue linked
No issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
