### PR TITLE
FIX: Added possibility to change_properties to pass the list of types.

### DIFF
--- a/doc/changelog.d/7632.fixed.md
+++ b/doc/changelog.d/7632.fixed.md
@@ -1,0 +1,1 @@
+Added possibility to change_properties to pass the list of types.

--- a/src/ansys/aedt/core/application/analysis.py
+++ b/src/ansys/aedt/core/application/analysis.py
@@ -2308,6 +2308,7 @@ class Analysis(Design, PyAedtBase):
         property_object: str,
         property_names: list,
         property_values: list,
+        property_types: list = None,
     ) -> bool:
         """Change multiple properties.
 
@@ -2324,6 +2325,9 @@ class Analysis(Design, PyAedtBase):
             List of property names. For example, ``["prop1", "prop2"]``.
         property_values : list
             List of property values corresponding to the property names.
+        property_types : list, optional
+            List of property types corresponding to the property names.
+            Values are  ``"Value"``, ``"ButtonText"``, ``"Hidden"``.
 
         Returns
         -------
@@ -2334,15 +2338,35 @@ class Analysis(Design, PyAedtBase):
         ----------
         >>> oEditor.ChangeProperty
         """
+        button_list = [
+            "file",
+            "buffer_mode",
+            "logic_in",
+            "out_of_in",
+            "DataPattern",
+            "txrj",
+            "txpj",
+            "txuj",
+            "txcj",
+            "txrj",
+            "EyeMeasurementFunctions",
+        ]
+
         if not isinstance(property_names, list) or not isinstance(property_values, list):
             raise ValueError("``property_names`` and ``property_values`` must be lists.")
 
         if len(property_names) != len(property_values):
             raise ValueError("``property_names`` and ``property_values`` must have the same length.")
+        if property_types and isinstance(property_types, str):
+            property_types = [property_types] * len(property_names)
+        elif property_types and len(property_types) != len(property_names):
+            raise ValueError("``property_names`` and ``property_types`` must have the same length.")
+        else:
+            property_types = ["Value" if i not in button_list else "ButtonText" for i in property_names]
 
         changed_props = []
-        for name, value in zip(property_names, property_values):
-            changed_props.append(["NAME:" + name, "Value:=", value])
+        for name, value, p_type in zip(property_names, property_values, property_types):
+            changed_props.append(["NAME:" + name, f"{p_type}:=", value])
 
         aedt_object.ChangeProperty(
             [

--- a/src/ansys/aedt/core/application/analysis.py
+++ b/src/ansys/aedt/core/application/analysis.py
@@ -2338,20 +2338,6 @@ class Analysis(Design, PyAedtBase):
         ----------
         >>> oEditor.ChangeProperty
         """
-        button_list = [
-            "file",
-            "buffer_mode",
-            "logic_in",
-            "out_of_in",
-            "DataPattern",
-            "txrj",
-            "txpj",
-            "txuj",
-            "txcj",
-            "txrj",
-            "EyeMeasurementFunctions",
-        ]
-
         if not isinstance(property_names, list) or not isinstance(property_values, list):
             raise ValueError("``property_names`` and ``property_values`` must be lists.")
 
@@ -2361,8 +2347,8 @@ class Analysis(Design, PyAedtBase):
             property_types = [property_types] * len(property_names)
         elif property_types and len(property_types) != len(property_names):
             raise ValueError("``property_names`` and ``property_types`` must have the same length.")
-        else:
-            property_types = ["Value" if i not in button_list else "ButtonText" for i in property_names]
+        elif not property_types:
+            property_types = ["Value"] * len(property_names)
 
         changed_props = []
         for name, value, p_type in zip(property_names, property_values, property_types):

--- a/src/ansys/aedt/core/application/analysis_nexxim.py
+++ b/src/ansys/aedt/core/application/analysis_nexxim.py
@@ -474,3 +474,66 @@ class FieldAnalysisCircuit(Analysis, PyAedtBase):
         setup.update()
         self._setups = tmp_setups + [setup]
         return setup
+
+    @pyaedt_function_handler()
+    def change_properties(
+        self,
+        aedt_object: object,
+        tab_name: str,
+        property_object: str,
+        property_names: list,
+        property_values: list,
+        property_types: list = None,
+    ) -> bool:
+        """Change multiple properties.
+
+        Parameters
+        ----------
+        aedt_object :
+            AEDT object. It can be oproject, odesign, oeditor or any of the objects to which the property belongs.
+        tab_name : str
+            Name of the tab to update. Options are ``BaseElementTab``, ``EM Design``, and
+            ``FieldsPostProcessorTab``. The default is ``BaseElementTab``.
+        property_object : str
+            Name of the property object.
+        property_names : list
+            List of property names. For example, ``["prop1", "prop2"]``.
+        property_values : list
+            List of property values corresponding to the property names.
+        property_types : list, optional
+            List of property types corresponding to the property names.
+            Values are  ``"Value"``, ``"ButtonText"``, ``"Hidden"``.
+
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+
+        References
+        ----------
+        >>> oEditor.ChangeProperty
+        """
+        button_list = [
+            "file",
+            "buffer_mode",
+            "logic_in",
+            "out_of_in",
+            "DataPattern",
+            "txrj",
+            "txpj",
+            "txuj",
+            "txcj",
+            "txrj",
+            "EyeMeasurementFunctions",
+        ]
+        if len(property_names) != len(property_values):
+            raise ValueError("``property_names`` and ``property_values`` must have the same length.")
+        if property_types and isinstance(property_types, str):
+            property_types = [property_types] * len(property_names)
+        elif property_types and len(property_types) != len(property_names):
+            raise ValueError("``property_names`` and ``property_types`` must have the same length.")
+        elif not property_types:
+            property_types = ["Value" if i not in button_list else "ButtonText" for i in property_names]
+        return super().change_properties(
+            aedt_object, tab_name, property_object, property_names, property_values, property_types
+        )

--- a/src/ansys/aedt/core/generic/configurations.py
+++ b/src/ansys/aedt/core/generic/configurations.py
@@ -2733,12 +2733,12 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
 
     def _hide_circuit_ibis(self, params, comp):
         input_buffer = False
-        output_buffer = False
+        output = False
         if params["buffer"] == "input":
             input_buffer = True
             comp._change_property("buffer_mode", True, value_name="Hidden")
         if params["buffer"] == "output":
-            output_buffer = True
+            output = True
             comp._change_property("buffer_mode", True, value_name="Hidden")
         if params["buffer"] == "input_output":
             comp._change_property("buffer_mode", False, value_name="Hidden")
@@ -2749,7 +2749,7 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
             if params.get("buffer_mode"):
                 comp._change_property("buffer_mode", params["buffer_mode"])
 
-        comp._change_property("logic_in", True if input_buffer or output_buffer else False, value_name="Hidden")
+        comp._change_property("logic_in", True if input_buffer or output else False, value_name="Hidden")
         comp._change_property("phase_delay", True if input_buffer else False, value_name="Hidden")
         comp._change_property("UIorBPS", True if input_buffer else False, value_name="Hidden")
         comp._change_property("UIorBPSValue", True if input_buffer else False, value_name="Hidden")

--- a/tests/system/general/test_ibis_reader.py
+++ b/tests/system/general/test_ibis_reader.py
@@ -73,6 +73,26 @@ def test_read_ibis(aedt_app) -> None:
     # Add buffer
     ibis.buffers["ansys_ddr4_dq_odt"].add()
     buffer = ibis.buffers["ansys_ddr4_dq_odt"].insert(0.1016, 0.05334, 0.0)
+    assert aedt_app.change_properties(
+        aedt_app.oeditor,
+        "PassedParameterTab",
+        buffer.composed_name,
+        ["DataPattern", "phase_delay"],
+        ["prbs_no=15 prbs_seed=0 prbs_bitlength='2^15-1' prbs_invert=0", "1s"],
+    )
+    assert buffer.parameters["DataPattern"] == "prbs_no=15 prbs_seed=0 prbs_bitlength='2^15-1' prbs_invert=0"
+    assert buffer.parameters["phase_delay"] == "1s"
+    assert aedt_app.change_properties(
+        aedt_app.oeditor,
+        "PassedParameterTab",
+        buffer.composed_name,
+        ["DataPattern", "phase_delay"],
+        ["prbs_no=16 prbs_seed=0 prbs_bitlength='2^16-1' prbs_invert=0", "0s"],
+        ["ButtonText", "Value"],
+    )
+    buffer._parameters = None
+    assert buffer.parameters["DataPattern"] == "prbs_no=16 prbs_seed=0 prbs_bitlength='2^16-1' prbs_invert=0"
+    assert buffer.parameters["phase_delay"] == "0s"
     assert buffer.name == "CompInst@ansys_ddr4_dq_odt_ansys_ddr4"
 
 

--- a/tests/system/solvers/test_analyze.py
+++ b/tests/system/solvers/test_analyze.py
@@ -802,6 +802,7 @@ def test_change_property(m3d_app) -> None:
         property_object="LocalVariables",
         property_names=["a", "b"],
         property_values=["15mm", "25mm"],
+        property_types=["Value", "Value"],
     )
 
     assert m3d_app["a"] == "15mm"


### PR DESCRIPTION
## Description
Added possibility to change_properties to pass the list of types.
Furthermore the property that are already mapped internally.


## Issue linked
Previosly the method can only change properties which item is named Value. It cannot address ButtonText objects in circuit.

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
