### PR TITLE
FIX: added model argument for SPICE in configuration

### DIFF
--- a/doc/changelog.d/7633.fixed.md
+++ b/doc/changelog.d/7633.fixed.md
@@ -1,0 +1,1 @@
+Added model argument for SPICE in configuration

--- a/src/ansys/aedt/core/generic/configurations.py
+++ b/src/ansys/aedt/core/generic/configurations.py
@@ -2582,6 +2582,8 @@ class ConfigurationsNexxim(Configurations, PyAedtBase):
                         new_comp = self._app.modeler.schematic.create_component_from_spicemodel(
                             input_file=value["file_path"],
                             location=j["position"],
+                            angle=j["angle"],
+                            model=j.get("model", None),
                             page=j.get("page", 1),
                         )
                     elif component_type == "nexxim state space":

--- a/src/ansys/aedt/core/modeler/circuits/object_3d_circuit.py
+++ b/src/ansys/aedt/core/modeler/circuits/object_3d_circuit.py
@@ -1097,7 +1097,7 @@ class CircuitComponent(PyAedtBase):
             right sides of the symbol, respectively.
         keep_original_size : bool, optional
             Whether if keep the original size and preserve images or ignore and write a new rectangle.
-            Default is ``True`╞.
+            Default is ``True``.
 
         Returns
         -------
@@ -1122,7 +1122,12 @@ class CircuitComponent(PyAedtBase):
         >>> ts_component.change_symbol_pin_locations(pin_locations)
         """
         base_spacing = 0.00254
-        symbol_pin_name_list = self.model_data.props.get("PortNames", [])
+        is_spice = False
+        if hasattr(self.model_data, "props") and "PortNames" in self.model_data.props:
+            symbol_pin_name_list = self.model_data.props.get("PortNames", [])
+        else:
+            is_spice = True
+            symbol_pin_name_list = [pin.name for pin in self.pins]
         pin_name_str_max_length = max(len(s) for s in symbol_pin_name_list)
 
         left_pins = pin_locations["left"]
@@ -1195,8 +1200,13 @@ class CircuitComponent(PyAedtBase):
             props_display_map = ["NAME:PropDisplayMap", "PinName:=", pin_name_def]
             return ["NAME:PinDef", "Pin:=", pin_def, props_display_map]
 
+        if not is_spice:
+            model_name = self.model_name
+        else:
+            model_name = self.parameters.get("Model", self.model_name)
+        
         args = [
-            f"NAME:{self.model_name}",
+            f"NAME:{model_name}",
             "ModTime:=",
             int(time.time()),
             "Library:=",
@@ -1234,13 +1244,13 @@ class CircuitComponent(PyAedtBase):
                 ]
             )
 
-        for pin_name in self.model_data.props.get("PortNames", []):
+        for pin_name in symbol_pin_name_list:
             terminals_arg.append("TermAttributes:=")
             terminals_arg.append([pin_name, pin_name, 0 if pin_name in left_pins else 1, 0, -1, ""])
 
-        edit_context_arg = ["NAME:EditContext", "RefPinOption:=", 2, "CompName:=", self.model_name, terminals_arg]
+        edit_context_arg = ["NAME:EditContext", "RefPinOption:=", 2, "CompName:=", model_name, terminals_arg]
 
-        self._circuit_components.osymbol_manager.EditSymbolAndUpdateComps(self.model_name, args, [], edit_context_arg)
+        self._circuit_components.osymbol_manager.EditSymbolAndUpdateComps(model_name, args, [], edit_context_arg)
         self._circuit_components.oeditor.MovePins(self.composed_name, -0, -0, 0, 0, ["NAME:PinMoveData"])
         return True
 

--- a/src/ansys/aedt/core/modeler/circuits/object_3d_circuit.py
+++ b/src/ansys/aedt/core/modeler/circuits/object_3d_circuit.py
@@ -1204,7 +1204,7 @@ class CircuitComponent(PyAedtBase):
             model_name = self.model_name
         else:
             model_name = self.parameters.get("Model", self.model_name)
-        
+
         args = [
             f"NAME:{model_name}",
             "ModTime:=",

--- a/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_circuit.py
@@ -1111,7 +1111,7 @@ class CircuitComponents(PyAedtBase):
     def create_component(
         self,
         name: str | None = None,
-        component_library: str = "Resistors",
+        component_library: str | None = "Resistors",
         component_name: str = "RES_",
         location: list[float] = None,
         angle: int = 0,

--- a/src/ansys/aedt/core/modeler/circuits/primitives_nexxim.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_nexxim.py
@@ -2208,6 +2208,7 @@ class NexximComponents(CircuitComponents, PyAedtBase):
         model: str = None,
         create_component: bool = True,
         location: list[float] = None,
+        angle: int = 0,
         symbol_path: str = "Nexxim Circuit Elements\\Nexxim_symbols:",
         symbol: str = "",
         page: int = 1,
@@ -2270,7 +2271,7 @@ class NexximComponents(CircuitComponents, PyAedtBase):
 
         if create_component:
             return self.create_component(
-                None, component_library=None, component_name=model, location=location, page=page
+                None, component_library=None, component_name=model, location=location, page=page, angle=angle
             )
         return True
 

--- a/src/ansys/aedt/core/modeler/circuits/primitives_nexxim.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_nexxim.py
@@ -2208,10 +2208,10 @@ class NexximComponents(CircuitComponents, PyAedtBase):
         model: str = None,
         create_component: bool = True,
         location: list[float] = None,
-        angle: int = 0,
         symbol_path: str = "Nexxim Circuit Elements\\Nexxim_symbols:",
         symbol: str = "",
         page: int = 1,
+        angle: int = 0,
     ) -> "CircuitComponent | bool":
         """Create and place a new component based on a spice .lib file.
 
@@ -2225,8 +2225,6 @@ class NexximComponents(CircuitComponents, PyAedtBase):
             If set to ``True``, create a spice model component. Otherwise, only import the spice model.
         location : list, optional
             Position in the schematic of the new component.
-        angle : int, optional
-            Angle rotation in degrees. The default is ``0``.
         symbol_path : str, optional
             Path to the symbol library.
             Default value is ``"Nexxim Circuit Elements\\Nexxim_symbols:"``.
@@ -2235,6 +2233,8 @@ class NexximComponents(CircuitComponents, PyAedtBase):
             Default value is an empty string which means the default symbol for spice is used.
         page: int, optional
             Schematic page number. The default value is ``1``.
+        angle : int, optional
+            Angle rotation in degrees. The default is ``0``.
 
         Returns
         -------

--- a/src/ansys/aedt/core/modeler/circuits/primitives_nexxim.py
+++ b/src/ansys/aedt/core/modeler/circuits/primitives_nexxim.py
@@ -2225,6 +2225,8 @@ class NexximComponents(CircuitComponents, PyAedtBase):
             If set to ``True``, create a spice model component. Otherwise, only import the spice model.
         location : list, optional
             Position in the schematic of the new component.
+        angle : int, optional
+            Angle rotation in degrees. The default is ``0``.
         symbol_path : str, optional
             Path to the symbol library.
             Default value is ``"Nexxim Circuit Elements\\Nexxim_symbols:"``.


### PR DESCRIPTION
## Description
Added support to explicitly define the subckt model name for spice netlists in configuration flow.

## Issue linked
Previously it isn't possible to specify which subckt to import in the flow.
Linked #7635  found during symbol pins update.

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
