### PR TITLE
CI: Skip ``check-pr-template`` on automated changelog update PRs for release

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -134,7 +134,8 @@ jobs:
     if: |
       github.event.pull_request.title != 'CHORE: Pre-commit automatic update' &&
       !startsWith(github.event.pull_request.title, 'BUILD(uv):') &&
-      !startsWith(github.event.pull_request.title, 'BUILD(actions):')
+      !startsWith(github.event.pull_request.title, 'BUILD(actions):') &&
+      !startsWith(github.event.pull_request.title, 'CHORE: update CHANGELOG for v')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read   # Required to read PR content for validation

--- a/doc/changelog.d/7640.maintenance.md
+++ b/doc/changelog.d/7640.maintenance.md
@@ -1,0 +1,1 @@
+Skip \`\`check-pr-template\`\` on automated changelog update PRs for release


### PR DESCRIPTION
## Description
This PR is suggesting a minimal update to the ``check-pr-template`` introduced in #7612: Skipping this check for the automated PRs opened during the release process for updating the changelog (like #7639 for instance).
These PRs do not use the same description template as other ``pyaedt`` PRs so the ``check-pr-template`` is currently failing on them.

## Issue linked
None.
Issue noticed first on #7639.

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
