### PR TITLE
FIX: Fresnel output clean

### DIFF
--- a/doc/changelog.d/7641.fixed.md
+++ b/doc/changelog.d/7641.fixed.md
@@ -1,1 +1,1 @@
-Code page and nan
+Fresnel output clean

--- a/doc/changelog.d/7641.fixed.md
+++ b/doc/changelog.d/7641.fixed.md
@@ -1,0 +1,1 @@
+Code page and nan

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -7985,7 +7985,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin, PyAedtBase):
             phi_step = np.round(phi_step, 6)
 
         # Write output file
-        with open(output_file, "w") as ofile:
+        with open(output_file, "w", encoding="utf-8") as ofile:
             ofile.write("# SBR native file format for Fresnel reflection / reflection-transmission table data.\n")
             ofile.write(f"# Generated from {self.project_name} project and {self.design_name} design.\n")
             ofile.write(

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -7776,8 +7776,8 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin, PyAedtBase):
         if not is_reflection:
             top, bot = floquet_ports[0], floquet_ports[1]
             # renormalization factors for transfer coefficients
-            _create_var("renorm_t", f"sqrt(re(Zo({bot}:1))/re(Zo({top}:1)))")
-            _create_var("renorm_t_inv", f"sqrt(re(Zo({top}:1))/re(Zo({bot}:1)))")
+            _create_var("renorm_t", f"if(re(Zo({top}:1))>0,sqrt(re(Zo({bot}:1))/re(Zo({top}:1))),0)")
+            _create_var("renorm_t_inv", f"if(re(Zo({bot}:1))>0,sqrt(re(Zo({top}:1))/re(Zo({bot}:1))),0)")
             # Co-pol transmission
             _create_var("t_te", f"S({bot}:1,{top}:1)*renorm_t")
             _create_var("t_tm", f"S({bot}:2,{top}:2)*renorm_t")
@@ -8070,23 +8070,15 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin, PyAedtBase):
                         for i in range(len(frequencies)):
                             ofile.write(f"{re_r_te[i]:.5e}\t{im_r_te[i]:.5e}\t{re_r_tm[i]:.5e}\t{im_r_tm[i]:.5e}\n")
                     else:
-                        # Impedance scaling factor (computed once for this theta)
-                        imp_top.active_variation = v
-                        imp_bot.active_variation = v
-                        imp1_real = imp_top.get_expression_data(formula="real")[1]
-                        imp2_real = imp_bot.get_expression_data(formula="real")[1]
-
-                        factor = [math.sqrt(b / a) for a, b in zip(imp1_real, imp2_real)]
-
                         # T TE
                         t_te.active_variation = v
-                        re_t_te = [a * b for a, b in zip(t_te.get_expression_data(formula="real")[1], factor)]
-                        im_t_te = [a * b for a, b in zip(t_te.get_expression_data(formula="imag")[1], factor)]
+                        re_t_te = t_te.get_expression_data(formula="real")[1]
+                        im_t_te = t_te.get_expression_data(formula="imag")[1]
 
                         # T TM
                         t_tm.active_variation = v
-                        re_t_tm = [a * b for a, b in zip(t_tm.get_expression_data(formula="real")[1], factor)]
-                        im_t_tm = [a * b for a, b in zip(t_tm.get_expression_data(formula="imag")[1], factor)]
+                        re_t_tm = t_tm.get_expression_data(formula="real")[1]
+                        im_t_tm = t_tm.get_expression_data(formula="imag")[1]
 
                         for i in range(len(frequencies)):
                             ofile.write(
@@ -8149,33 +8141,25 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin, PyAedtBase):
                                     write_360.append(output_str)
                                 ofile.write(output_str)
                         else:
-                            # Impedance scaling factor (computed once per (theta, phi))
-                            imp_top.active_variation = var_index[vkey]
-                            imp_bot.active_variation = var_index[vkey]
-                            imp1_real = imp_top.get_expression_data(formula="real")[1]
-                            imp2_real = imp_bot.get_expression_data(formula="real")[1]
-
-                            factor = [math.sqrt(b / a) for a, b in zip(imp2_real, imp1_real)]
-
                             # T TE TE
                             t_te.active_variation = var_index[vkey]
-                            re_t_te_te = [a * b for a, b in zip(t_te.get_expression_data(formula="real")[1], factor)]
-                            im_t_te_te = [a * b for a, b in zip(t_te.get_expression_data(formula="imag")[1], factor)]
+                            re_t_te_te = t_te.get_expression_data(formula="real")[1]
+                            im_t_te_te = t_te.get_expression_data(formula="imag")[1]
 
                             # T TM TM
                             t_tm.active_variation = var_index[vkey]
-                            re_t_tm_tm = [a * b for a, b in zip(t_tm.get_expression_data(formula="real")[1], factor)]
-                            im_t_tm_tm = [a * b for a, b in zip(t_tm.get_expression_data(formula="imag")[1], factor)]
+                            re_t_tm_tm = t_tm.get_expression_data(formula="real")[1]
+                            im_t_tm_tm = t_tm.get_expression_data(formula="imag")[1]
 
                             # T TM TE
                             t_tm_te.active_variation = var_index[vkey]
-                            re_t_tm_te = [a * b for a, b in zip(t_tm_te.get_expression_data(formula="real")[1], factor)]
-                            im_t_tm_te = [a * b for a, b in zip(t_tm_te.get_expression_data(formula="imag")[1], factor)]
+                            re_t_tm_te = t_tm_te.get_expression_data(formula="real")[1]
+                            im_t_tm_te = t_tm_te.get_expression_data(formula="imag")[1]
 
                             # T TE TM
                             t_te_tm.active_variation = var_index[vkey]
-                            re_t_te_tm = [a * b for a, b in zip(t_te_tm.get_expression_data(formula="real")[1], factor)]
-                            im_t_te_tm = [a * b for a, b in zip(t_te_tm.get_expression_data(formula="imag")[1], factor)]
+                            re_t_te_tm = t_te_tm.get_expression_data(formula="real")[1]
+                            im_t_te_tm = t_te_tm.get_expression_data(formula="imag")[1]
 
                             for i in range(len(frequencies)):
                                 output_str = (
@@ -8216,48 +8200,25 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin, PyAedtBase):
                             re_r_te_tm = r_te_tm_inv.get_expression_data(formula="real")[1]
                             im_r_te_tm = r_te_tm_inv.get_expression_data(formula="imag")[1]
 
-                            # Impedance scaling factor for inverse part (mirrors original direction)
-                            imp_top.active_variation = var_index[vkey]
-                            imp_bot.active_variation = var_index[vkey]
-                            imp1_real = imp_top.get_expression_data(formula="real")[1]
-                            imp2_real = imp_bot.get_expression_data(formula="real")[1]
-                            factor = [math.sqrt(a / b) for a, b in zip(imp1_real, imp2_real)]
-
                             # T TE TE (inverse)
                             t_te_inv.active_variation = var_index[vkey]
-                            re_t_te_te = [
-                                a * b for a, b in zip(t_te_inv.get_expression_data(formula="real")[1], factor)
-                            ]
-                            im_t_te_te = [
-                                a * b for a, b in zip(t_te_inv.get_expression_data(formula="imag")[1], factor)
-                            ]
+                            re_t_te_te = t_te_inv.get_expression_data(formula="real")[1]
+                            im_t_te_te = t_te_inv.get_expression_data(formula="imag")[1]
 
                             # T TM TM (inverse)
                             t_tm_inv.active_variation = var_index[vkey]
-                            re_t_tm_tm = [
-                                a * b for a, b in zip(t_tm_inv.get_expression_data(formula="real")[1], factor)
-                            ]
-                            im_t_tm_tm = [
-                                a * b for a, b in zip(t_tm_inv.get_expression_data(formula="imag")[1], factor)
-                            ]
+                            re_t_tm_tm = t_tm_inv.get_expression_data(formula="real")[1]
+                            im_t_tm_tm = t_tm_inv.get_expression_data(formula="imag")[1]
 
                             # T TM TE (inverse)
                             t_tm_te_inv.active_variation = var_index[vkey]
-                            re_t_tm_te = [
-                                a * b for a, b in zip(t_tm_te_inv.get_expression_data(formula="real")[1], factor)
-                            ]
-                            im_t_tm_te = [
-                                a * b for a, b in zip(t_tm_te_inv.get_expression_data(formula="imag")[1], factor)
-                            ]
+                            re_t_tm_te = t_tm_te_inv.get_expression_data(formula="real")[1]
+                            im_t_tm_te = t_tm_te_inv.get_expression_data(formula="imag")[1]
 
                             # T TE TM (inverse)
                             t_te_tm_inv.active_variation = var_index[vkey]
-                            re_t_te_tm = [
-                                a * b for a, b in zip(t_te_tm_inv.get_expression_data(formula="real")[1], factor)
-                            ]
-                            im_t_te_tm = [
-                                a * b for a, b in zip(t_te_tm_inv.get_expression_data(formula="imag")[1], factor)
-                            ]
+                            re_t_te_tm = t_te_tm_inv.get_expression_data(formula="real")[1]
+                            im_t_te_tm = t_te_tm_inv.get_expression_data(formula="imag")[1]
 
                             for i in range(len(frequencies)):
                                 output_str = (


### PR DESCRIPTION
## Description
This pull request refactors parts of the `src/ansys/aedt/core/hfss.py` module to simplify the calculation of transmission coefficients and improve file handling. The main changes remove redundant impedance scaling factors from several calculations, making the code cleaner and more maintainable. Additionally, file writing is updated to explicitly specify UTF-8 encoding.

**Refactoring of transmission coefficient calculations:**

* Removed the computation and application of impedance scaling factors in the calculation of transmission coefficients (e.g., `t_te`, `t_tm`, `t_te_te`, etc.) throughout the `_get_sd` function, now using only the expression data directly. This reduces complexity and potential sources of error.

**Improvement in variable creation logic:**

* Updated the creation of renormalization variables (`renorm_t`, `renorm_t_inv`) to include a conditional check for positive impedance values, preventing math errors when impedance is non-physical (zero or negative).

**File handling improvements:**

* Changed file writing to use explicit UTF-8 encoding when generating output files, ensuring compatibility with non-ASCII characters.

## Issue linked
No issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
