### PR TITLE
FIX: Add xfce4-terminal for xfce desktops

### DIFF
--- a/doc/changelog.d/7647.fixed.md
+++ b/doc/changelog.d/7647.fixed.md
@@ -1,0 +1,1 @@
+Add xfce4-terminal for xfce desktops

--- a/src/ansys/aedt/core/extensions/templates/pyaedt_utils.py
+++ b/src/ansys/aedt/core/extensions/templates/pyaedt_utils.py
@@ -64,7 +64,7 @@ def check_file(file_path, oDesktop):
 
 def get_linux_terminal():
     """Get a Linux terminal."""
-    for terminal in ["x-terminal-emulator", "xterm", "gnome-terminal", "lxterminal", "mlterm"]:
+    for terminal in ["x-terminal-emulator", "xterm", "xfce4-terminal", "gnome-terminal", "lxterminal", "mlterm"]:
         terminal_exe = which(terminal)
         if terminal_exe:
             return terminal, terminal_exe

--- a/src/ansys/aedt/core/extensions/templates/pyaedt_utils.py
+++ b/src/ansys/aedt/core/extensions/templates/pyaedt_utils.py
@@ -78,6 +78,8 @@ def get_linux_terminal_command():
         return [terminal_exe, "-e"]
     elif terminal == "xterm":
         return [terminal_exe, "-e"]
+    elif terminal == "xfce4-terminal":
+        return [terminal_exe, "-e"]
     elif terminal == "gnome-terminal":
         return [terminal_exe, "--"]
     elif terminal == "lxterminal":


### PR DESCRIPTION
## Description
This pull request adds support for the `xfce4-terminal` terminal emulator on Linux systems, specifically enhancing compatibility for XFCE desktop environments.

**Terminal support improvements:**

* Updated the `get_linux_terminal` function in `pyaedt_utils.py` to include `xfce4-terminal` in the list of recognized terminal emulators, ensuring better support for XFCE desktops.

**Documentation:**

* Added a changelog entry noting the addition of `xfce4-terminal` support for XFCE desktops.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
