### PR TITLE
FIX: fixed the nonetype error in eye points when pass fail was given false for statistical contour eye

### DIFF
--- a/doc/changelog.d/7652.fixed.md
+++ b/doc/changelog.d/7652.fixed.md
@@ -1,0 +1,1 @@
+Fixed the nonetype error in eye points when pass fail was given false for statistical contour eye

--- a/src/ansys/aedt/core/visualization/report/common.py
+++ b/src/ansys/aedt/core/visualization/report/common.py
@@ -753,7 +753,7 @@ class CommonReport(BinaryTreeNode, PyAedtBase):
         ):
             eye_xunits = self.__props_with_default(self._legacy_props["eye_mask"], "xunits", "ns")
             eye_yunits = self.__props_with_default(self._legacy_props["eye_mask"], "yunits", "mV")
-            eye_points = self.__props_with_default(self._legacy_props["eye_mask"], "points")
+            eye_points = self.__props_with_default(self._legacy_props["eye_mask"], "points", [])
             eye_enable = self.__props_with_default(self._legacy_props["eye_mask"], "enable_limits", False)
             eye_upper = self.__props_with_default(self._legacy_props["eye_mask"], "upper_limit", 500)
             eye_lower = self.__props_with_default(self._legacy_props["eye_mask"], "lower_limit", 0.3)


### PR DESCRIPTION
## Description
This PR fixed the nonetype error in eye points when pass fail was given false

## Issue linked
#7651 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).



