### PR TITLE
FIX: correct order of azimuth and elevation properties in hfss.py and update related tests

### DIFF
--- a/doc/changelog.d/7662.fixed.md
+++ b/doc/changelog.d/7662.fixed.md
@@ -1,0 +1,1 @@
+Correct order of azimuth and elevation properties in hfss.py and update related tests

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -5361,12 +5361,12 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin, PyAedtBase):
             defs = ["AzimuthStart", "AzimuthStop", "AzimuthStep", "ElevationStart", "ElevationStop", "ElevationStep"]
         else:
             defs = ["ElevationStart", "ElevationStop", "ElevationStep", "AzimuthStart", "AzimuthStop", "AzimuthStep"]
-        props[defs[0]] = self.value_with_units(phi_start, units)
-        props[defs[1]] = self.value_with_units(phi_stop, units)
-        props[defs[2]] = self.value_with_units(phi_step, units)
-        props[defs[3]] = self.value_with_units(theta_start, units)
-        props[defs[4]] = self.value_with_units(theta_stop, units)
-        props[defs[5]] = self.value_with_units(theta_step, units)
+        props[defs[0]] = self.value_with_units(theta_start, units)
+        props[defs[1]] = self.value_with_units(theta_stop, units)
+        props[defs[2]] = self.value_with_units(theta_step, units)
+        props[defs[3]] = self.value_with_units(phi_start, units)
+        props[defs[4]] = self.value_with_units(phi_stop, units)
+        props[defs[5]] = self.value_with_units(phi_step, units)
         props["UseLocalCS"] = custom_coordinate_system is not None
         if custom_coordinate_system:
             props["CoordSystem"] = custom_coordinate_system

--- a/tests/system/general/test_hfss.py
+++ b/tests/system/general/test_hfss.py
@@ -1242,17 +1242,28 @@ def test_create_infinite_sphere(aedt_app) -> None:
         polarization_angle=30,
     )
     assert bound
-    assert bound.azimuth_start == "1deg"
-    assert bound.azimuth_stop == "91deg"
-    assert bound.azimuth_step == "45deg"
-    assert bound.elevation_start == "2deg"
-    assert bound.elevation_stop == "92deg"
-    assert bound.elevation_step == "10deg"
+    assert bound.azimuth_start == "2deg"
+    assert bound.properties["Start Azimuth"] == "2deg"
+    assert bound.azimuth_stop == "92deg"
+    assert bound.properties["Stop Azimuth"] == "92deg"
+    assert bound.azimuth_step == "10deg"
+    assert bound.properties["Azimuth Step"] == "10deg"
+    assert bound.elevation_start == "1deg"
+    assert bound.properties["Start Elevation"] == "1deg"
+    assert bound.elevation_stop == "91deg"
+    assert bound.properties["Stop Elevation"] == "91deg"
+    assert bound.elevation_step == "45deg"
+    assert bound.properties["Elevation Step"] == "45deg"
     assert bound.slant_angle == "30deg"
+    assert bound.properties["Slant Angle"] == "30deg"
     assert bound.polarization == "Slant"
+    assert bound.properties["Polarization"] == "Slant"
+
     bound.azimuth_start = 20
     assert bound.azimuth_start == "20deg"
+    assert bound.properties["Start Azimuth"] == "20deg"
     assert bound.delete()
+
     bound = aedt_app.insert_infinite_sphere(
         definition="Az Over El",
         phi_start=1,
@@ -1264,14 +1275,16 @@ def test_create_infinite_sphere(aedt_app) -> None:
         use_slant_polarization=True,
         polarization_angle=30,
     )
-    assert bound.azimuth_start == "2deg"
+    assert bound.azimuth_start == "1deg"
+    assert bound.properties["Start Azimuth"] == "1deg"
     assert bound.delete()
+
     # Test with default "Theta-Phi" definition
     bound = aedt_app.insert_infinite_sphere(
         definition="Theta-Phi",
         phi_start=0,
         phi_stop=180,
-        phi_step=10,
+        phi_step=7,
         theta_start=-180,
         theta_stop=180,
         theta_step=10,
@@ -1279,13 +1292,20 @@ def test_create_infinite_sphere(aedt_app) -> None:
         polarization_angle=0,
     )
     assert bound
-    assert bound.theta_start == "0deg"
+    assert bound.theta_start == "-180deg"
+    assert bound.properties["Start Theta"] == "-180deg"
     assert bound.theta_stop == "180deg"
+    assert bound.properties["Stop Theta"] == "180deg"
     assert bound.theta_step == "10deg"
-    assert bound.phi_start == "-180deg"
+    assert bound.properties["Theta step"] == "10deg"
+    assert bound.phi_start == "0deg"
+    assert bound.properties["Start Phi"] == "0deg"
     assert bound.phi_stop == "180deg"
-    assert bound.phi_step == "10deg"
+    assert bound.properties["Stop Phi"] == "180deg"
+    assert bound.phi_step == "7deg"
+    assert bound.properties["Phi Step"] == "7deg"
     assert bound.polarization == "Linear"
+    assert bound.properties["Polarization"] == "Linear"
 
     air = aedt_app.modeler.create_box([0, 0, 0], [20, 20, 20], name="rad", material="vacuum")
     aedt_app.assign_radiation_boundary_to_objects(air)


### PR DESCRIPTION
## Description
This pull request corrects the mapping of theta and phi parameters in the `insert_infinite_sphere` function and updates the corresponding system tests to reflect the new behavior. The changes ensure that the properties for azimuth and elevation (or theta and phi) are assigned correctly according to the selected definition, and the tests now assert both the direct attributes and the underlying properties for accuracy.

Parameter mapping correction:

* Fixed the assignment of theta and phi values to the correct property keys in the `insert_infinite_sphere` method, ensuring that the order matches the expected definitions for both "Az Over El" and "Theta-Phi". (`src/ansys/aedt/core/hfss.py`)

Test updates for new behavior:

* Updated system tests to assert the correct values for azimuth and elevation (or theta and phi) attributes and their corresponding entries in the `properties` dictionary, reflecting the corrected parameter mapping. (`tests/system/general/test_hfss.py`)

## Issue linked
Close #7649 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
