### PR TITLE
FIX: remove redundant RangeCount assignment and add LogScale subrange

### DIFF
--- a/doc/changelog.d/7664.fixed.md
+++ b/doc/changelog.d/7664.fixed.md
@@ -1,0 +1,1 @@
+Remove redundant RangeCount assignment and add LogScale subrange

--- a/src/ansys/aedt/core/modules/solve_sweeps.py
+++ b/src/ansys/aedt/core/modules/solve_sweeps.py
@@ -811,7 +811,6 @@ class SweepMatrix(SweepCommon):
             sweep_range["RangeStep"] = str(count) + unit
         elif range_type == "LogScale":
             sweep_range["RangeEnd"] = str(end) + unit
-            sweep_range["RangeCount"] = self.props["RangeCount"]
             sweep_range["RangeSamples"] = count
         if not self.props.get("SweepRanges") or not self.props["SweepRanges"].get("Subrange"):
             self.props["SweepRanges"] = {"Subrange": []}

--- a/tests/system/general/test_q2d.py
+++ b/tests/system/general/test_q2d.py
@@ -92,6 +92,7 @@ def test_add_sweep(aedt_app) -> None:
     sweep = setup.add_sweep("Q2D_Sweep1")
     assert sweep.add_subrange("LinearCount", 0.0, 100e6, 10)
     assert sweep.add_subrange("LinearStep", 100e6, 2e9, 50e6)
+    assert sweep.add_subrange("LogScale", 100, 100e6, 10)
     assert sweep.add_subrange("LogScale", 100, 100e6, 10, clear=True)
     assert sweep.add_subrange("LinearStep", 100, 100e6, 1e4, clear=True)
     assert sweep.add_subrange("LinearCount", 100, 100e6, 10, clear=True)


### PR DESCRIPTION
## Description

This pull request makes a minor adjustment to the logic for adding sweep subranges and updates the corresponding test to improve coverage for the "LogScale" sweep type.

- **Bug Fixes & Logic Updates:**
  * In the `add_subrange` method in `solve_sweeps.py`, the assignment of `RangeCount` for "LogScale" sweep types has been removed, leaving only `RangeSamples` to be set. This likely corrects or clarifies the intended behavior for log-scale sweeps.

- **Test Coverage:**
  * The system test in `test_q2d.py` now includes an explicit assertion for adding a "LogScale" subrange, ensuring this sweep type is properly tested.
  
## Issue linked

Close #7603 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
