### PR TITLE
FEAT: expose transient step and stop in create_tdr_schematic_from_snp

### DIFF
--- a/doc/changelog.d/5965.added.md
+++ b/doc/changelog.d/5965.added.md
@@ -1,0 +1,1 @@
+Expose transient step and stop time parameters in create_tdr_schematic_from_snp

--- a/doc/changelog.d/5965.added.md
+++ b/doc/changelog.d/5965.added.md
@@ -1,1 +1,0 @@
-Expose transient step and stop time parameters in create_tdr_schematic_from_snp

--- a/doc/changelog.d/7665.added.md
+++ b/doc/changelog.d/7665.added.md
@@ -1,0 +1,1 @@
+Expose transient step and stop in create_tdr_schematic_from_snp

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -1750,7 +1750,7 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
         impedance: float | None = 50,
         time_step: str | None = None,
         time_stop: str | None = None,
-    ) -> list[str]:
+    ) -> list[str] | bool:
         """Create a schematic from a Touchstone file and automatically setup a TDR transient analysis.
 
         Parameters

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -1745,7 +1745,7 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
         impedance: float | None = 50,
         time_step: str | None = None,
         time_stop: str | None = None,
-    ) -> list[str] | bool:
+    ) -> list[str]:
         """Create a schematic from a Touchstone file and automatically setup a TDR transient analysis.
 
         Parameters

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -1789,8 +1789,8 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
 
         Returns
         -------
-        list
-            List of TDR probe traces.
+        list, bool
+            List of TDR probe traces when successful, `False` when failing to retrieve the pins.
         """
         if design_name in self.design_list:
             self.logger.warning("Design already exists. renaming.")

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -1748,6 +1748,8 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
         analyze: bool | None = False,
         design_name: str | None = "LNA",
         impedance: float | None = 50,
+        transient_step: str | None = None,
+        transient_stop: str | None = None,
     ) -> None:
         """Create a schematic from a Touchstone file and automatically setup a TDR transient analysis.
 
@@ -1776,6 +1778,14 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
             New schematic name. The default is ``"LNA"``.
         impedance : float, optional
             TDR single ended impedance. The default is ``50``. For differential tdr, it will be computed by PyAEDT.
+        transient_step : str, optional
+            Transient analysis step size, including units (for example ``"10ps"``). The default
+            is ``None``, which derives ``rise_time / 4`` in nanoseconds. The recommended range
+            for the step size is 2-15 ps depending on the frequency content of the model.
+        transient_stop : str, optional
+            Transient analysis stop time, including units (for example ``"35ns"``). The default
+            is ``None``, which derives ``rise_time * 1000`` in nanoseconds. The stop time should
+            be chosen based on the flight time of the signal under test.
 
         Returns
         -------
@@ -1852,7 +1862,9 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
                 p1.pins[0].connect_to_component(pin, use_wire=True)
                 p1.impedance = [f"{impedance}ohm", "0ohm"]
         setup = self.create_setup(name="Transient_TDR", setup_type=Setups.NexximTransient)
-        setup.props["TransientData"] = [f"{rise_time / 4}ns", f"{rise_time * 1000}ns"]
+        step_value = transient_step if transient_step is not None else f"{rise_time / 4}ns"
+        stop_value = transient_stop if transient_stop is not None else f"{rise_time * 1000}ns"
+        setup.props["TransientData"] = [step_value, stop_value]
         if use_convolution:
             self.oanalysis.AddAnalysisOptions(
                 [

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -1748,9 +1748,9 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
         analyze: bool | None = False,
         design_name: str | None = "LNA",
         impedance: float | None = 50,
-        transient_step: str | None = None,
-        transient_stop: str | None = None,
-    ) -> None:
+        time_step: str | None = None,
+        time_stop: str | None = None,
+    ) -> list[str]:
         """Create a schematic from a Touchstone file and automatically setup a TDR transient analysis.
 
         Parameters
@@ -1778,18 +1778,19 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
             New schematic name. The default is ``"LNA"``.
         impedance : float, optional
             TDR single ended impedance. The default is ``50``. For differential tdr, it will be computed by PyAEDT.
-        transient_step : str, optional
+        time_step : str, optional
             Transient analysis step size, including units (for example ``"10ps"``). The default
             is ``None``, which derives ``rise_time / 4`` in nanoseconds. The recommended range
             for the step size is 2-15 ps depending on the frequency content of the model.
-        transient_stop : str, optional
+        time_stop : str, optional
             Transient analysis stop time, including units (for example ``"35ns"``). The default
             is ``None``, which derives ``rise_time * 1000`` in nanoseconds. The stop time should
             be chosen based on the flight time of the signal under test.
 
         Returns
         -------
-
+        list
+            List of TDR probe traces.
         """
         if design_name in self.design_list:
             self.logger.warning("Design already exists. renaming.")
@@ -1862,8 +1863,8 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
                 p1.pins[0].connect_to_component(pin, use_wire=True)
                 p1.impedance = [f"{impedance}ohm", "0ohm"]
         setup = self.create_setup(name="Transient_TDR", setup_type=Setups.NexximTransient)
-        step_value = transient_step if transient_step is not None else f"{rise_time / 4}ns"
-        stop_value = transient_stop if transient_stop is not None else f"{rise_time * 1000}ns"
+        step_value = time_step if time_step is not None else f"{rise_time / 4}ns"
+        stop_value = time_stop if time_stop is not None else f"{rise_time * 1000}ns"
         setup.props["TransientData"] = [step_value, stop_value]
         if use_convolution:
             self.oanalysis.AddAnalysisOptions(
@@ -1885,7 +1886,7 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
             self.analyze()
             for trace in tdr_probe_names:
                 self.post.create_report(trace)
-        return True, tdr_probe_names
+        return tdr_probe_names
 
     @pyaedt_function_handler()
     @deprecate_argument(

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -1732,10 +1732,6 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
         return hfss_3d_layout_model
 
     @pyaedt_function_handler()
-    @deprecate_argument(
-        arg_name="analyze",
-        message="The ``analyze`` argument will be removed in future versions. Analyze before exporting results.",
-    )
     def create_tdr_schematic_from_snp(
         self,
         input_file: str | Hfss3dLayout | Path,
@@ -1745,7 +1741,6 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
         differential: bool | None = True,
         rise_time: float | int = 30,
         use_convolution: bool | None = True,
-        analyze: bool | None = False,
         design_name: str | None = "LNA",
         impedance: float | None = 50,
         time_step: str | None = None,
@@ -1772,8 +1767,6 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
         use_convolution : bool, optional
             Whether to use convolution for the Touchstone file. The default is ``True``.
             If ``False``, state-space is used.
-        analyze : bool
-             Whether to automatically assign differential pairs. The default is ``False``.
         design_name : str, optional
             New schematic name. The default is ``"LNA"``.
         impedance : float, optional
@@ -1830,8 +1823,7 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
                     if differential:
                         n_pin = [k for k in sub.pins if k.name == tx_schematic_differential_pins[i]][0]
             except IndexError:
-                self.logger.error("Failed to retrieve the pins.")
-                return False
+                raise IndexError("Failed to retrieve the pins.")
 
             _, first, second = new_tdr_comp.pins[0].connect_to_component(p_pin)
             self.modeler.move(first, [0, 100], "mil")
@@ -1882,10 +1874,6 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
                 ]
             )
             setup.props["OptionName"] = "Nexxim Options"
-        if analyze:
-            self.analyze()
-            for trace in tdr_probe_names:
-                self.post.create_report(trace)
         return tdr_probe_names
 
     @pyaedt_function_handler()

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -1782,8 +1782,8 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
 
         Returns
         -------
-        list, bool
-            List of TDR probe traces when successful, `False` when failing to retrieve the pins.
+        list
+            List of TDR probe traces when successful.
         """
         if design_name in self.design_list:
             self.logger.warning("Design already exists. renaming.")

--- a/tests/system/general/test_circuit.py
+++ b/tests/system/general/test_circuit.py
@@ -996,7 +996,7 @@ def test_automatic_lna(aedt_app, test_tmp_dir) -> None:
 @pytest.mark.skipif(NON_GRAPHICAL and is_linux, reason="Method is not working in Linux and non-graphical mode.")
 def test_automatic_tdr(aedt_app, test_tmp_dir) -> None:
     touchstone_1 = shutil.copy2(TOUCHSTONE_FILE_CUSTOM, test_tmp_dir / TOUCHSTONE_CUSTOM)
-    result, _ = aedt_app.create_tdr_schematic_from_snp(
+    result = aedt_app.create_tdr_schematic_from_snp(
         input_file=touchstone_1,
         tx_schematic_pins=["A-MII-RXD1_30.SQFP28X28_208.P"],
         tx_schematic_differential_pins=["A-MII-RXD1_65.SQFP20X20_144.N"],
@@ -1007,8 +1007,8 @@ def test_automatic_tdr(aedt_app, test_tmp_dir) -> None:
         analyze=False,
         design_name="TDR",
     )
-    assert result
-    result, _ = aedt_app.create_tdr_schematic_from_snp(
+    assert isinstance(result, list)
+    result = aedt_app.create_tdr_schematic_from_snp(
         input_file=touchstone_1,
         tx_schematic_pins=[
             "A-MII-RXD1_30.SQFP28X28_208.P",
@@ -1026,6 +1026,8 @@ def test_automatic_tdr(aedt_app, test_tmp_dir) -> None:
         use_convolution=True,
         analyze=False,
         design_name="TDR_Single",
+        time_step="2ns",
+        time_stop="10ns"
     )
     assert result
 

--- a/tests/system/general/test_circuit.py
+++ b/tests/system/general/test_circuit.py
@@ -1004,7 +1004,6 @@ def test_automatic_tdr(aedt_app, test_tmp_dir) -> None:
         differential=True,
         rise_time=35,
         use_convolution=True,
-        analyze=False,
         design_name="TDR",
     )
     assert isinstance(result, list)
@@ -1024,7 +1023,6 @@ def test_automatic_tdr(aedt_app, test_tmp_dir) -> None:
         differential=False,
         rise_time=35,
         use_convolution=True,
-        analyze=False,
         design_name="TDR_Single",
         time_step="2ns",
         time_stop="10ns",

--- a/tests/system/general/test_circuit.py
+++ b/tests/system/general/test_circuit.py
@@ -1027,7 +1027,7 @@ def test_automatic_tdr(aedt_app, test_tmp_dir) -> None:
         analyze=False,
         design_name="TDR_Single",
         time_step="2ns",
-        time_stop="10ns"
+        time_stop="10ns",
     )
     assert result
 

--- a/tests/system/general/test_circuit.py
+++ b/tests/system/general/test_circuit.py
@@ -1029,7 +1029,7 @@ def test_automatic_tdr(aedt_app, test_tmp_dir) -> None:
         time_step="2ns",
         time_stop="10ns",
     )
-    assert result
+    assert isinstance(result, list)
 
 
 @pytest.mark.skipif(NON_GRAPHICAL and is_linux, reason="Method not working in Linux and Non graphical.")


### PR DESCRIPTION

(cherry picked from commit c10a31524e29231a8b53c753b8c2a8a45870bfde)

## Description
This pull request enhances the `create_tdr_schematic_from_snp` function in `circuit.py` by exposing new parameters that give users more control over the transient analysis setup. Specifically, it allows users to specify the transient step size and stop time directly, rather than relying solely on default calculations.

**Enhancements to transient analysis configuration:**

* Added `transient_step` and `transient_stop` parameters to the `create_tdr_schematic_from_snp` function signature, allowing users to specify these values explicitly.
* Updated the function's docstring to document the new parameters, including their purpose, expected format, and recommended usage.
* Modified the implementation to use the user-provided `transient_step` and `transient_stop` values if given, or fall back to the previously computed defaults if not.

**Documentation update:**

* Added a changelog entry noting that transient step and stop time parameters are now exposed in `create_tdr_schematic_from_snp`.

## Issue linked
Close #5965

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
