### PR TITLE
CHORE: Enable dependabot updates on pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,3 +46,24 @@ updates:
     # NOTE: if the 'prefix' is changed, the changes must be adapted in label.yml
     commit-message:
       prefix: "BUILD(actions)"
+
+  - package-ecosystem: "pre-commit"
+    cooldown:
+      default-days: 7 # Fallback cooldown if no specific rule applies
+      include:
+        - "*"  # Include all dependencies in cooldown
+      exclude:
+        - "ansys/pre-commit-hooks"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "Europe/Paris"
+    assignees:
+      - "pyansys-ci-bot"
+    labels:
+      - "maintenance"
+      - "dependencies"
+    commit-message:
+      prefix: "BUILD(pre-commit)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,6 @@
 # NOTE: if the 'autoupdate_commit_msg' is changed, the changes must be adapted in label.yml
 ci:
   autofix_commit_msg: 'CHORE: Auto fixes from pre-commit hooks'
-  autoupdate_commit_msg: 'CHORE: Pre-commit automatic update'
-  autoupdate_schedule: weekly
 
 exclude: |
   (?x)(

--- a/doc/changelog.d/7673.maintenance.md
+++ b/doc/changelog.d/7673.maintenance.md
@@ -1,0 +1,1 @@
+Enable dependabot updates on pre-commit


### PR DESCRIPTION
## Description
Leverage dependabot to handle the update logic of our pre-commit hooks. This is available since March and comes with the cooldown feature which wasn't available through pre-commit.ci.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
