### PR TITLE
FIX: use desktop launch timeout setting for AEDT startup

### DIFF
--- a/doc/changelog.d/7687.fixed.md
+++ b/doc/changelog.d/7687.fixed.md
@@ -1,0 +1,1 @@
+Use desktop launch timeout setting for AEDT startup

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -483,7 +483,7 @@ def launch_aedt_in_lsf(non_graphical: bool, port: int, host: str | None = None):
         pyaedt_logger.info("[LSF]:" + err)
         m = re.search(r"<<Starting on (.+?)>>", err)
         if m:
-            aedt_startup_timeout = 120
+            aedt_startup_timeout = settings.desktop_launch_timeout
             k = 0
             # LSF resources are assigned. Make sure AEDT starts
             while not _is_port_occupied(port, host=m.group(1)):


### PR DESCRIPTION
## Description
This pull request makes a small but important change to how #7685 he AEDT startup timeout is determined in the `lsf_message` function. Instead of using a hardcoded value, the timeout now uses the configurable `settings.desktop_launch_timeout` value, improving flexibility and maintainability.

* The AEDT startup timeout in `lsf_message` (in `src/ansys/aedt/core/desktop.py`) now uses `settings.desktop_launch_timeout` instead of the hardcoded value `120`.

## Issue linked
Close #7685 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
