### PR TITLE
FEAT: Improve auto complete experience with type hint

### DIFF
--- a/doc/changelog.d/7700.added.md
+++ b/doc/changelog.d/7700.added.md
@@ -1,0 +1,1 @@
+Improve auto complete experience with type hint

--- a/src/ansys/aedt/core/generic/general_methods.py
+++ b/src/ansys/aedt/core/generic/general_methods.py
@@ -26,8 +26,8 @@ from __future__ import annotations
 
 import datetime
 import difflib
-import functools
 from functools import update_wrapper
+from functools import wraps
 import inspect
 import itertools
 import logging
@@ -41,6 +41,8 @@ import sys
 import time
 import traceback
 from typing import TYPE_CHECKING
+from typing import Callable
+from typing import TypeVar
 
 if TYPE_CHECKING:
     from numpy import array
@@ -56,6 +58,8 @@ from ansys.aedt.core.generic.settings import settings
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from ansys.aedt.core.internal.errors import GrpcApiError
 from ansys.aedt.core.internal.errors import MethodNotSupportedError
+
+_F = TypeVar("_F", bound=Callable[..., Any])
 
 system = platform.system()
 is_linux = system == "Linux"
@@ -287,8 +291,8 @@ def deprecate_argument(arg_name: str, version: str = None, message: str = None, 
             If ``False``, a DeprecationWarning is issued.
     """
 
-    def decorator(func):
-        @functools.wraps(func)
+    def decorator(func: _F) -> _F:
+        @wraps(func)
         def wrapper(*args, **kwargs):
             sig = inspect.signature(func)
             try:
@@ -312,16 +316,27 @@ def deprecate_argument(arg_name: str, version: str = None, message: str = None, 
 
             return func(*args, **kwargs)
 
-        return wrapper
+        return wrapper  # type: ignore[return-value]
 
     return decorator
 
 
-def pyaedt_function_handler(direct_func=None, **deprecated_kwargs):
-    """Provide an exception handler, logging mechanism, and argument converter for client-server communications.
+def pyaedt_function_handler(direct_func: _F | None = None, **deprecated_kwargs) -> _F:
+    """Decorator that provides exception handling, execution logging, and deprecated kwargs management.
 
-    This method returns the function itself if correctly executed. Otherwise, it returns ``False``
-    and displays errors.
+    On successful execution, the decorated function returns its normal return value.
+
+    On exception, the behavior depends on ``settings.enable_error_handler``:
+
+    - If ``True``: the exception is caught, logged, and ``False`` is returned
+      (or ``None`` when the exception originates from ``__init__``).
+      If ``settings.release_on_exception`` is also ``True``, all active desktop
+      sessions are released before re-raising.
+    - If ``False``: the exception is re-raised directly to the caller.
+
+    ``**deprecated_kwargs`` maps old argument names to their replacements.
+    A ``DeprecationWarning`` is emitted when a deprecated argument is used,
+    and a ``TypeError`` is raised if both the old and new name are supplied.
 
     """
     if callable(direct_func):

--- a/src/ansys/aedt/core/internal/checks.py
+++ b/src/ansys/aedt/core/internal/checks.py
@@ -27,6 +27,7 @@
 from functools import wraps
 import warnings
 
+from ansys.aedt.core.generic.general_methods import _F
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 
 # NOTE: This should be updated for any modifications in pyaedt's graphics install target.
@@ -93,7 +94,7 @@ def min_aedt_version(min_version: str) -> callable:
             if desktop_class is not None:
                 return desktop_class.odesktop
 
-    def aedt_version_decorator(method: callable) -> callable:
+    def aedt_version_decorator(method: _F) -> _F:
         """Decorator to check AEDT version compatibility for a method."""
 
         @wraps(method)
@@ -115,7 +116,7 @@ def min_aedt_version(min_version: str) -> callable:
             else:
                 return method(self, *args, **kwargs)
 
-        return wrapper
+        return wrapper  # type: ignore[return-value]
 
     return aedt_version_decorator
 
@@ -199,14 +200,14 @@ def requires_graphical_dependency(*dependencies: str) -> callable:
         If any of the required dependencies are not available.
     """
 
-    def decorator(method: callable) -> callable:
+    def decorator(method: _F) -> _F:
         @wraps(method)
         def wrapper(*args, **kwargs):
             for dep in dependencies:
                 check_dependency_available(dep, warning=False)
             return method(*args, **kwargs)
 
-        return wrapper
+        return wrapper  # type: ignore[return-value]
 
     return decorator
 


### PR DESCRIPTION
## Description
Not reproducible everywhere but I was having an issue with my IDE's autocomplete because of how type hints were passed in decorators definitions.

For example, instead of the expected arguments of the function, I had `(...)` which is not very convenient..
<img width="568" height="312" alt="image" src="https://github.com/user-attachments/assets/714ae27a-309a-47a2-835a-17f6631e27dc" />

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
