### PR TITLE
FIX: Wrong Line setter in HFSS 3D Layout

### DIFF
--- a/.github/actions/label-from-trailers/action.yml
+++ b/.github/actions/label-from-trailers/action.yml
@@ -122,7 +122,7 @@ runs:
               emit)          add_label "EMIT" ;;
               mechanical)    add_label "Mechanical" ;;
               twin-builder)  add_label "Twin Builder" ;;
-              hfss3dlayout)  add_label "HFSS3DLayout" ;;
+              hfss3dlayout)  add_label "HFSS 3D Layout" ;;
               *) echo "::warning::Unknown Application value: '${APP}'" ;;
             esac
           done <<< "$(split_and_normalize "$LINE")"

--- a/.github/actions/label-from-trailers/action.yml
+++ b/.github/actions/label-from-trailers/action.yml
@@ -6,7 +6,7 @@ description: |
 
   Supported trailers:
     Application:   hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical,
-                   twin-builder  (comma-separated values allowed)
+                   twin-builder, hfss3dlayout  (comma-separated values allowed)
     AEDT-Version:  24.1, 24.2, 25.1, 25.2, 26.1  (comma-separated values allowed)
     Platform:      windows, linux, rocky  (comma-separated values allowed)
     Deprecation:   <scope>   -> adds label "deprecation"
@@ -122,6 +122,7 @@ runs:
               emit)          add_label "EMIT" ;;
               mechanical)    add_label "Mechanical" ;;
               twin-builder)  add_label "Twin Builder" ;;
+              hfss3dlayout)  add_label "HFSS3DLayout" ;;
               *) echo "::warning::Unknown Application value: '${APP}'" ;;
             esac
           done <<< "$(split_and_normalize "$LINE")"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -80,6 +80,10 @@
   description: Related to the Twin Builder application
   color: 0369a1
 
+- name: HFSS 3D Layout
+  description: Related to the HFSS 3D Layout application
+  color: 0369a1
+
 # AEDT versions
 
 - name: AEDT 24.1

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 Trailers must be placed at the end of the description, separated from the
 rest of the text by a blank line. Available trailers for automatic labeling:
 
-  Application: hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical, twin-builder
+  Application: hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical, twin-builder, hfss3dlayout
                (comma-separated values allowed)
   AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
                 (comma-separated values allowed)

--- a/doc/changelog.d/7724.fixed.md
+++ b/doc/changelog.d/7724.fixed.md
@@ -1,0 +1,1 @@
+Wrong Line setter in HFSS 3D Layout

--- a/src/ansys/aedt/core/modeler/pcb/object_3d_layout.py
+++ b/src/ansys/aedt/core/modeler/pcb/object_3d_layout.py
@@ -1345,7 +1345,7 @@ class Circle3dLayout(Geometries3DLayout, PyAedtBase):
 
     @center.setter
     def center(self, position) -> None:
-        vMaterial = ["NAME:Center", "Value:=", position]
+        vMaterial = ["NAME:Center", "X:=", position[0], "Y:=", position[1]]
         self.change_property(vMaterial)
 
     @property

--- a/src/ansys/aedt/core/modeler/pcb/object_3d_layout.py
+++ b/src/ansys/aedt/core/modeler/pcb/object_3d_layout.py
@@ -1581,7 +1581,7 @@ class Line3dLayout(Geometries3DLayout, PyAedtBase):
 
     @start_cap_type.setter
     def start_cap_type(self, value) -> None:
-        vMaterial = ["NAME:StartCap Type", "Value:=", value]
+        vMaterial = ["NAME:StartCapType", "Value:=", value]
         self.change_property(vMaterial)
 
     @property
@@ -1601,7 +1601,7 @@ class Line3dLayout(Geometries3DLayout, PyAedtBase):
 
     @end_cap_type.setter
     def end_cap_type(self, value) -> None:
-        vMaterial = ["NAME:EndCap Type", "Value:=", value]
+        vMaterial = ["NAME:EndCapType", "Value:=", value]
         self.change_property(vMaterial)
 
     @property

--- a/src/ansys/aedt/core/modeler/pcb/object_3d_layout.py
+++ b/src/ansys/aedt/core/modeler/pcb/object_3d_layout.py
@@ -99,7 +99,7 @@ class Object3DLayout(PyAedtBase):
         return True
 
     @pyaedt_function_handler()
-    def set_property_value(self, name: str, value: str):
+    def set_property_value(self, name: str, value: str) -> bool:
         """Set a property value.
 
         Parameters
@@ -119,14 +119,14 @@ class Object3DLayout(PyAedtBase):
         >>> oEditor.ChangeProperty
         """
         if "Pt" in name:
-            coordinates = value.split(",")
+            coordinates = [value_split.strip() for value_split in value.split(",")]
             vProp = ["NAME:" + name, "X:=", coordinates[0], "Y:=", coordinates[1]]
         else:
             vProp = ["NAME:" + name, "Value:=", value]
         return self.change_property(vProp)
 
     @property
-    def angle(self) -> str:
+    def angle(self) -> str | None:
         """Get/Set the circle radius.
 
         Returns
@@ -297,7 +297,7 @@ class Object3DLayout(PyAedtBase):
         return True
 
     @property
-    def location(self) -> list[float]:
+    def location(self) -> list[float] | None:
         """Retrieve/Set the absolute location in model units.
 
         Location is computed with combination of 3d Layout location and model center.
@@ -329,7 +329,8 @@ class Object3DLayout(PyAedtBase):
             loc_y = round(unit_converter(loc_y, output_units=self._primitives.model_units), 9)
             return [loc_x, loc_y]
         elif self.prim_type in ["pin", "via"]:
-            location = self._oeditor.GetPropertyValue("BaseElementTab", self.name, "Location").split(",")
+            location = self._oeditor.GetPropertyValue("BaseElementTab", self.name, "Location")
+            location = [location_split.strip() for location_split in location.split(",")]
             locs = []
             for i in location:
                 try:
@@ -1341,7 +1342,7 @@ class Circle3dLayout(Geometries3DLayout, PyAedtBase):
         """
         cent = self._oeditor.GetPropertyValue("BaseElementTab", self.name, "Center")
         if cent:
-            return cent.split(",")
+            return [cent_split.strip() for cent_split in cent.split(",")]
 
     @center.setter
     def center(self, position) -> None:
@@ -1435,7 +1436,7 @@ class Rect3dLayout(Geometries3DLayout, PyAedtBase):
         if not self.two_point_description:
             cent = self._oeditor.GetPropertyValue("BaseElementTab", self.name, "Center")
             if cent:
-                return cent.split(",")
+                return [cent_split.strip() for cent_split in cent.split(",")]
 
     @center.setter
     def center(self, value) -> None:
@@ -1503,7 +1504,7 @@ class Rect3dLayout(Geometries3DLayout, PyAedtBase):
         if self.two_point_description:
             pa = self._oeditor.GetPropertyValue("BaseElementTab", self.name, "Pt A")
             if pa:
-                return pa.split(",")
+                return [p_split.strip() for p_split in pa.split(",")]
 
     @point_a.setter
     def point_a(self, value) -> None:
@@ -1527,7 +1528,7 @@ class Rect3dLayout(Geometries3DLayout, PyAedtBase):
         if self.two_point_description:
             pa = self._oeditor.GetPropertyValue("BaseElementTab", self.name, "Pt B")
             if pa:
-                return pa.split(",")
+                return [p_split.strip() for p_split in pa.split(",")]
 
     @point_b.setter
     def point_b(self, value) -> None:

--- a/tests/system/layout/test_3dlayout_modeler.py
+++ b/tests/system/layout/test_3dlayout_modeler.py
@@ -300,7 +300,7 @@ def test_create_create_rectangle(aedt_app) -> None:
 
     assert n2.center
     n2.center = ["150mm", "150mm"]
-    assert n2.center == ["150mm", "150mm"]
+    assert n2.center == ["150 ", "150"] or n2.center == ["150", "150"]
 
 
 def test_subtract(aedt_app) -> None:

--- a/tests/system/layout/test_3dlayout_modeler.py
+++ b/tests/system/layout/test_3dlayout_modeler.py
@@ -287,7 +287,7 @@ def test_create_create_rectangle(aedt_app) -> None:
     n2.point_a = ["10", "10"]
     assert n2.point_a == ["10 ", "10"] or n2.point_a == ["10", "10"]
     n2.point_b = ["20", "20"]
-    assert n2.point_b == ["20", "20"]
+    assert n2.point_b == ["20 ", "20"] or n2.point_b == ["20", "20"]
 
     n2.two_point_description = False
     assert n2.height

--- a/tests/system/layout/test_3dlayout_modeler.py
+++ b/tests/system/layout/test_3dlayout_modeler.py
@@ -259,6 +259,10 @@ def test_create_circle(aedt_app) -> None:
     )
     n1 = aedt_app.modeler.create_circle("Top", 0, 5, 40, "mycircle")
     assert n1.name == "mycircle"
+    n1.radius = 5
+    assert n1.radius == "5"
+    n1.center = [10, 10]
+    assert n1.center == ["10", "10"]
 
 
 def test_create_create_rectangle(aedt_app) -> None:

--- a/tests/system/layout/test_3dlayout_modeler.py
+++ b/tests/system/layout/test_3dlayout_modeler.py
@@ -262,7 +262,7 @@ def test_create_circle(aedt_app) -> None:
     n1.radius = 5
     assert n1.radius == "5"
     n1.center = [10, 10]
-    assert n1.center == ["10 ", "10"] or n1.center == ["10", "10"]
+    assert n1.center == ["10", "10"]
 
 
 def test_create_create_rectangle(aedt_app) -> None:
@@ -285,9 +285,9 @@ def test_create_create_rectangle(aedt_app) -> None:
     assert not n2.width
     assert not n2.center
     n2.point_a = ["10", "10"]
-    assert n2.point_a == ["10 ", "10"] or n2.point_a == ["10", "10"]
+    assert n2.point_a == ["10", "10"]
     n2.point_b = ["20", "20"]
-    assert n2.point_b == ["20 ", "20"] or n2.point_b == ["20", "20"]
+    assert n2.point_b == ["20", "20"]
 
     n2.two_point_description = False
     assert n2.height
@@ -300,7 +300,7 @@ def test_create_create_rectangle(aedt_app) -> None:
 
     assert n2.center
     n2.center = ["150mm", "150mm"]
-    assert n2.center == ["150 ", "150"] or n2.center == ["150", "150"]
+    assert n2.center == ["150", "150"]
 
 
 def test_subtract(aedt_app) -> None:

--- a/tests/system/layout/test_3dlayout_modeler.py
+++ b/tests/system/layout/test_3dlayout_modeler.py
@@ -277,6 +277,31 @@ def test_create_create_rectangle(aedt_app) -> None:
     n2 = aedt_app.modeler.create_rectangle("Top", [0, 0], [6, 8], 3, 2, "myrectangle")
     assert n2.name == "myrectangle"
 
+    n2.corner_radius = "2mm"
+    assert n2.corner_radius == "2mm"
+
+    n2.two_point_description = True
+    assert not n2.height
+    assert not n2.width
+    assert not n2.center
+    n2.point_a = ["10", "10"]
+    assert n2.point_a == ["10 ", "10"] or n2.point_a == ["10", "10"]
+    n2.point_b = ["20", "20"]
+    assert n2.point_b == ["20", "20"]
+
+    n2.two_point_description = False
+    assert n2.height
+    n2.height = 200
+    assert n2.height == "200"
+
+    assert n2.width
+    n2.width = "100mm"
+    assert n2.width == "100mm"
+
+    assert n2.center
+    n2.center = ["150mm", "150mm"]
+    assert n2.center == ["150mm", "150mm"]
+
 
 def test_subtract(aedt_app) -> None:
     aedt_app.modeler.layers.add_layer(

--- a/tests/system/layout/test_3dlayout_modeler.py
+++ b/tests/system/layout/test_3dlayout_modeler.py
@@ -414,6 +414,23 @@ def test_create_line(aedt_app) -> None:
     assert line.set_property_value("Pt0", "10mm ,10mm")
     assert line.get_property_value("Pt0") == "10 ,10"
 
+    line.bend_type = "Round"
+    assert line.bend_type == "Round"
+
+    line.start_cap_type = "Round"
+    assert line.start_cap_type == "Round"
+
+    line.end_cap_type = "Extended"
+    assert line.end_cap_type == "Extended"
+
+    line.width = "2mm"
+    assert line.width == "2mm"
+
+    center = line.center_line
+    center["Pt0"] = ["0", "0"]
+    line.center_line = center
+    assert line.center_line == center
+
 
 def test_create_edge_port(aedt_app) -> None:
     aedt_app.modeler.layers.add_layer(

--- a/tests/system/layout/test_3dlayout_modeler.py
+++ b/tests/system/layout/test_3dlayout_modeler.py
@@ -262,7 +262,7 @@ def test_create_circle(aedt_app) -> None:
     n1.radius = 5
     assert n1.radius == "5"
     n1.center = [10, 10]
-    assert n1.center == ["10", "10"]
+    assert n1.center == ["10 ", "10"] or n1.center == ["10", "10"]
 
 
 def test_create_create_rectangle(aedt_app) -> None:


### PR DESCRIPTION
## Description
This pull request primarily adds and enhances tests for the 3D layout modeler, increasing coverage for property setters and getters of geometric objects like circles, rectangles, and lines. Additionally, it updates the implementation of the `center` property setter in the PCB 3D layout object to handle coordinates explicitly.

**Test enhancements for geometric objects:**

* Expanded tests for the circle object to verify setting and retrieving the `radius` and `center` properties, ensuring correct behavior and type handling.
* Added comprehensive tests for the rectangle object, covering `corner_radius`, switching between two-point and center/size descriptions, and validating properties like `height`, `width`, `center`, `point_a`, and `point_b`.
* Improved line object tests to cover `bend_type`, `start_cap_type`, `end_cap_type`, `width`, and manipulation of the `center_line` property.

**Implementation update:**

* Modified the `center` property setter in `object_3d_layout.py` to explicitly set `"X:="` and `"Y:="` values from the provided position, improving clarity and correctness in property assignment.

Application: hfss3dlayout
AEDT-Version: 26.1
Platform: windows, linux

## Issue linked
Close #7716 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue(s) that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
