### PR TITLE
FIX: Export touchstone on completion bug

### DIFF
--- a/doc/changelog.d/7726.fixed.md
+++ b/doc/changelog.d/7726.fixed.md
@@ -1,0 +1,1 @@
+Export touchstone on completion bug

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -7496,7 +7496,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin, PyAedtBase):
             self.logger.info("Disabling Export On Completion")
         if not output_dir:
             output_dir = ""
-        props = {"ExportAfterSolve": export, "ExportDir": output_dir}
+        props = {"Export After Simulation": export, "Export Dir": output_dir}
         return self.change_design_settings(props)
 
     @pyaedt_function_handler()


### PR DESCRIPTION
## Description

This pull request updates the property keys used when exporting simulation results in the `export_touchstone_on_completion` method of `src/ansys/aedt/core/hfss.py`. The change ensures that the property names match the expected format for design settings.

- **Property Key Updates:**
  * Changed the keys in the `props` dictionary from `"ExportAfterSolve"` and `"ExportDir"` to `"Export After Simulation"` and `"Export Dir"` in the `export_touchstone_on_completion` method to align with the correct design settings nomenclature.

Bug introduced in #6367

This can not be tested because there is no way to get the value of the checkbox.

Application: hfss
AEDT-Version: 25.2, 26.1
Platform: windows, linux

## Issue linked

Close #7712 

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue(s) that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have added the minimum version decorator to any new backend method implemented.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
