### PR TITLE
DOCS: Fix changelog breaking changes

### DIFF
--- a/doc/changelog.d/7737.documentation.md
+++ b/doc/changelog.d/7737.documentation.md
@@ -1,0 +1,1 @@
+Fix changelog breaking changes

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,22 +15,6 @@ This document contains the release notes for the project.
 .. tab-set::
 
 
-  .. tab-item:: Breaking
-
-    .. list-table::
-        :header-rows: 0
-        :widths: auto
-
-        * - Update pre-commit ci config and ruff hook
-          - `#7723 <https://github.com/ansys/pyaedt/pull/7723>`_
-
-        * - Update doc dependencies
-          - `#7727 <https://github.com/ansys/pyaedt/pull/7727>`_
-
-        * - Update most CI jobs to use python 3.14
-          - `#7729 <https://github.com/ansys/pyaedt/pull/7729>`_
-
-
   .. tab-item:: Fixed
 
     .. list-table::
@@ -81,6 +65,9 @@ This document contains the release notes for the project.
         * - Bump aiohttp from 3.13.4 to 3.14.0
           - `#7731 <https://github.com/ansys/pyaedt/pull/7731>`_
 
+        * - Update doc dependencies
+          - `#7727 <https://github.com/ansys/pyaedt/pull/7727>`_
+
 
   .. tab-item:: Maintenance
 
@@ -100,6 +87,11 @@ This document contains the release notes for the project.
         * - Fix linux rocky grpc issue
           - `#7728 <https://github.com/ansys/pyaedt/pull/7728>`_
 
+        * - Update pre-commit ci config and ruff hook
+          - `#7723 <https://github.com/ansys/pyaedt/pull/7723>`_
+
+        * - Update most CI jobs to use python 3.14
+          - `#7729 <https://github.com/ansys/pyaedt/pull/7729>`_
 
 `1.0.0 <https://github.com/ansys/pyaedt/releases/tag/v1.0.0>`_ - May 26, 2026
 =============================================================================


### PR DESCRIPTION
## Description
As title says. The changes are fixing a misplacement of some PRs where the breaking change trailers were kept as HTML comment in the PR body.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
