### PR TITLE
FEAT: added monitor flag in launch_aedt and launch_aedt_in_lsf

### DIFF
--- a/doc/changelog.d/7741.added.md
+++ b/doc/changelog.d/7741.added.md
@@ -1,0 +1,1 @@
+Added monitor flag in launch_aedt and launch_aedt_in_lsf

--- a/src/ansys/aedt/core/application/analysis.py
+++ b/src/ansys/aedt/core/application/analysis.py
@@ -1586,6 +1586,7 @@ class Analysis(Design, PyAedtBase):
                 cores=cores,
                 tasks=tasks,
                 revert_to_initial_mesh=revert_to_initial_mesh,
+                blocking=blocking,
             )
         else:
             return self.analyze_setup(
@@ -1914,6 +1915,7 @@ class Analysis(Design, PyAedtBase):
         tasks: int = 1,
         setup: str = None,
         revert_to_initial_mesh: bool = False,
+        blocking: bool = True,
     ) -> bool:  # pragma: no cover
         """Analyze a design setup in batch mode.
 
@@ -1946,6 +1948,9 @@ class Analysis(Design, PyAedtBase):
             The default is ``None``, in which case all setups are solved.
         revert_to_initial_mesh : bool, optional
             Whether to revert to the initial mesh before solving. The default is ``False``.
+        blocking : bool, optional
+            Whether to block script while analysis is completed or not. It works from AEDT 2023 R2.
+            Default is ``True``.
 
         Returns
         -------
@@ -1989,7 +1994,7 @@ class Analysis(Design, PyAedtBase):
             "-BatchSolve",
             "-machinelist",
             f"list={machine}:{tasks}:{cores}:90%:1",
-            "-Monitor",
+            "-monitor",
         ]
         if is_linux and settings.use_lsf_scheduler and tasks == -1:
             options.append("-distributed")
@@ -2030,7 +2035,7 @@ class Analysis(Design, PyAedtBase):
             subprocess.Popen(command)  # nosec
             self.logger.info("Batch job finished.")
 
-        if machine == "localhost":
+        if machine == "localhost" and blocking:
             while not os.path.exists(queue_file):
                 time.sleep(0.5)
             with open_file(queue_file, "r") as f:

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -346,6 +346,8 @@ def launch_aedt(
         command[-1] = str(port)
     if non_graphical:
         command.append("-ng")
+    if settings.enable_monitor_in_aedt:
+        command.append("-monitor")
     if settings.wait_for_license:
         command.append("-waitforlicense")
     if settings.aedt_log_file:
@@ -451,6 +453,8 @@ def launch_aedt_in_lsf(non_graphical: bool, port: int, host: str | None = None):
             command.append(f"-q {settings.lsf_queue}")
         if non_graphical:
             command.append("-ng")
+        if settings.enable_monitor_in_aedt:
+            command.append("-monitor")
         if settings.wait_for_license:
             command.append("-waitforlicense")
         if settings.aedt_log_file:

--- a/src/ansys/aedt/core/generic/settings.py
+++ b/src/ansys/aedt/core/generic/settings.py
@@ -243,6 +243,7 @@ class Settings(PyAedtBase):
         self.__grpc_local = DEFAULT_GRPC_LOCAL
         self.__grpc_listen_all = DEFAULT_GRPC_LISTEN_ALL
         self.__pyedb_use_grpc: bool | None = None
+        self.__enable_monitor_in_aedt: bool = False
         self._update_settings()
 
     def _update_settings(self) -> None:
@@ -256,6 +257,17 @@ class Settings(PyAedtBase):
         self.load_yaml_configuration(pyaedt_settings_path)
 
     # ########################## gRPC properties ##########################
+
+    @property
+    def enable_monitor_in_aedt(self) -> bool:
+        """Enable monitor in AEDT application during its launch.
+        Default is ``False`` to guarantee back compatibility.
+        """
+        return self.__enable_monitor_in_aedt
+
+    @enable_monitor_in_aedt.setter
+    def enable_monitor_in_aedt(self, value: bool) -> None:
+        self.__enable_monitor_in_aedt = value
 
     @property
     def pyedb_use_grpc(self) -> bool | None:

--- a/src/ansys/aedt/core/generic/settings.py
+++ b/src/ansys/aedt/core/generic/settings.py
@@ -65,6 +65,7 @@ ALLOWED_LOG_SETTINGS = [
     "enable_global_log_file",
     "enable_local_log_file",
     "enable_logger",
+    "enable_monitor_in_aedt",
     "enable_screen_logs",
     "global_log_file_name",
     "global_log_file_size",


### PR DESCRIPTION


## Description
Added monitor flag in launch_aedt and launch_aedt_in_lsf.
To enable the monitor in simulation run.

Application: hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical, twin-builder, hfss3dlayout
AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
Platform: windows, linux


## Issue linked
GetMonitorData method requires aedt to be launched with -monitor flag.

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
