### PR TITLE
CI: Add deploy PR documentation

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,6 +10,10 @@
   description: Improvements or additions to documentation
   color: 0677ba
 
+- name: deploy-pr-doc
+  description: Deploy pull request documentation
+  color: 00ff00
+
 - name: enhancement
   description: New features or code improvements
   color: FFD827

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -221,6 +221,25 @@ jobs:
           optional-dependencies-name: 'all'
           group-dependencies-name: 'doc'
 
+  doc-deploy-pr:
+    name: Deploy PR documentation
+    if: contains(github.event.pull_request.labels.*.name, 'deploy-pr-doc')
+    needs: doc-build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to update files on the gh-pages branch
+      pull-requests: write # Needed to create deployment comments on PRs
+    steps:
+      - uses: ansys/actions/doc-deploy-pr@d946b24b9a765f4169bcc94afdb27bd1a0533741 # v10.3.2
+        with:
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          doc-artifact-name: documentation-ubuntu-latest-html
+          maximum-pr-doc-deployments: 3
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+
   smoke-tests:
     name: Build wheelhouse and smoke tests
     runs-on: ${{ matrix.os }}

--- a/doc/changelog.d/7748.maintenance.md
+++ b/doc/changelog.d/7748.maintenance.md
@@ -1,0 +1,1 @@
+Add deploy PR documentation


### PR DESCRIPTION
## Description
Adds a job to deploy the PR documentation allowing one to ensure that the documentation changes render well without downloading artifacts. Moreover, in some cases, downloading the artifact is not enough to ensure that changes are fixing the doc issue.

The job is only running when one adds the `deploy-pr-doc` label to avoid having too many PR documentations.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
