### PR TITLE
CI: Rerun sync-release on labeled/unlabeled events

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - release/2.0
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 env:
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}

--- a/doc/changelog.d/7756.maintenance.md
+++ b/doc/changelog.d/7756.maintenance.md
@@ -1,0 +1,1 @@
+Rerun sync-release on labeled/unlabeled events


### PR DESCRIPTION
## Description
This should avoid having to push empty commit when performing maintenance PR on the release/2.0 branch. Adding the label should trigger the CI instead.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
