### PR TITLE
FEAT: support for loading cli plugins

### DIFF
--- a/doc/changelog.d/7757.added.md
+++ b/doc/changelog.d/7757.added.md
@@ -1,0 +1,1 @@
+Support for loading cli plugins

--- a/src/ansys/aedt/core/cli/__init__.py
+++ b/src/ansys/aedt/core/cli/__init__.py
@@ -24,6 +24,8 @@
 
 """PyAEDT CLI based on typer."""
 
+import logging
+
 try:
     import typer
 except ImportError as e:  # pragma: no cover
@@ -40,6 +42,8 @@ from ansys.aedt.core.cli.export import export_app
 from ansys.aedt.core.cli.panels import panels_app
 from ansys.aedt.core.cli.project import project_app
 from ansys.aedt.core.cli.script import run_script
+
+logger = logging.getLogger("Global")
 
 app = typer.Typer(no_args_is_help=True)
 
@@ -113,12 +117,10 @@ try:
         try:
             plugin_app = ep.load()
             app.add_typer(plugin_app, name=ep.name)
-        except Exception:
-            # Silently skip plugins that fail to load
-            pass
-except Exception:
-    # If entry point loading fails, just continue without plugins
-    pass
+        except Exception as exc:
+            logger.debug("Skipping CLI plugin '%s' because it failed to load: %s", ep.name, exc)
+except Exception as exc:
+    logger.debug("Skipping CLI plugin discovery because entry-point loading failed: %s", exc)
 
 if __name__ == "__main__":
     app()

--- a/src/ansys/aedt/core/cli/__init__.py
+++ b/src/ansys/aedt/core/cli/__init__.py
@@ -102,5 +102,23 @@ app.add_typer(panels_app, name="panels")
 app.add_typer(doc_app, name="doc")
 app.add_typer(test_config_app, name="test-config")
 
+# Load plugin entry points
+try:
+    import importlib.metadata
+
+    entry_points = importlib.metadata.entry_points()
+    plugin_group = entry_points.select(group="pyaedt.cli")
+
+    for ep in plugin_group:
+        try:
+            plugin_app = ep.load()
+            app.add_typer(plugin_app, name=ep.name)
+        except Exception:
+            # Silently skip plugins that fail to load
+            pass
+except Exception:
+    # If entry point loading fails, just continue without plugins
+    pass
+
 if __name__ == "__main__":
     app()

--- a/src/ansys/aedt/core/cli/__init__.py
+++ b/src/ansys/aedt/core/cli/__init__.py
@@ -24,8 +24,6 @@
 
 """PyAEDT CLI based on typer."""
 
-import logging
-
 try:
     import typer
 except ImportError as e:  # pragma: no cover
@@ -42,8 +40,6 @@ from ansys.aedt.core.cli.export import export_app
 from ansys.aedt.core.cli.panels import panels_app
 from ansys.aedt.core.cli.project import project_app
 from ansys.aedt.core.cli.script import run_script
-
-logger = logging.getLogger("Global")
 
 app = typer.Typer(no_args_is_help=True)
 
@@ -118,9 +114,9 @@ try:
             plugin_app = ep.load()
             app.add_typer(plugin_app, name=ep.name)
         except Exception as exc:
-            logger.debug("Skipping CLI plugin '%s' because it failed to load: %s", ep.name, exc)
+            typer.secho(f"Skipping CLI plugin '{ep.name}' because it failed to load: {exc}", fg="yellow")
 except Exception as exc:
-    logger.debug("Skipping CLI plugin discovery because entry-point loading failed: %s", exc)
+    typer.secho(f"Skipping CLI plugin discovery because entry-point loading failed: {exc}", fg="yellow")
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
## Description
Implement support for loading plugin entry points in the CLI, allowing dynamic integration of plugins defined in the `pyaedt.cli` group.

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).

