### PR TITLE
FEAT: add new material property for litz wire

### DIFF
--- a/doc/changelog.d/7793.breaking.md
+++ b/doc/changelog.d/7793.breaking.md
@@ -1,0 +1,1 @@
+Add new material property for litz wire

--- a/src/ansys/aedt/core/modules/material.py
+++ b/src/ansys/aedt/core/modules/material.py
@@ -1446,6 +1446,7 @@ class Material(CommonMaterial, PyAedtBase):
         self._stacking_direction = None
         self._stacking_factor = None
         self._strand_number = None
+        self._twisting_length_factor = None
 
         if "thermal_material_type" in self._props:
             self.thermal_material_type = self._props["thermal_material_type"]["Choice"]
@@ -2110,6 +2111,27 @@ class Material(CommonMaterial, PyAedtBase):
         self._stacking_direction = value
         if self._material_update:
             self._update_props("stacking_direction", dict({"property_type": "ChoiceProperty", "Choice": value}))
+
+    @property
+    def twisting_length_factor(self) -> MatProperty:
+        """Ratio of the twisted-strand length to the bundle length for Litz Wire.
+
+        Returns
+        -------
+        :class:`ansys.aedt.core.modules.material.MatProperty`
+            Twisting length factor.
+
+        References
+        ----------
+        >>> oDefinitionManager.EditMaterial
+        """
+        return self._twisting_length_factor
+
+    @twisting_length_factor.setter
+    def twisting_length_factor(self, value: MatProperty) -> None:
+        self._twisting_length_factor = value
+        if self._material_update:
+            self._update_props("litz_wire_twisting_length_factor", value)
 
     @pyaedt_function_handler()
     def set_magnetic_coercivity(self, value: int = 0, x: int = 1, y: int = 0, z: int = 0) -> bool:

--- a/tests/system/general/test_maxwell_3d.py
+++ b/tests/system/general/test_maxwell_3d.py
@@ -98,10 +98,12 @@ def test_litz_wire(m3d_app) -> None:
     m3d_app.materials["magnesium"].wire_type = "Round"
     m3d_app.materials["magnesium"].strand_number = 3
     m3d_app.materials["magnesium"].wire_diameter = "1mm"
+    m3d_app.materials["magnesium"].twisting_length_factor = "1.5"
     assert m3d_app.materials["magnesium"].stacking_type == "Litz Wire"
     assert m3d_app.materials["magnesium"].wire_type == "Round"
     assert m3d_app.materials["magnesium"].strand_number == 3
     assert m3d_app.materials["magnesium"].wire_diameter == "1mm"
+    assert m3d_app.materials["magnesium"].twisting_length_factor == "1.5"
 
     m3d_app.materials["magnesium"].wire_type = "Square"
     m3d_app.materials["magnesium"].wire_width = "2mm"


### PR DESCRIPTION
## Description
Currently the twisting length factor property is missing for litz wire.

<!--
Trailers must be placed at the end of the description, separated from the
rest of the text by a blank line. Available trailers for automatic labeling:

  Application: hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical, twin-builder, hfss3dlayout
               (comma-separated values allowed)
  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
                (comma-separated values allowed)
  Platform: windows, linux, rocky
            (comma-separated values allowed)
  Deprecation: <scope>
  Breaking-Change: <scope>

Examples:
  Application: hfss, maxwell
  AEDT-Version: 25.2, 26.1
  Platform: windows, linux
  Breaking-Change: removed MyClass
-->

## Issue linked
#7791
## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
