### PR TITLE
FIX: Bugfix AMI analysis report where AMISOURCE and AMIPROBES for non AMI ibis models

### DIFF
--- a/doc/changelog.d/7824.breaking.md
+++ b/doc/changelog.d/7824.breaking.md
@@ -1,0 +1,1 @@
+Bugfix AMI analysis report where AMISOURCE and AMIPROBES for non AMI ibis models

--- a/src/ansys/aedt/core/visualization/report/eye.py
+++ b/src/ansys/aedt/core/visualization/report/eye.py
@@ -80,7 +80,18 @@ class AMIConturEyeDiagram(CommonReport):
         new_exprs = []
         for expr_dict in self._legacy_props["expressions"]:
             expr = expr_dict["name"] if isinstance(expr_dict, dict) else expr_dict
-            if ".int_ami" not in expr:
+            if "amiprobe" in expr.lower() or "amisource" in expr.lower():
+                if "Bit Error Rate" not in expr:
+                    qtype = int(self.quantity_type)
+                    if qtype == 0:
+                        new_exprs.append(f"Initial{expr_head}(" + expr.lower() + ")<Bit Error Rate>")
+                    elif qtype == 1:
+                        new_exprs.append(f"{expr_head}AfterSource(" + expr.lower() + ")<Bit Error Rate>")
+                    elif qtype == 2:
+                        new_exprs.append(f"{expr_head}AfterChannel(" + expr.lower() + ")<Bit Error Rate>")
+                    elif qtype == 3:
+                        new_exprs.append(f"{expr_head}AfterProbe(" + expr.lower() + ")<Bit Error Rate>")
+            elif ".int_ami" not in expr:
                 qtype = int(self.quantity_type)
                 if qtype == 0:
                     new_exprs.append(f"Initial{expr_head}(" + expr + ".int_ami_tx)<Bit Error Rate>")
@@ -522,7 +533,20 @@ class AMIEyeDiagram(CommonReport):
         new_exprs = []
         for expr_dict in self._legacy_props["expressions"]:
             expr = expr_dict["name"] if isinstance(expr_dict, dict) else expr_dict
-            if ".int_ami" not in expr and ("amiprobe" not in expr.lower() and "amisource" not in expr.lower()):
+            if "amiprobe" in expr.lower() or "amisource" in expr.lower():
+                if "Initial" not in expr or "After" not in expr:
+                    qtype = int(self.quantity_type)
+                    if qtype == 0:
+                        new_exprs.append(f"Initial{expr_head}<" + expr + ">")
+                    elif qtype == 1:
+                        new_exprs.append(f"{expr_head}AfterSource<" + expr + ">")
+                    elif qtype == 2:
+                        new_exprs.append(f"{expr_head}AfterChannel<" + expr + ">")
+                    elif qtype == 3:
+                        new_exprs.append(f"{expr_head}AfterProbe<" + expr + ">")
+                    else:
+                        new_exprs.append(expr)
+            elif ".int_ami" not in expr:
                 qtype = int(self.quantity_type)
                 if qtype == 0:
                     new_exprs.append(f"Initial{expr_head}<" + expr + ".int_ami_tx>")

--- a/src/ansys/aedt/core/visualization/report/eye.py
+++ b/src/ansys/aedt/core/visualization/report/eye.py
@@ -65,7 +65,7 @@ class AMIConturEyeDiagram(CommonReport):
 
     @property
     def expressions(self) -> list:
-        """Expressions.
+        """Get the expressions for the eye diagram.
 
         Returns
         -------


### PR DESCRIPTION
## Description
Eye Analysis for rectangular and statistical eye was not working when we use a non-AMI ibis' model at receiver side in virtual compliance. Solution data was not getting coming

Examples:
  Application: circuit
  AEDT-Version: 26.1
  Platform: windows
  Breaking-Change: eye probe for non-AMI ibis case for serdes
-->

## Issue linked
#7823 

## Checklist
[yes ] I have tested my changes locally.
[yes] I have added necessary documentation or updated existing documentation.
[yes ] I have followed the coding style guidelines of this project.
[yes ] I have added appropriate tests (unit, integration, system).
[yes ] I have reviewed my changes before submitting this pull request.
[yes] I have linked the issue(s) that are solved by the PR if any.
[yes] I have assigned this PR to myself.
[yes] I have added the minimum version decorator to any new backend method implemented.
[yes] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
