### PR TITLE
FIX: bug in quick_eye which prevented to create report for Statistical Eye and Contour Eye

### DIFF
--- a/doc/changelog.d/7841.fixed.md
+++ b/doc/changelog.d/7841.fixed.md
@@ -1,0 +1,1 @@
+Bug in quick_eye which prevented to create report for Statistical Eye and Contour Eye

--- a/src/ansys/aedt/core/visualization/post/common.py
+++ b/src/ansys/aedt/core/visualization/post/common.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     from ansys.aedt.core.visualization.report.eye import AMIConturEyeDiagram
     from ansys.aedt.core.visualization.report.eye import AMIEyeDiagram
     from ansys.aedt.core.visualization.report.eye import EyeDiagram
+    from ansys.aedt.core.visualization.report.field import AntennaParameters
     from ansys.aedt.core.visualization.report.field import FarField
     from ansys.aedt.core.visualization.report.field import Fields
     from ansys.aedt.core.visualization.report.field import NearField
@@ -1490,8 +1491,18 @@ class PostProcessorCommon(PyAedtBase):
         width: int = 800,
         height: int = 450,
     ) -> (
-        "Standard | AMIEyeDiagram | AMIConturEyeDiagram | EMIReceiver | EyeDiagram | CircuitNetlistReport | Fields | "
-        "FarField | NearField | Spectral | ReportPlotter"
+        Standard
+        | AMIEyeDiagram
+        | AMIConturEyeDiagram
+        | EMIReceiver
+        | EyeDiagram
+        | CircuitNetlistReport
+        | Fields
+        | FarField
+        | NearField
+        | Spectral
+        | ReportPlotter
+        | bool
     ):
         """Create a report in AEDT or in Matplotlib. It can be a 2D plot, 3D plot, polar plot, or a data table.
 
@@ -1686,7 +1697,7 @@ class PostProcessorCommon(PyAedtBase):
         subdesign_id: int | None = None,
         polyline_points: int = 1001,
         math_formula: str | None = None,
-    ) -> "SolutionData":
+    ) -> SolutionData | bool:
         """Get a simulation result from a solved setup and cast it in a ``SolutionData`` object.
 
         Data to be retrieved from Electronics Desktop are any simulation results available in that
@@ -1845,8 +1856,19 @@ class PostProcessorCommon(PyAedtBase):
         width: int = 800,
         height: int = 450,
     ) -> (
-        "Standard | AMIEyeDiagram | AMIConturEyeDiagram | EMIReceiver | EyeDiagram | CircuitNetlistReport | Fields | "
-        "FarField | NearField | Spectral | ReportPlotter | None | bool"
+        Standard
+        | AMIEyeDiagram
+        | AMIConturEyeDiagram
+        | EMIReceiver
+        | EyeDiagram
+        | CircuitNetlistReport
+        | Fields
+        | FarField
+        | NearField
+        | Spectral
+        | ReportPlotter
+        | None
+        | bool
     ):
         """Create a report based on a JSON file, TOML file, RPT file, or dictionary of properties.
 
@@ -2029,7 +2051,7 @@ class PostProcessorCommon(PyAedtBase):
 
     @requires_graphical_dependency("matplotlib")
     @pyaedt_function_handler()
-    def _report_plotter(self, report, show: bool = True, snapshot_path="", width=800, height=450) -> "ReportPlotter":
+    def _report_plotter(self, report, show: bool = True, snapshot_path="", width=800, height=450) -> ReportPlotter:
         """Create a Matplotlib plot from a report.
 
         Parameters
@@ -2319,7 +2341,7 @@ class Reports(PyAedtBase):
         )
 
     @pyaedt_function_handler()
-    def standard(self, expressions: str | list = None, setup: str = None) -> "Standard":
+    def standard(self, expressions: str | list = None, setup: str = None) -> Standard:
         """Create a standard or default report object.
 
         Parameters
@@ -2359,7 +2381,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def monitor(self, expressions: str | list = None, setup: str = None) -> "Standard":
+    def monitor(self, expressions: str | list = None, setup: str = None) -> Standard:
         """Create an Icepak Monitor Report object.
 
         Parameters
@@ -2393,7 +2415,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def fields(self, expressions: str | list = None, setup: str = None, polyline: str = None) -> "report_field.Fields":
+    def fields(self, expressions: str | list = None, setup: str = None, polyline: str = None) -> Fields:
         """Create a Field Report object.
 
         Parameters
@@ -2434,9 +2456,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def cg_fields(
-        self, expressions: str | list = None, setup: str | None = None, polyline: str = None
-    ) -> "report_field.Fields":
+    def cg_fields(self, expressions: str | list = None, setup: str | None = None, polyline: str = None) -> Fields:
         """Create a CG Field Report object in Q3D and Q2D.
 
         Parameters
@@ -2476,9 +2496,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def dc_fields(
-        self, expressions: str | list = None, setup: str | None = None, polyline: str = None
-    ) -> "report_field.Fields":
+    def dc_fields(self, expressions: str | list = None, setup: str | None = None, polyline: str = None) -> Fields:
         """Create a DC Field Report object in Q3D.
 
         Parameters
@@ -2518,9 +2536,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def rl_fields(
-        self, expressions: str | list = None, setup: str | None = None, polyline: str = None
-    ) -> "report_field.Fields":
+    def rl_fields(self, expressions: str | list = None, setup: str | None = None, polyline: str = None) -> Fields:
         """Create an AC RL Field Report object in Q3D and Q2D.
 
         Parameters
@@ -2570,7 +2586,7 @@ class Reports(PyAedtBase):
         sphere_name: str = None,
         source_context: str = None,
         **variations,
-    ) -> "report_field.FarField":
+    ) -> FarField:
         """Create a Far Field Report object.
 
         Parameters
@@ -2622,7 +2638,7 @@ class Reports(PyAedtBase):
     @pyaedt_function_handler()
     def antenna_parameters(
         self, expressions: str | list = None, setup: str | None = None, infinite_sphere: str = None
-    ) -> "report_field.AntennaParameters":
+    ) -> AntennaParameters:
         """Create an Antenna Parameters Report object.
 
         Parameters
@@ -2659,7 +2675,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def near_field(self, expressions: str | list = None, setup: str | None = None) -> "report_field.NearField":
+    def near_field(self, expressions: str | list = None, setup: str | None = None) -> NearField:
         """Create a Field Report object.
 
         Parameters
@@ -2695,7 +2711,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def modal_solution(self, expressions: str | list = None, setup: str | None = None) -> "report_standard.Standard":
+    def modal_solution(self, expressions: str | list = None, setup: str | None = None) -> Standard:
         """Create a Standard or Default Report object.
 
         Parameters
@@ -2730,7 +2746,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def terminal_solution(self, expressions: str | list = None, setup: str | None = None) -> "report_standard.Standard":
+    def terminal_solution(self, expressions: str | list = None, setup: str | None = None) -> Standard:
         """Create a Standard or Default Report object.
 
         Parameters
@@ -2765,7 +2781,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def eigenmode(self, expressions: str | list = None, setup: str | None = None) -> "report_standard.Standard":
+    def eigenmode(self, expressions: str | list = None, setup: str | None = None) -> Standard:
         """Create a Standard or Default Report object.
 
         Parameters
@@ -2802,7 +2818,7 @@ class Reports(PyAedtBase):
     @pyaedt_function_handler()
     def statistical_eye_contour(
         self, expressions: str | list = None, setup: str | None = None, quantity_type: int = 3
-    ) -> "report_eye.AMIConturEyeDiagram | bool":
+    ) -> AMIConturEyeDiagram | bool:
         """Create a standard statistical AMI contour plot.
 
         Parameters
@@ -2864,7 +2880,7 @@ class Reports(PyAedtBase):
         quantity_type: int = 3,
         statistical_analysis: bool = True,
         unit_interval: str = "1ns",
-    ) -> "report_eye.EyeDiagram | report_eye.AMIEyeDiagram | None":
+    ) -> EyeDiagram | AMIEyeDiagram | None:
         """Create a Standard or Default Report object.
 
         Parameters
@@ -2922,7 +2938,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def spectral(self, expressions: str | list = None, setup: str = None) -> "report_standard.Spectral":
+    def spectral(self, expressions: str | list = None, setup: str = None) -> Spectral:
         """Create a Spectral Report object.
 
         Parameters
@@ -2958,7 +2974,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def emi_receiver(self, expressions: str | list = None, setup_name: str = None) -> "report_emi.EMIReceiver":
+    def emi_receiver(self, expressions: str | list = None, setup_name: str = None) -> EMIReceiver:
         """Create an EMI receiver report.
 
         Parameters
@@ -3004,9 +3020,7 @@ class Reports(PyAedtBase):
         return rep
 
     @pyaedt_function_handler()
-    def circuit_netlist(
-        self, setup: str, expressions: str | list = None, domain: str = None
-    ) -> "report_netlist.CircuitNetlistReport":
+    def circuit_netlist(self, setup: str, expressions: str | list = None, domain: str = None) -> CircuitNetlistReport:
         """Create a Circuit Netlist Report object.
 
         Parameters

--- a/src/ansys/aedt/core/visualization/post/common.py
+++ b/src/ansys/aedt/core/visualization/post/common.py
@@ -1950,10 +1950,13 @@ class PostProcessorCommon(PyAedtBase):
                 report_temp = TEMPLATES_BY_NAME["Spectrum"]
             elif (
                 "AMIAnalysis" in self._app.get_setup(solution_name.split(":")[0].strip()).props
-                and props["report_category"] == "Standard"
-            ):
+                or "QuickEyeAnalysis" in self._app.get_setup(solution_name.split(":")[0].strip()).props
+            ) and props["report_category"] == "Standard":
                 report_temp = TEMPLATES_BY_NAME["AMI Contour"]
-            elif "AMIAnalysis" in self._app.get_setup(solution_name.split(":")[0].strip()).props:
+            elif (
+                "AMIAnalysis" in self._app.get_setup(solution_name.split(":")[0].strip()).props
+                or "QuickEyeAnalysis" in self._app.get_setup(solution_name.split(":")[0].strip()).props
+            ):
                 report_temp = TEMPLATES_BY_NAME["Statistical Eye"]
             else:
                 report_temp = TEMPLATES_BY_NAME[props["report_category"]]

--- a/src/ansys/aedt/core/visualization/post/common.py
+++ b/src/ansys/aedt/core/visualization/post/common.py
@@ -2824,7 +2824,7 @@ class Reports(PyAedtBase):
         """
         if not setup:
             for setup in self._post_app._app.setups:
-                if "AMIAnalysis" in setup.props:
+                if "AMIAnalysis" in setup.props or "QuickEyeAnalysis" in setup.props:
                     setup = setup.name
             if not setup:
                 self._post_app._app.logger.error("AMI analysis is needed to create this report.")
@@ -2885,7 +2885,10 @@ class Reports(PyAedtBase):
         if not setup:
             setup = self._post_app._app.nominal_sweep
         if "Eye Diagram" in self._templates:
-            if "AMIAnalysis" in self._post_app._app.get_setup(setup).props:
+            if (
+                "AMIAnalysis" in self._post_app._app.get_setup(setup).props
+                or "QuickEyeAnalysis" in self._post_app._app.get_setup(setup).props
+            ):
                 report_cat = "Eye Diagram"
                 if statistical_analysis:
                     report_cat = "Statistical Eye"
@@ -2893,7 +2896,6 @@ class Reports(PyAedtBase):
                 rep.quantity_type = quantity_type
                 rep.expressions = self._retrieve_default_expressions(expressions, rep, setup)
                 return rep
-
             else:
                 rep = report_eye.EyeDiagram(self._post_app, "Eye Diagram", setup)
             rep.unit_interval = unit_interval

--- a/src/ansys/aedt/core/visualization/post/common.py
+++ b/src/ansys/aedt/core/visualization/post/common.py
@@ -1846,7 +1846,7 @@ class PostProcessorCommon(PyAedtBase):
         height: int = 450,
     ) -> (
         "Standard | AMIEyeDiagram | AMIConturEyeDiagram | EMIReceiver | EyeDiagram | CircuitNetlistReport | Fields | "
-        "FarField | NearField | Spectral | ReportPlotter"
+        "FarField | NearField | Spectral | ReportPlotter | None | bool"
     ):
         """Create a report based on a JSON file, TOML file, RPT file, or dictionary of properties.
 
@@ -1878,7 +1878,7 @@ class PostProcessorCommon(PyAedtBase):
 
         Returns
         -------
-        :class:`ansys.aedt.core.modules.report_templates.Standard`
+        :class:`ansys.aedt.core.modules.report_templates.Standard` or None
             Report object if succeeded.
 
         Examples
@@ -1905,6 +1905,7 @@ class PostProcessorCommon(PyAedtBase):
         if not report_settings and not input_file:  # pragma: no cover
             self.logger.error("Either a file or a dictionary must be passed as input.")
             return False
+
         props = {}
         if input_file:
             _, file_extension = os.path.splitext(input_file)
@@ -1937,7 +1938,9 @@ class PostProcessorCommon(PyAedtBase):
             props["expressions"] = {i: {} for i in props["expressions"]}
         elif isinstance(props.get("expressions", {}), str):  # pragma: no cover
             props["expressions"] = {props["expressions"]: {}}
+
         _dict_items_to_list_items(props, "expressions")
+
         if not solution_name:
             if "Fields" not in props.get("report_category", ""):
                 solution_name = self._app.nominal_sweep
@@ -1945,6 +1948,7 @@ class PostProcessorCommon(PyAedtBase):
                 solution_name = self._app.nominal_adaptive
         else:
             solution_name = self._get_setup_from_sweep_name(solution_name)  # If only the sweep name is passed.
+
         if props.get("report_category", None) and props["report_category"] in TEMPLATES_BY_NAME:
             if props.get("context", {"context": {}}).get("domain", "") == "Spectral":
                 report_temp = TEMPLATES_BY_NAME["Spectrum"]
@@ -1982,8 +1986,11 @@ class PostProcessorCommon(PyAedtBase):
                 "__Amplitude",
             ] and "Freq" in report._legacy_props.get("context", {}).get("variations", {}):
                 del report._legacy_props["context"]["variations"]["Freq"]
+
             _update_props(props, report._legacy_props)
+
             nominal_values = self._app.available_variations.nominal_variation(dependent_params=False)
+
             for el, k in nominal_values.items():
                 if (
                     report._legacy_props.get("context", None)
@@ -1991,7 +1998,9 @@ class PostProcessorCommon(PyAedtBase):
                     and el not in report._legacy_props["context"]["variations"]
                 ):
                     report._legacy_props["context"]["variations"][el] = k
+
             _ = report.expressions
+
             if matplotlib:
                 try:
                     return self._report_plotter(
@@ -2001,9 +2010,11 @@ class PostProcessorCommon(PyAedtBase):
                     self.logger.error("Failed to create report.")
                     return False
             report.create(name)
+
             if report.report_type != "Data Table":
                 report._update_traces()
                 self.oreportsetup.UpdateReports(report.plot_name)
+
             self.logger.info(f"Report {report.plot_name} created successfully.")
             if hide_legend:
                 report.hide_legend()
@@ -2012,6 +2023,7 @@ class PostProcessorCommon(PyAedtBase):
                 if not out:
                     self.logger.error("Failed to export report to image.")
             return report
+
         self.logger.error("Failed to create report.")
         return False  # pragma: no cover
 
@@ -2790,7 +2802,7 @@ class Reports(PyAedtBase):
     @pyaedt_function_handler()
     def statistical_eye_contour(
         self, expressions: str | list = None, setup: str | None = None, quantity_type: int = 3
-    ) -> "report_eye.AMIConturEyeDiagram":
+    ) -> "report_eye.AMIConturEyeDiagram | bool":
         """Create a standard statistical AMI contour plot.
 
         Parameters
@@ -2829,6 +2841,8 @@ class Reports(PyAedtBase):
             for setup in self._post_app._app.setups:
                 if "AMIAnalysis" in setup.props or "QuickEyeAnalysis" in setup.props:
                     setup = setup.name
+                    break
+
             if not setup:
                 self._post_app._app.logger.error("AMI analysis is needed to create this report.")
                 return False
@@ -2850,7 +2864,7 @@ class Reports(PyAedtBase):
         quantity_type: int = 3,
         statistical_analysis: bool = True,
         unit_interval: str = "1ns",
-    ) -> "report_eye.EyeDiagram" | "report_eye.AMIEyeDiagram" | None:
+    ) -> "report_eye.EyeDiagram | report_eye.AMIEyeDiagram | None":
         """Create a Standard or Default Report object.
 
         Parameters
@@ -2874,7 +2888,7 @@ class Reports(PyAedtBase):
 
         Returns
         -------
-        :class:`ansys.aedt.core.modules.report_templates.AMIEyeDiagram` | None
+        :class:`ansys.aedt.core.modules.report_templates.AMIEyeDiagram` or None
 
         Examples
         --------
@@ -2887,11 +2901,12 @@ class Reports(PyAedtBase):
         """
         if not setup:
             setup = self._post_app._app.nominal_sweep
+
+        rep = None
+        setup_props = self._post_app._app.get_setup(setup).props
+
         if "Eye Diagram" in self._templates:
-            if (
-                "AMIAnalysis" in self._post_app._app.get_setup(setup).props
-                or "QuickEyeAnalysis" in self._post_app._app.get_setup(setup).props
-            ):
+            if "AMIAnalysis" in setup_props or "QuickEyeAnalysis" in setup_props:
                 report_cat = "Eye Diagram"
                 if statistical_analysis:
                     report_cat = "Statistical Eye"
@@ -2904,8 +2919,7 @@ class Reports(PyAedtBase):
             rep.unit_interval = unit_interval
             rep.expressions = self._retrieve_default_expressions(expressions, rep, setup)
             return rep
-
-        return
+        return rep
 
     @pyaedt_function_handler()
     def spectral(self, expressions: str | list = None, setup: str = None) -> "report_standard.Spectral":

--- a/src/ansys/aedt/core/visualization/post/common.py
+++ b/src/ansys/aedt/core/visualization/post/common.py
@@ -126,8 +126,16 @@ class PostProcessorCommon(PyAedtBase):
         self,
     ) -> list[
         (
-            "Standard | AMIEyeDiagram | AMIConturEyeDiagram | EMIReceiver | EyeDiagram | CircuitNetlistReport | "
-            "Fields | FarField | NearField | Spectral"
+            Standard
+            | AMIEyeDiagram
+            | AMIConturEyeDiagram
+            | EMIReceiver
+            | EyeDiagram
+            | CircuitNetlistReport
+            | Fields
+            | FarField
+            | NearField
+            | Spectral
         )
     ]:
         """Plot list.
@@ -145,8 +153,16 @@ class PostProcessorCommon(PyAedtBase):
     def plots(
         self,
         value: list[
-            "Standard | AMIEyeDiagram | AMIConturEyeDiagram | EMIReceiver | EyeDiagram | CircuitNetlistReport | "
-            "Fields | FarField | NearField | Spectral"
+            Standard
+            | AMIEyeDiagram
+            | AMIConturEyeDiagram
+            | EMIReceiver
+            | EyeDiagram
+            | CircuitNetlistReport
+            | Fields
+            | FarField
+            | NearField
+            | Spectral
         ],
     ) -> None:
         self.__plots = value

--- a/src/ansys/aedt/core/visualization/post/common.py
+++ b/src/ansys/aedt/core/visualization/post/common.py
@@ -2903,9 +2903,9 @@ class Reports(PyAedtBase):
             setup = self._post_app._app.nominal_sweep
 
         rep = None
-        setup_props = self._post_app._app.get_setup(setup).props
 
         if "Eye Diagram" in self._templates:
+            setup_props = self._post_app._app.get_setup(setup).props
             if "AMIAnalysis" in setup_props or "QuickEyeAnalysis" in setup_props:
                 report_cat = "Eye Diagram"
                 if statistical_analysis:

--- a/src/ansys/aedt/core/visualization/report/common.py
+++ b/src/ansys/aedt/core/visualization/report/common.py
@@ -1826,7 +1826,7 @@ class CommonReport(BinaryTreeNode, PyAedtBase):
         return write_configuration_file(output_dict, output_file)
 
     @pyaedt_function_handler()
-    def get_solution_data(self) -> "SolutionData":
+    def get_solution_data(self) -> SolutionData | bool:
         """Get the report solution data.
 
         Returns

--- a/src/ansys/aedt/core/visualization/report/common.py
+++ b/src/ansys/aedt/core/visualization/report/common.py
@@ -22,6 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import copy
 import os
 import re

--- a/src/ansys/aedt/core/visualization/report/eye.py
+++ b/src/ansys/aedt/core/visualization/report/eye.py
@@ -92,6 +92,8 @@ class AMIConturEyeDiagram(CommonReport):
                         new_exprs.append(f"{expr_head}AfterChannel(" + expr.lower() + ")<Bit Error Rate>")
                     elif qtype == 3:
                         new_exprs.append(f"{expr_head}AfterProbe(" + expr.lower() + ")<Bit Error Rate>")
+            elif "aeyeprobe" in expr.lower():
+                new_exprs.append(f"{expr}<Bit Error Rate>")
             elif ".int_ami" not in expr:
                 qtype = int(self.quantity_type)
                 if qtype == 0:
@@ -547,6 +549,8 @@ class AMIEyeDiagram(CommonReport):
                         new_exprs.append(f"{expr_head}AfterProbe<" + expr + ">")
                     else:
                         new_exprs.append(expr)
+            elif "eyeprobe" in expr.lower() or "eyesource" in expr.lower():
+                new_exprs.append(expr)
             elif ".int_ami" not in expr:
                 qtype = int(self.quantity_type)
                 if qtype == 0:

--- a/tests/system/visualization/test_postprocessing.py
+++ b/tests/system/visualization/test_postprocessing.py
@@ -559,7 +559,9 @@ def test_eye_diagram(eye_test) -> None:
 
 @pytest.mark.skipif(DESKTOP_VERSION < "2022.2", reason="Not working in non graphical in version lower than 2022.2")
 def test_mask(eye_test) -> None:
-    rep = eye_test.post.reports_by_category.eye_diagram("AEYEPROBE(OutputEye)", "QuickEyeAnalysis")
+    rep = eye_test.post.reports_by_category.eye_diagram(
+        "AEYEPROBE(OutputEye)", "QuickEyeAnalysis", statistical_analysis=False
+    )
     rep.time_start = "0ps"
     rep.time_stop = "50us"
     rep.unit_interval = "1e-9"


### PR DESCRIPTION
## Description
Quick Eye Analysis for rectangular and statistical eye was not working when we use a non-AMI ibis' model at receiver side in virtual compliance. Solution data was not getting coming.

Examples:
Application: circuit
AEDT-Version: 26.1
Platform: windows

## Issue linked
Quick Eye Analysis for rectangular and statistical eye was not working when we use a non-AMI ibis' model at receiver side in virtual compliance. Solution data was not getting coming.

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
