### PR TITLE
docs: add troubleshooting note for student version gRPC launch failure

### DIFF
--- a/doc/source/Getting_started/Troubleshooting.rst
+++ b/doc/source/Getting_started/Troubleshooting.rst
@@ -246,6 +246,30 @@ Now run the PyAEDT script, (making sure it connects to the same port as the gRPC
 Capture the output in a file. For example *client.txt*. Then send all the logs
 to `Ansys Support <https://www.ansys.com/it-solutions/contacting-technical-support>`_.
 
+Student version fails to start via the default gRPC transport
+---------------------------------------------------------------------
+On some AEDT Student builds (for example AEDT 2025 R2 Student), launching a new
+session with the default secure-local (``wnua``) gRPC transport fails: PyAEDT
+reports ``Failed to start on gRPC port`` and the spawned ``ansysedtsv.exe``
+process exits immediately, even though the installation is healthy (starting the
+server manually with the legacy ``ansysedtsv.exe -grpcsrv <port>`` form works).
+
+In that case, force the classic TCP *InsecureMode* transport before creating the
+``Desktop`` object:
+
+.. code:: python
+
+    import os
+
+    os.environ["PYAEDT_USE_PRE_GRPC_ARGS"] = "True"
+
+    from ansys.aedt.core import settings, Desktop
+
+    settings.grpc_secure_mode = False
+
+    desktop = Desktop(version="2025.2", student_version=True, new_desktop=True)
+
+See issue `#7842 <https://github.com/ansys/pyaedt/issues/7842>`_ for details.
 
 Numpy compatibility
 -------------------


### PR DESCRIPTION

## Description
This documents the workaround for #7842: on some AEDT Student builds
(e.g. AEDT 2025 R2 Student), `Desktop()` fails to launch via the default
`wnua` gRPC transport, and only works after forcing the classic TCP
InsecureMode transport (`PYAEDT_USE_PRE_GRPC_ARGS=True` +
`settings.grpc_secure_mode = False`).

Adds a short subsection under **Run PyAEDT** in the Troubleshooting page.

<!--
Trailers must be placed at the end of the description, separated from the
rest of the text by a blank line. Available trailers for automatic labeling:

  Application: hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical, twin-builder, hfss3dlayout
               (comma-separated values allowed)
  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
                (comma-separated values allowed)
  Platform: windows, linux, rocky
            (comma-separated values allowed)
  Deprecation: <scope>
  Breaking-Change: <scope>

Examples:
  Application: hfss, maxwell
  AEDT-Version: 25.2, 26.1
  Platform: windows, linux
  Breaking-Change: removed MyClass
-->

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
