### PR TITLE
DOCS: Student version gRPC

### DIFF
--- a/doc/changelog.d/7844.documentation.md
+++ b/doc/changelog.d/7844.documentation.md
@@ -1,0 +1,1 @@
+Student version gRPC

--- a/doc/source/Getting_started/ClientServer.rst
+++ b/doc/source/Getting_started/ClientServer.rst
@@ -93,6 +93,7 @@ Version and service pack requirements
      only insecure mode is available.
    - To check your service pack version, look at the ``builddate.txt`` file in your
      Ansys installation directory.
+   - For Ansys 2025 R2 Student and earlier, only insecure mode is available, see the :ref:`pre service pack <_pre_service_pack_compatibility>` section
 
 Default configuration
 ---------------------
@@ -194,6 +195,8 @@ To use insecure client-server mode (no encryption), set:
     settings.grpc_local = False
 
 This configuration uses standard gRPC without encryption.
+
+.. _pre_service_pack_compatibility:
 
 Pre-service pack compatibility
 ------------------------------

--- a/doc/source/Getting_started/Troubleshooting.rst
+++ b/doc/source/Getting_started/Troubleshooting.rst
@@ -251,8 +251,7 @@ AEDT Student version fails to start via the default gRPC transport
 For AEDT Student 2025 R2 and earlier, launching a new session with the default secure-local (``wnua``) gRPC transport
 fails: PyAEDT reports ``Failed to start on gRPC port`` and the spawned ``ansysedtsv.exe`` process exits immediately.
 
-In that case, force the TCP *InsecureMode* transport before creating the
-``Desktop`` object:
+In that case, force the TCP *InsecureMode* transport before creating the ``Desktop`` object:
 
 .. code:: python
 

--- a/doc/source/Getting_started/Troubleshooting.rst
+++ b/doc/source/Getting_started/Troubleshooting.rst
@@ -246,30 +246,26 @@ Now run the PyAEDT script, (making sure it connects to the same port as the gRPC
 Capture the output in a file. For example *client.txt*. Then send all the logs
 to `Ansys Support <https://www.ansys.com/it-solutions/contacting-technical-support>`_.
 
-Student version fails to start via the default gRPC transport
----------------------------------------------------------------------
-On some AEDT Student builds (for example AEDT 2025 R2 Student), launching a new
-session with the default secure-local (``wnua``) gRPC transport fails: PyAEDT
-reports ``Failed to start on gRPC port`` and the spawned ``ansysedtsv.exe``
-process exits immediately, even though the installation is healthy (starting the
-server manually with the legacy ``ansysedtsv.exe -grpcsrv <port>`` form works).
+AEDT Student version fails to start via the default gRPC transport
+------------------------------------------------------------------
+For AEDT Student 2025 R2 and earlier, launching a new session with the default secure-local (``wnua``) gRPC transport
+fails: PyAEDT reports ``Failed to start on gRPC port`` and the spawned ``ansysedtsv.exe`` process exits immediately.
 
-In that case, force the classic TCP *InsecureMode* transport before creating the
+In that case, force the TCP *InsecureMode* transport before creating the
 ``Desktop`` object:
 
 .. code:: python
 
     import os
+    from ansys.aedt.core import settings, Desktop
 
     os.environ["PYAEDT_USE_PRE_GRPC_ARGS"] = "True"
-
-    from ansys.aedt.core import settings, Desktop
 
     settings.grpc_secure_mode = False
 
     desktop = Desktop(version="2025.2", student_version=True, new_desktop=True)
 
-See issue `#7842 <https://github.com/ansys/pyaedt/issues/7842>`_ for details.
+For more information about gRPC transport modes, see the :ref:`Client-server <client_server>` section.
 
 Numpy compatibility
 -------------------

--- a/doc/source/Getting_started/Troubleshooting.rst
+++ b/doc/source/Getting_started/Troubleshooting.rst
@@ -246,6 +246,30 @@ Now run the PyAEDT script, (making sure it connects to the same port as the gRPC
 Capture the output in a file. For example *client.txt*. Then send all the logs
 to `Ansys Support <https://www.ansys.com/it-solutions/contacting-technical-support>`_.
 
+Student version fails to start via the default gRPC transport
+---------------------------------------------------------------------
+On some AEDT Student builds (for example AEDT 2025 R2 Student), launching a new
+session with the default secure-local (``wnua``) gRPC transport fails: PyAEDT
+reports ``Failed to start on gRPC port`` and the spawned ``ansysedtsv.exe``
+process exits immediately, even though the installation is healthy (starting the
+server manually with the legacy ``ansysedtsv.exe -grpcsrv <port>`` form works).
+
+In that case, force the classic TCP *InsecureMode* transport before creating the
+``Desktop`` object:
+
+.. code:: python
+
+    import os
+
+    os.environ["PYAEDT_USE_PRE_GRPC_ARGS"] = "True"
+
+    from ansys.aedt.core import settings, Desktop
+
+    settings.grpc_secure_mode = False
+
+    desktop = Desktop(version="2025.2", student_version=True, new_desktop=True)
+
+See issue `#7842 <https://github.com/ansys/pyaedt/issues/7842>`_ for details.
 
 Numpy compatibility
 -------------------


### PR DESCRIPTION
## Description

This pull request updates the documentation to clarify client-server compatibility and troubleshooting for Ansys AEDT Student versions, especially regarding gRPC transport modes. It adds instructions and references to help users resolve issues when using AEDT Student 2025 R2 and earlier.

Documentation updates for AEDT Student version compatibility:

* Clarified in the `ClientServer.rst` that for Ansys 2025 R2 Student and earlier, only insecure mode is available, and added a reference to a new section on pre-service pack compatibility.
* Introduced a new "Pre-service pack compatibility" section in `ClientServer.rst` to document behavior and requirements for older Student versions.

Troubleshooting guidance:

* Added a detailed troubleshooting section in `Troubleshooting.rst` describing how AEDT Student 2025 R2 and earlier fails to start with the default secure gRPC transport, and provided step-by-step instructions (including code) to force the insecure transport mode as a workaround.

AEDT-Version: 25.2
Platform: windows, linux

## Issue linked
Close #7842 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
