### PR TITLE
REFACTOR: Update CLI plugin handling

### DIFF
--- a/doc/changelog.d/7846.miscellaneous.md
+++ b/doc/changelog.d/7846.miscellaneous.md
@@ -1,0 +1,1 @@
+Update CLI plugin handling

--- a/src/ansys/aedt/core/cli/__init__.py
+++ b/src/ansys/aedt/core/cli/__init__.py
@@ -41,6 +41,14 @@ from ansys.aedt.core.cli.panels import panels_app
 from ansys.aedt.core.cli.project import project_app
 from ansys.aedt.core.cli.script import run_script
 
+# NOTE: This should be updated when new plugins are added to the CLI.
+# The key is the entry point name, and the value is the package name that provides it.
+# This allows better error messages when a plugin is not installed, by suggesting the package to install.
+MAPPING_PLUGIN_PACKAGE = {
+    "ansys.aedt.toolkits.antenna.cli:antenna_app": "ansys-aedt-toolkits-antenna",
+    "pyedb.cli:app": "pyedb",
+}
+
 app = typer.Typer(no_args_is_help=True)
 
 
@@ -113,8 +121,19 @@ try:
         try:
             plugin_app = ep.load()
             app.add_typer(plugin_app, name=ep.name)
-        except Exception as exc:
-            typer.secho(f"Skipping CLI plugin '{ep.name}' because it failed to load: {exc}", fg="yellow")
+        except Exception:
+            package = MAPPING_PLUGIN_PACKAGE.get(ep.value, "the required package")
+            msg = f"CLI plugin '{ep.name}' is not available."
+            install_msg = f"Install {package} to use this command."
+
+            @app.command(
+                name=ep.name,
+                help=f"[Plugin not installed] {install_msg}",
+                context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+            )
+            def unavailable_plugin(ctx: typer.Context, _msg: str = msg + " " + install_msg) -> None:
+                typer.secho(_msg, fg="red", err=True)
+                raise typer.Exit(code=1)
 except Exception as exc:
     typer.secho(f"Skipping CLI plugin discovery because entry-point loading failed: {exc}", fg="yellow")
 


### PR DESCRIPTION
## Description
Refactor the CLI to avoid having the warning message about the antenna plugin being missing. Here is the current behavior

<img width="871" height="115" alt="image" src="https://github.com/user-attachments/assets/6c98481c-3f89-457f-a135-46a5df10fe59" />


Below is the new rendering (I removed part of the image to show the antenna line), the warning has been removed.

<img width="922" height="145" alt="image" src="https://github.com/user-attachments/assets/8de5d311-2b65-4253-84b8-3e50a634e929" />

and when calling the command

<img width="875" height="49" alt="image" src="https://github.com/user-attachments/assets/618ebde6-8819-4135-870b-75c0d957ed6e" />

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
