### PR TITLE
FIX: aedt_process_id connecting to correct session

### DIFF
--- a/doc/changelog.d/7847.fixed.md
+++ b/doc/changelog.d/7847.fixed.md
@@ -1,0 +1,1 @@
+Aedt_process_id connecting to correct session

--- a/doc/source/User_guide/desktop_sessions.rst
+++ b/doc/source/User_guide/desktop_sessions.rst
@@ -46,15 +46,15 @@ Use a context manager when you want deterministic cleanup at the end of a block:
 
 .. code:: python
 
-    import ansys.aedt.core
+    from ansys.aedt.core import Desktop, Hfss, Maxwell3d
 
-    with ansys.aedt.core.Desktop(
+    with Desktop(
         version="2026.1",
         non_graphical=True,
         new_desktop=True,
-    ):
-        hfss = ansys.aedt.core.Hfss()
-        maxwell = ansys.aedt.core.Maxwell3d()
+    ) as d:
+        hfss = Hfss()
+        maxwell = Maxwell3d()
         # ...
         # Work with AEDT here.
         # ...
@@ -65,16 +65,16 @@ If needed, you can still override the default behavior explicitly:
 
 .. code:: python
 
-    import ansys.aedt.core
+    from ansys.aedt.core import Desktop, Hfss, Maxwell3d
 
-    with ansys.aedt.core.Desktop(
+    with Desktop(
         version="2026.1",
         non_graphical=True,
         new_desktop=False,
         close_on_exit=False,
     ):
-        hfss = ansys.aedt.core.Hfss()
-        maxwell = ansys.aedt.core.Maxwell3d()
+        hfss = Hfss()
+        maxwell = Maxwell3d()
         # Work with an existing AEDT session here.
 
     # The AEDT session remains open here.

--- a/doc/source/User_guide/desktop_sessions.rst
+++ b/doc/source/User_guide/desktop_sessions.rst
@@ -72,7 +72,7 @@ If needed, you can still override the default behavior explicitly:
         non_graphical=True,
         new_desktop=False,
         close_on_exit=False,
-    ):
+    ) as d:
         hfss = Hfss()
         maxwell = Maxwell3d()
         # Work with an existing AEDT session here.

--- a/doc/source/User_guide/desktop_sessions.rst
+++ b/doc/source/User_guide/desktop_sessions.rst
@@ -53,6 +53,7 @@ Use a context manager when you want deterministic cleanup at the end of a block:
         non_graphical=True,
         new_desktop=True,
     ) as d:
+        version = d.aedt_version_id
         hfss = Hfss()
         maxwell = Maxwell3d()
         # ...
@@ -73,6 +74,7 @@ If needed, you can still override the default behavior explicitly:
         new_desktop=False,
         close_on_exit=False,
     ) as d:
+        version = d.aedt_version_id
         hfss = Hfss()
         maxwell = Maxwell3d()
         # Work with an existing AEDT session here.

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -2375,15 +2375,14 @@ class Desktop(PyAedtBase):
             if self.aedt_process_id is not None:
                 specified_version = next(
                     (
-                        installed_aedt
+                        installed_aedt[0:6]
                         for installed_aedt in aedt_versions.installed_versions.keys()
-                        if is_number(installed_aedt)
+                        if is_number(installed_aedt[0:6])
                         and self.aedt_process_id
-                        in active_sessions(installed_aedt, self.student_version, self.non_graphical)
+                        in active_sessions(installed_aedt[0:6], self.student_version, self.non_graphical)
                     ),
                     None,
                 )
-
             elif student_version and self.current_student_version:
                 specified_version = self.current_student_version
             elif student_version and self.current_version:

--- a/src/ansys/aedt/core/desktop.py
+++ b/src/ansys/aedt/core/desktop.py
@@ -943,11 +943,7 @@ class Desktop(PyAedtBase):
             self.aedt_version_id.replace("SV", "") if "SV" in (self.aedt_version_id or "") else self.aedt_version_id
         )
 
-        if is_linux:
-            self.__starting_mode = "grpc"
-        elif is_windows and "pythonnet" not in modules:
-            self.__starting_mode = "grpc"
-        elif settings.remote_rpc_session:
+        if settings.remote_rpc_session:
             self.__starting_mode = "grpc"
         elif self.aedt_process_id and not self.new_desktop:  # pragma: no cover
             # connecting to an existing session has the precedence over use_grpc_api user preference
@@ -969,6 +965,10 @@ class Desktop(PyAedtBase):
                     f"The version specified ({self.aedt_version_id}) doesn't correspond "
                     "to the pid specified ({self.aedt_process_id})"
                 )
+        elif is_windows and "pythonnet" not in modules:
+            self.__starting_mode = "grpc"
+        elif is_linux:
+            self.__starting_mode = "grpc"
         elif float(aedt_version_id) < 2022.2:  # pragma no cover
             raise Exception("Unsupported AEDT version")
         elif float(aedt_version_id) == 2022.2:  # pragma no cover
@@ -2372,7 +2372,19 @@ class Desktop(PyAedtBase):
             raise AEDTRuntimeError("AEDT is not installed on your system. Install AEDT version 2022 R2 or higher.")
         specified_version = _normalize_version_to_string(specified_version)
         if not specified_version:
-            if student_version and self.current_student_version:
+            if self.aedt_process_id is not None:
+                specified_version = next(
+                    (
+                        installed_aedt
+                        for installed_aedt in aedt_versions.installed_versions.keys()
+                        if is_number(installed_aedt)
+                        and self.aedt_process_id
+                        in active_sessions(installed_aedt, self.student_version, self.non_graphical)
+                    ),
+                    None,
+                )
+
+            elif student_version and self.current_student_version:
                 specified_version = self.current_student_version
             elif student_version and self.current_version:
                 specified_version = self.current_version


### PR DESCRIPTION
## Description
This pull request updates the user guide examples and refines the logic for determining the AEDT starting mode and version selection when connecting to existing sessions. The changes improve clarity in documentation, ensure the correct startup mode is chosen based on session and environment, and enhance version detection for session attachment.

**Documentation improvements:**

* Updated code examples in `desktop_sessions.rst` to use direct imports (`from ansys.aedt.core import Desktop, Hfss, Maxwell3d`) and context manager variable assignment (`with Desktop(...) as d:`), making the usage clearer and more Pythonic. [[1]](diffhunk://#diff-ebf19fdb040c26b7c2ba29d053bffc8bb93cf211c52c06d9e7c8015ee9d6e0d9L49-R57) [[2]](diffhunk://#diff-ebf19fdb040c26b7c2ba29d053bffc8bb93cf211c52c06d9e7c8015ee9d6e0d9L68-R77)

**Logic changes for AEDT startup and session handling:**

* Changed the order and conditions for selecting the AEDT starting mode in `desktop.py`: now prioritizes `settings.remote_rpc_session` before checking for platform-specific requirements, ensuring remote session settings take precedence. 
* Enhanced version selection in `__check_version`: when attaching to an existing session (`self.aedt_process_id` is not `None`), the code now tries to infer the AEDT version from active sessions, improving robustness when connecting to running instances.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
