### PR TITLE
FEAT: Automatic personallib discovery

### DIFF
--- a/doc/changelog.d/7857.added.md
+++ b/doc/changelog.d/7857.added.md
@@ -1,0 +1,1 @@
+Automatic personallib discovery

--- a/src/ansys/aedt/core/cli/panels.py
+++ b/src/ansys/aedt/core/cli/panels.py
@@ -39,13 +39,51 @@ from ansys.aedt.core.internal.aedt_versions import aedt_versions
 panels_app = typer.Typer(help="Manage PyAEDT panels in AEDT", no_args_is_help=True)
 
 
+def _get_personal_lib_from_open_session() -> Path | None:
+    """Return the PersonalLib path from the first running gRPC AEDT session."""
+    from ansys.aedt.core.cli import common
+    from ansys.aedt.core.cli.aedt import _discover_aedt_sessions
+
+    for session in _discover_aedt_sessions():
+        port = session.get("port")
+        if port is None:
+            continue
+
+        desktop = common.get_desktop(port=port)
+        return Path(desktop.personallib)
+
+    return None
+
+
+def _resolve_personal_lib_path(personal_lib: str | None) -> Path | None:
+    """Resolve PersonalLib from CLI input, a running AEDT session, or a manual prompt."""
+    if personal_lib:
+        return Path(personal_lib.strip()).expanduser()
+
+    personal_lib_path = _get_personal_lib_from_open_session()
+    if personal_lib_path is not None:
+        typer.secho(
+            f"Using PersonalLib from running AEDT session: {personal_lib_path}",
+            fg=typer.colors.CYAN,
+        )
+        return personal_lib_path.expanduser()
+
+    typer.secho(
+        "No opened AEDT session was found. Enter the PersonalLib folder manually.",
+        fg=typer.colors.YELLOW,
+    )
+    manual_path = typer.prompt("Enter path to PersonalLib folder", default="").strip()
+    if not manual_path:
+        return None
+    return Path(manual_path).expanduser()
+
+
 @panels_app.command("add")
 def add_panels(
     personal_lib: str = typer.Option(
         None,
         "--personal-lib",
         help="Path to AEDT PersonalLib folder",
-        prompt="Enter path to PersonalLib folder",
     ),
     skip_version_manager: bool = typer.Option(
         False,
@@ -95,25 +133,16 @@ def add_panels(
             typer.echo("\nPlease install AEDT before running this command.")
             raise typer.Exit(code=1)
 
+        personal_lib_path = _resolve_personal_lib_path(personal_lib)
+
         # Validate personal_lib path
-        if not personal_lib or not isinstance(personal_lib, str):
+        if personal_lib_path is None:
             typer.secho(
                 "✗ the 'personal_lib' path is invalid. Provide a valid path",
                 fg=typer.colors.RED,
                 bold=True,
             )
             raise typer.Exit(code=1)
-
-        personal_lib = personal_lib.strip()
-        if not personal_lib:
-            typer.secho(
-                "✗ The 'personal_lib' path is invalid. Provide a valid path.",
-                fg=typer.colors.RED,
-                bold=True,
-            )
-            raise typer.Exit(code=1)
-
-        personal_lib_path = Path(personal_lib)
 
         if not personal_lib_path.exists():
             typer.secho(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -763,6 +763,40 @@ def test_panels_add_success(cli_runner, temp_personal_lib, mock_installed_versio
     mock_add.assert_called_once()
 
 
+def test_panels_add_uses_open_session_personal_lib(cli_runner, temp_personal_lib, mock_installed_versions):
+    with (
+        patch(
+            "ansys.aedt.core.cli.panels._get_personal_lib_from_open_session",
+            return_value=temp_personal_lib,
+        ),
+        patch(
+            "ansys.aedt.core.extensions.installer.pyaedt_installer.add_pyaedt_to_aedt",
+            return_value=True,
+        ) as mock_add,
+    ):
+        result = cli_runner.invoke(app, ["panels", "add"])
+
+    assert result.exit_code == 0
+    assert "Using PersonalLib from running AEDT session" in result.stdout
+    assert mock_add.call_args.kwargs["personal_lib"] == str(temp_personal_lib)
+
+
+def test_panels_add_prompts_when_no_open_session(cli_runner, temp_personal_lib, mock_installed_versions):
+    with (
+        patch("ansys.aedt.core.cli.panels._get_personal_lib_from_open_session", return_value=None),
+        patch("ansys.aedt.core.cli.panels.typer.prompt", return_value=str(temp_personal_lib)) as mock_prompt,
+        patch(
+            "ansys.aedt.core.extensions.installer.pyaedt_installer.add_pyaedt_to_aedt",
+            return_value=True,
+        ) as mock_add,
+    ):
+        result = cli_runner.invoke(app, ["panels", "add"])
+
+    assert result.exit_code == 0
+    mock_prompt.assert_called_once()
+    assert mock_add.call_args.kwargs["personal_lib"] == str(temp_personal_lib)
+
+
 def test_panels_add_nonexistent_personal_lib(cli_runner, mock_installed_versions):
     result = cli_runner.invoke(app, ["panels", "add", "--personal-lib", "/nonexistent/path/PersonalLib"])
     assert result.exit_code == 1


### PR DESCRIPTION
## Description
Added automatic personallib discovery when available for `pyaedt panels add` command. This simplifies the user experience

## Issue linked
No issue

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
