### PR TITLE
CI: Add uv clean on nightly tests

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -154,7 +154,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -227,7 +227,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -293,7 +293,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -369,7 +369,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -438,7 +438,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -515,7 +515,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -582,7 +582,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -655,7 +655,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -721,7 +721,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -794,7 +794,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -861,7 +861,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -937,7 +937,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -1005,7 +1005,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -1076,7 +1076,7 @@ jobs:
           save-cache: false
 
       - name: Clean uv cache
-        run: uv clean
+        run: uv cache clean
 
       - name: Create virtual environment
         run: uv venv .venv

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -151,6 +151,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -220,6 +224,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -282,6 +290,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -354,6 +366,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -419,6 +435,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -492,6 +512,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -555,6 +579,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -624,6 +652,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -686,6 +718,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -755,6 +791,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -818,6 +858,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -890,6 +934,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Set up headless display
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
@@ -954,6 +1002,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Create virtual environment
         run: uv venv .venv
@@ -1021,6 +1073,10 @@ jobs:
         with:
           enable-cache: false
           prune-cache: true
+          save-cache: false
+
+      - name: Clean uv cache
+        run: uv clean
 
       - name: Create virtual environment
         run: uv venv .venv

--- a/doc/changelog.d/7858.maintenance.md
+++ b/doc/changelog.d/7858.maintenance.md
@@ -1,0 +1,1 @@
+Add uv clean on nightly tests


### PR DESCRIPTION
## Description
Recently we have had issues with disk usage on our self hosted runners. After some investigation, it is related to the use of cache when using `uv`. Given that the self hosted runners are also shared by other projects in the pyaedt ecosystem, I think we can leverage the nightly test runs to ensure that every VM gets its cache cleaned. This should prevent recurrent disk usage issues.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
