### PR TITLE
FIX: Add q23d dynamic link

### DIFF
--- a/doc/changelog.d/7879.fixed.md
+++ b/doc/changelog.d/7879.fixed.md
@@ -1,0 +1,1 @@
+Add q23d dynamic link

--- a/src/ansys/aedt/core/twinbuilder.py
+++ b/src/ansys/aedt/core/twinbuilder.py
@@ -426,7 +426,7 @@ class TwinBuilder(AnalysisTwinBuilder, PyAedtBase):
         maximum_order: float | None = 10000,
         error_tolerance: float | None = 0.005,
         z_ref: float | None = 50,
-        state_space_dynamic_link_type: str | None = "RLGC",
+        state_space_dynamic_link_type: str | None = None,
         component_name: str | None = None,
         save_project: bool | None = True,
     ) -> CircuitComponent | bool:
@@ -584,6 +584,10 @@ class TwinBuilder(AnalysisTwinBuilder, PyAedtBase):
             port_info_list = ["NAME:PortInfo"]
             port_info_list.extend(port_info_list_A)
             port_info_list.extend(port_info_list_B)
+        # None is treated as "RLGC" for backward compatibility
+        if state_space_dynamic_link_type is None:
+            state_space_dynamic_link_type = "RLGC"
+
         if state_space_dynamic_link_type == "RLGC":
             # For versions before 2024.1 use the TB link form. For 2024.1 and
             # later use Q3DRLGCLink for 3D designs and the TB link for 2D.

--- a/src/ansys/aedt/core/twinbuilder.py
+++ b/src/ansys/aedt/core/twinbuilder.py
@@ -426,7 +426,7 @@ class TwinBuilder(AnalysisTwinBuilder, PyAedtBase):
         maximum_order: float | None = 10000,
         error_tolerance: float | None = 0.005,
         z_ref: float | None = 50,
-        state_space_dynamic_link_type: str | None = None,
+        state_space_dynamic_link_type: str | None = "RLGC",
         component_name: str | None = None,
         save_project: bool | None = True,
     ) -> CircuitComponent | bool:
@@ -584,10 +584,12 @@ class TwinBuilder(AnalysisTwinBuilder, PyAedtBase):
             port_info_list = ["NAME:PortInfo"]
             port_info_list.extend(port_info_list_A)
             port_info_list.extend(port_info_list_B)
-        if not state_space_dynamic_link_type or state_space_dynamic_link_type == "RLGC":
-            if dkp.aedt_version_id >= "2024.1":
+        if state_space_dynamic_link_type == "RLGC":
+            # For versions before 2024.1 use the TB link form. For 2024.1 and
+            # later use Q3DRLGCLink for 3D designs and the TB link for 2D.
+            if dkp.aedt_version_id >= "2024.1" and app.design_type != "2D Extractor":
                 state_space_dynamic_link_type = "Q3DRLGCLink"
-            else:  # pragma: no cover
+            else:
                 state_space_dynamic_link_type = f"{design_type}RLGCTBLink"
             q3d_model_type = 1
             ref_pin_style = 5


### PR DESCRIPTION
## Description
Fix Add dynamic link q2d for AEDT versions later than 2024.1.

<!--
Trailers must be placed at the end of the description, separated from the
rest of the text by a blank line. Available trailers for automatic labeling:

  Application: hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical, twin-builder, hfss3dlayout
               (comma-separated values allowed)
  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
                (comma-separated values allowed)
  Platform: windows, linux, rocky
            (comma-separated values allowed)
  Deprecation: <scope>
  Breaking-Change: <scope>

Examples:
  Application: hfss, maxwell
  AEDT-Version: 25.2, 26.1
  Platform: windows, linux
  Breaking-Change: removed MyClass
-->

## Issue linked
#7877 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
