### PR TITLE
TEST: Add xfail marker on pyedb related extensions

### DIFF
--- a/doc/changelog.d/7913.test.md
+++ b/doc/changelog.d/7913.test.md
@@ -1,0 +1,1 @@
+Add xfail marker on pyedb related extensions

--- a/tests/system/extensions/test_configure_layout.py
+++ b/tests/system/extensions/test_configure_layout.py
@@ -40,8 +40,11 @@ EDB_PROJECT = "ANSYS_SVP_V1_1.aedb"
 SI_VERSE_PATH = TESTS_EXTENSIONS_PATH / "example_models" / TEST_SUBFOLDER / EDB_PROJECT
 
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
+# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
+edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
+@edb_xfail
 def test_get_active_db(add_app_example) -> None:
     app = add_app_example(application=Hfss3dLayout, project=SI_VERSE_PROJECT, subfolder=TEST_SUBFOLDER)
     extension = ConfigureLayoutExtension(withdraw=True)
@@ -49,6 +52,7 @@ def test_get_active_db(add_app_example) -> None:
     app.close_project(app.project_name, save=False)
 
 
+@edb_xfail
 def test_apply_config_to_edb(add_app_example, test_tmp_dir) -> None:
     app = add_app_example(application=Hfss3dLayout, project=SI_VERSE_PROJECT, subfolder=TEST_SUBFOLDER)
     config_path = test_tmp_dir / "config.json"
@@ -61,6 +65,7 @@ def test_apply_config_to_edb(add_app_example, test_tmp_dir) -> None:
     app.close_project(app.project_name, save=False)
 
 
+@edb_xfail
 def test_export_config_from_edb(add_app_example) -> None:
     app = add_app_example(application=Hfss3dLayout, project=SI_VERSE_PROJECT, subfolder=TEST_SUBFOLDER)
     extension = ConfigureLayoutExtension(withdraw=True)
@@ -68,6 +73,7 @@ def test_export_config_from_edb(add_app_example) -> None:
     app.close_project(app.project_name, save=False)
 
 
+@edb_xfail
 def test_load_edb_into_hfss3dlayout(add_app, test_tmp_dir) -> None:
     test_project = test_tmp_dir / EDB_PROJECT
     shutil.copytree(SI_VERSE_PATH, test_project)
@@ -78,6 +84,7 @@ def test_load_edb_into_hfss3dlayout(add_app, test_tmp_dir) -> None:
     app.close_project(app.project_name, save=False)
 
 
+@edb_xfail
 def test_ui_initial_state(add_app, test_tmp_dir) -> None:
     """Test the initial state of the UI variables."""
     test_project = test_tmp_dir / EDB_PROJECT
@@ -90,6 +97,7 @@ def test_ui_initial_state(add_app, test_tmp_dir) -> None:
     app.close_project(app.project_name, save=False)
 
 
+@edb_xfail
 def test_selected_edb_property(add_app_example) -> None:
     """Test the selected_edb property."""
     # Test with active design

--- a/tests/system/extensions/test_cutout.py
+++ b/tests/system/extensions/test_cutout.py
@@ -37,8 +37,11 @@ from tests.conftest import DESKTOP_VERSION
 AEDB_FILE_NAME = "ANSYS-HSD_V1"
 TEST_SUBFOLDER = "T45"
 SI_VERSE_PATH = TESTS_EXTENSIONS_PATH / "example_models" / TEST_SUBFOLDER / (AEDB_FILE_NAME + ".aedb")
+# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
+edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
+@edb_xfail
 def test_cutout_success(add_app_example, test_tmp_dir) -> None:
     """Test the successful execution of the cutout operation in Hfss3dLayout."""
     test_project = test_tmp_dir / (AEDB_FILE_NAME + ".aedb")

--- a/tests/system/extensions/test_export_layout.py
+++ b/tests/system/extensions/test_export_layout.py
@@ -37,6 +37,8 @@ TEST_SUBFOLDER = "post_layout_design"
 AEDT_FILE_PATH = TESTS_EXTENSIONS_PATH / "example_models" / TEST_SUBFOLDER / (AEDB_FILE_NAME + ".aedb")
 
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
+# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
+edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
 def cleanup_files(*files) -> None:
@@ -46,6 +48,7 @@ def cleanup_files(*files) -> None:
             export_file.unlink()
 
 
+@edb_xfail
 def test_export_layout_all_options(add_app_example, test_tmp_dir) -> None:
     """Test successful execution of export layout with all options enabled."""
     data = ExportLayoutExtensionData(
@@ -88,6 +91,7 @@ def test_export_layout_all_options(add_app_example, test_tmp_dir) -> None:
         assert isinstance(config_data, dict)
 
 
+@edb_xfail
 def test_export_layout_ipc_only(add_app_example, test_tmp_dir) -> None:
     """Test export layout with only IPC2581 option enabled."""
     ipc_file = test_tmp_dir / f"{AEDB_FILE_NAME}_ipc2581.xml"
@@ -121,6 +125,7 @@ def test_export_layout_ipc_only(add_app_example, test_tmp_dir) -> None:
     assert ipc_file.stat().st_size > 0
 
 
+@edb_xfail
 def test_export_layout_bom_only(add_app_example, test_tmp_dir) -> None:
     """Test export layout with only BOM option enabled."""
     ipc_file = test_tmp_dir / f"{AEDB_FILE_NAME}_ipc2581.xml"
@@ -154,6 +159,7 @@ def test_export_layout_bom_only(add_app_example, test_tmp_dir) -> None:
     assert bom_file.stat().st_size > 0
 
 
+@edb_xfail
 def test_export_layout_config_only(add_app_example, test_tmp_dir) -> None:
     """Test export layout with only configuration option enabled."""
     ipc_file = test_tmp_dir / f"{AEDB_FILE_NAME}_ipc2581.xml"
@@ -191,6 +197,7 @@ def test_export_layout_config_only(add_app_example, test_tmp_dir) -> None:
         assert isinstance(config_data, dict)
 
 
+@edb_xfail
 def test_export_layout_no_options(add_app_example, test_tmp_dir) -> None:
     """Test export layout with all options disabled."""
     ipc_file = test_tmp_dir / f"{AEDB_FILE_NAME}_ipc2581.xml"

--- a/tests/system/extensions/test_parametrize_edb.py
+++ b/tests/system/extensions/test_parametrize_edb.py
@@ -36,8 +36,11 @@ TEST_SUBFOLDER = "T45"
 EDB_PROJECT = "ANSYS-HSD_V1.aedb"
 SI_VERSE_PATH = TESTS_EXTENSIONS_PATH / "example_models" / TEST_SUBFOLDER / EDB_PROJECT
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
+# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
+edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
+@edb_xfail
 def test_parametrize_layout(desktop, test_tmp_dir) -> None:
     """Test parametrizing EDB layout with comprehensive settings."""
     file_path = test_tmp_dir / "ANSYS-HSD_V1_param.aedb"
@@ -87,6 +90,7 @@ def test_parametrize_edb_exceptions(desktop) -> None:
         main(data)
 
 
+@edb_xfail
 def test_parametrize_edb_custom_settings(desktop, test_tmp_dir) -> None:
     """Test Parametrize EDB extension with custom settings."""
     file_path = test_tmp_dir / "ANSYS-HSD_V1_param.aedb"
@@ -111,6 +115,7 @@ def test_parametrize_edb_custom_settings(desktop, test_tmp_dir) -> None:
     assert result is True
 
 
+@edb_xfail
 def test_parametrize_edb_zero_expansions(desktop, test_tmp_dir) -> None:
     """Test Parametrize EDB extension with zero expansions."""
     file_path = test_tmp_dir / "ANSYS-HSD_V1_zero.aedb"

--- a/tests/system/extensions/test_post_layout_design.py
+++ b/tests/system/extensions/test_post_layout_design.py
@@ -32,6 +32,8 @@ from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from tests import TESTS_EXTENSIONS_PATH
 
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
+# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
+edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
 def test_post_layout_design_data_class() -> None:
@@ -73,6 +75,7 @@ def test_post_layout_design_main_function_exceptions() -> None:
         post_layout_design.main(data)
 
 
+@edb_xfail
 def test_layout_design_toolkit_antipad_1(add_app_example) -> None:
     """Test antipad creation with racetrack enabled."""
     h3d = add_app_example(
@@ -99,6 +102,7 @@ def test_layout_design_toolkit_antipad_1(add_app_example) -> None:
     h3d.close_project(save=False)
 
 
+@edb_xfail
 def test_layout_design_toolkit_antipad_2(add_app_example) -> None:
     """Test antipad creation with racetrack disabled."""
     h3d = add_app_example(
@@ -124,6 +128,7 @@ def test_layout_design_toolkit_antipad_2(add_app_example) -> None:
     h3d.close_project(save=False)
 
 
+@edb_xfail
 def test_layout_design_toolkit_unknown_action(add_app_example) -> None:
     """Test main function with unknown action."""
     h3d = add_app_example(
@@ -148,6 +153,7 @@ def test_layout_design_toolkit_unknown_action(add_app_example) -> None:
     h3d.close_project(save=False)
 
 
+@edb_xfail
 def test_layout_design_toolkit_microvia(add_app_example) -> None:
     """Test microvia creation with conical shape."""
     h3d = add_app_example(

--- a/tests/system/extensions/test_via_clustering.py
+++ b/tests/system/extensions/test_via_clustering.py
@@ -35,8 +35,11 @@ from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from tests import TESTS_EXTENSIONS_PATH
 
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
+# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
+edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
+@edb_xfail
 def test_via_clustering_main_function(test_tmp_dir) -> None:
     """Test the main function of the Via Clustering extension."""
     # Copy test model to scratch directory
@@ -70,6 +73,7 @@ def test_via_clustering_main_function(test_tmp_dir) -> None:
     assert new_file.exists()
 
 
+@edb_xfail
 def test_via_clustering_extension_ui(add_app_example) -> None:
     """Test the Via Clustering extension UI components."""
     # Create an HFSS 3D Layout application for testing
@@ -127,6 +131,7 @@ def test_via_clustering_exceptions() -> None:
         main(data)
 
 
+@edb_xfail
 def test_via_clustering_button_functions(add_app_example) -> None:
     """Test the button functions in the Via Clustering extension."""
     # Copy the test model to scratch directory


### PR DESCRIPTION
## Description
Since some extensions tests related to pyedb are randomly failing, this PR adds an `xfail` marker on tests opening an AEDB file. If required we could create another batch of tests (like the flaky one we used to have) and run them separately.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
