### PR TITLE
FIX: Bug in create single point in frequency sweep

### DIFF
--- a/doc/changelog.d/7914.fixed.md
+++ b/doc/changelog.d/7914.fixed.md
@@ -1,0 +1,1 @@
+Bug in create single point in frequency sweep

--- a/src/ansys/aedt/core/hfss.py
+++ b/src/ansys/aedt/core/hfss.py
@@ -2006,7 +2006,7 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin, PyAedtBase):
         save_single_field: bool = True,
         save_fields: bool = False,
         save_rad_fields: bool = False,
-    ) -> "SweepHFSS | bool":
+    ) -> SweepHFSS | bool:
         """Create a sweep with a single frequency point.
 
         Parameters
@@ -2065,16 +2065,14 @@ class Hfss(FieldAnalysis3D, ScatteringMethods, CreateBoundaryMixin, PyAedtBase):
         if isinstance(freq, list):
             if not freq:
                 raise AttributeError("Frequency list is empty. Specify at least one frequency point.")
-            _ = freq.pop(0)
             if freq:
                 add_subranges = True
 
-        if isinstance(save_single_field, list):
-            _ = save_single_field.pop(0)
-        else:
+        if not isinstance(save_single_field, list):
             save0 = save_single_field
             if add_subranges:
-                save_single_field = [save0] * len(freq)
+                freq_mult = len(freq) if isinstance(freq, list) else 1
+                save_single_field = [save0] * freq_mult
 
         for s in self.setups:
             if s.name == setup:

--- a/src/ansys/aedt/core/hfss3dlayout.py
+++ b/src/ansys/aedt/core/hfss3dlayout.py
@@ -24,13 +24,14 @@
 
 """The module contains the ``Hfss3dLayout`` class."""
 
+from __future__ import annotations
+
 import fnmatch
 import io
 import os
 from pathlib import Path
 import re
 from typing import TYPE_CHECKING
-from typing import Union
 
 from ansys.aedt.core.application.analysis_3d_layout import FieldAnalysis3DLayout
 from ansys.aedt.core.application.analysis_hf import ScatteringMethods
@@ -217,7 +218,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout, ScatteringMethods, PyAedtBase):
     @pyaedt_function_handler()
     def create_edge_port(
         self,
-        assignment: Union[str, "Line3dLayout"],
+        assignment: str | "Line3dLayout",
         edge_number: int,
         is_circuit_port: bool | None = False,
         is_wave_port: bool | None = False,
@@ -1237,7 +1238,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout, ScatteringMethods, PyAedtBase):
         interpolation_tol_percent: float | None = 0.5,
         interpolation_max_solutions: int | None = 250,
         use_q3d_for_dc: bool | None = False,
-    ) -> Union["SweepHFSS3DLayout", bool]:
+    ) -> "SweepHFSS3DLayout" | bool:
         """Create a sweep with the specified number of points.
 
         Parameters
@@ -1351,7 +1352,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout, ScatteringMethods, PyAedtBase):
         interpolation_tol_percent: float | None = 0.5,
         interpolation_max_solutions: int | None = 250,
         use_q3d_for_dc: bool | None = False,
-    ) -> Union["SweepHFSS3DLayout", bool]:
+    ) -> "SweepHFSS3DLayout" | bool:
         """Create a sweep with the specified frequency step.
 
         Parameters
@@ -1459,7 +1460,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout, ScatteringMethods, PyAedtBase):
         name: str | None = None,
         save_fields: bool | None = False,
         save_rad_fields_only: bool | None = False,
-    ) -> Union["SweepHFSS", bool]:
+    ) -> SweepHFSS | bool:
         """Create a sweep with a single frequency point.
 
         Parameters
@@ -1529,6 +1530,10 @@ class Hfss3dLayout(FieldAnalysis3DLayout, ScatteringMethods, PyAedtBase):
                     for f in freq:
                         sweepdata.add_subrange(range_type="SinglePoint", start=f, unit=unit)
                 self.logger.info("Single point sweep %s has been correctly created.", sweep_name)
+
+                # Reset children to populate again the new properties
+                s._children = {}
+
                 return sweepdata
         return False
 

--- a/src/ansys/aedt/core/modules/solve_setup.py
+++ b/src/ansys/aedt/core/modules/solve_setup.py
@@ -36,6 +36,7 @@ import re
 import secrets
 import time
 from typing import TYPE_CHECKING
+from typing import Any
 import warnings
 
 from ansys.aedt.core.base import PyAedtBase
@@ -58,16 +59,39 @@ from ansys.aedt.core.modules.solve_sweeps import SweepMaxwellEC
 from ansys.aedt.core.modules.solve_sweeps import identify_setup
 
 if TYPE_CHECKING:
+    from ansys.aedt.core.application.analysis import Analysis
     from ansys.aedt.core.visualization.post.solution_data import SolutionData
     from ansys.aedt.core.visualization.report.standard import Standard
 
 
 class CommonSetup(PropsManager, BinaryTreeNode, PyAedtBase):
-    """Provide common setup."""
+    """Provide common setup.
 
-    def __init__(self, app, solution_type, name: str = "MySetupAuto", is_new_setup: bool = True) -> None:
+    Parameters
+    ----------
+    app : :class:`ansys.aedt.core.application.analysis.Analysis`
+        Inherited app object.
+    solution_type : int or str
+        Type of the setup.
+    name : str, optional
+        Name of the setup. The default is ``"MySetupAuto"``.
+    is_new_setup : bool, optional
+        Whether to create the setup from a template. The default is ``True``.
+        If ``False``, access is to the existing setup.
+
+    Examples
+    --------
+    >>> from ansys.aedt.core import Hfss
+    >>> app = Hfss()
+    >>> setup = app.create_setup()
+
+    """
+
+    def __init__(
+        self, app: Analysis, solution_type: str | int, name: str = "MySetupAuto", is_new_setup: bool = True
+    ) -> None:
         self.auto_update = False
-        self._app = app
+        self._app: Any = app
         if solution_type is None:
             self.setuptype = self._app.design_solutions.default_setup
         elif isinstance(solution_type, int):
@@ -121,8 +145,17 @@ class CommonSetup(PropsManager, BinaryTreeNode, PyAedtBase):
         return False
 
     @property
-    def sweeps(self) -> list:
-        """Retrieve sweeps."""
+    def sweeps(self) -> list | None:
+        """Retrieve sweeps.
+
+        Examples
+        --------
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.sweeps
+
+        """
         if self._sweeps is not None:
             return self._sweeps
         try:
@@ -167,9 +200,10 @@ class CommonSetup(PropsManager, BinaryTreeNode, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import CommonSetup
-        >>> obj = CommonSetup()
-        >>> obj.default_intrinsics
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.default_intrinsics
 
         """
         intrinsics = {}
@@ -276,9 +310,11 @@ class CommonSetup(PropsManager, BinaryTreeNode, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import CommonSetup
-        >>> obj = CommonSetup()
-        >>> obj.analyze(cores=[1, 2, 3], tasks=[1, 2, 3])
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.default_intrinsics
+        >>> setup.analyze(cores=4)
 
         """
         self._app.analyze(
@@ -301,9 +337,10 @@ class CommonSetup(PropsManager, BinaryTreeNode, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import CommonSetup
-        >>> obj = CommonSetup()
-        >>> obj.props
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.props
 
         """
         if self._legacy_props:
@@ -342,9 +379,10 @@ class CommonSetup(PropsManager, BinaryTreeNode, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import CommonSetup
-        >>> obj = CommonSetup()
-        >>> obj.is_solved
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.is_solved
 
         """
         if self._app.design_type == "Circuit Design":
@@ -373,9 +411,10 @@ class CommonSetup(PropsManager, BinaryTreeNode, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import CommonSetup
-        >>> obj = CommonSetup()
-        >>> obj.omodule
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.omodule
 
         """
         return self._app.oanalysis
@@ -386,9 +425,10 @@ class CommonSetup(PropsManager, BinaryTreeNode, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import CommonSetup
-        >>> obj = CommonSetup()
-        >>> obj.name
+         >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.name
 
         """
         return self._name
@@ -409,9 +449,10 @@ class CommonSetup(PropsManager, BinaryTreeNode, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import CommonSetup
-        >>> obj = CommonSetup()
-        >>> obj.get_profile()
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.get_profile()
 
         """
         return self._app.get_profile(self.name)  # Native API getter.
@@ -681,8 +722,9 @@ class Setup(CommonSetup):
 
     Examples
     --------
-    >>> from ansys.aedt.core.modules.solve_setup import Setup
-    >>> obj = Setup()
+    >>> from ansys.aedt.core import Hfss
+    >>> app = Hfss()
+    >>> setup = app.create_setup()
 
     """
 
@@ -704,9 +746,9 @@ class Setup(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup
-        >>> obj = Setup()
-        >>> obj.create()
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
 
         """
         soltype = SetupKeys.SetupNames[self.setuptype]
@@ -734,9 +776,10 @@ class Setup(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup
-        >>> obj = Setup()
-        >>> obj.update(properties={"Name": "Value"})
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.update(properties={"Name": "Value"})
 
         """
         legacy_update = self.auto_update
@@ -761,9 +804,10 @@ class Setup(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup
-        >>> obj = Setup()
-        >>> obj.delete()
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.delete()
 
         """
         self._app.delete_setup(self.name)
@@ -793,6 +837,9 @@ class Setup(CommonSetup):
             List of Boolean values indicating whether the expressions are in
             the convergence criteria.
         isrelativeconvergence : bool
+            Whether to use relative convergence.
+        conv_criteria: float
+            Convergence criteria.
 
         conv_criteria:
 
@@ -938,8 +985,9 @@ class Setup(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup
-        >>> obj = Setup()
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
         >>> obj.enable_expression_cache(expressions=["dB(S(1,1))"])
 
         """
@@ -977,9 +1025,10 @@ class Setup(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup
-        >>> obj = Setup()
-        >>> obj.enable()
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.enable()
 
         """
         self.props["Enabled"] = True
@@ -1005,9 +1054,10 @@ class Setup(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup
-        >>> obj = Setup()
-        >>> obj.disable()
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss()
+        >>> setup = app.create_setup()
+        >>> setup.disable()
 
         """
         self.props["Enabled"] = False
@@ -1241,7 +1291,8 @@ class Setup(CommonSetup):
 
         Examples
         --------
-        >>> m2d = ansys.aedt.core.Maxwell2d()
+        >>> from ansys.aedt.core import Maxwell2d
+        >>> m2d = Maxwell2d()
         >>> setup = m2d.get_setup("Setup1")
         >>> setup.start_continue_from_previous_setup(design="IM", solution="Setup1 : Transient")
 
@@ -1292,8 +1343,10 @@ class SetupCircuit(CommonSetup):
 
     Examples
     --------
-    >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-    >>> obj = SetupCircuit()
+    >>> from ansys.aedt.core import Circuit
+    >>> from ansys.aedt.core.generic.constants import Setups
+    >>> circuit_app = Circuit()
+    >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
 
     """
 
@@ -1302,7 +1355,17 @@ class SetupCircuit(CommonSetup):
 
     @property
     def props(self) -> SetupProps:
-        """Retrieve props."""
+        """Retrieve props.
+
+        Examples
+        --------
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.props
+
+        """
         if self._legacy_props:
             return self._legacy_props
         if self._is_new_setup:
@@ -1350,9 +1413,10 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.create()
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
 
         """
         soltype = SetupKeys.SetupNames[self.setuptype]
@@ -1422,9 +1486,11 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.update(properties={"Name": "Value"})
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.update(properties={"Name": "Value"})
 
         """
         legacy_update = self.auto_update
@@ -1478,9 +1544,11 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.add_sweep_points(sweep_variable=1, sweep_points=[0, 0, 0])
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.add_sweep_points(sweep_variable="Freq", sweep_points=[1, 2, 3])
 
         """
         if isinstance(sweep_points, (int, float)):
@@ -1542,9 +1610,11 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.add_sweep_count(sweep_variable=1, start=[0, 0, 0])
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.add_sweep_count(sweep_variable="Freq", start=1)
 
         """
         if isinstance(start, (int, float)):
@@ -1605,9 +1675,11 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.add_sweep_step(sweep_variable=1, start=[0, 0, 0])
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.add_sweep_step(sweep_variable="Freq", start=1)
 
         """
         if isinstance(start, (int, float)):
@@ -1802,9 +1874,11 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.enable_expression_cache(expressions=["dB(S(1,1))"])
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.enable_expression_cache(expressions=["dB(S(1,1))"])
 
         """
         arg = self._setup_dict_to_arg(name="SimSetup")
@@ -1835,9 +1909,11 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.enable(name="MyObject")
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.enable()
 
         """
         if not name:
@@ -1865,9 +1941,11 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.disable(name="MyObject")
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.disable()
 
         """
         if not name:
@@ -1947,9 +2025,11 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.get_solution_data(expressions=["dB(S(1,1))"], domain=1)
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.get_solution_data(expressions=["dB(S(1,1))"], domain="Sweep")
 
         """
         return self._app.post.get_solution_data(
@@ -1984,7 +2064,7 @@ class SetupCircuit(CommonSetup):
         snapshot_path: str = None,
         width: int = 800,
         height: int = 450,
-    ) -> "Standard":
+    ) -> Standard:
         """Create a report in AEDT. It can be a 2D plot, 3D plot, polar plots or data tables.
 
         Parameters
@@ -2047,9 +2127,11 @@ class SetupCircuit(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupCircuit
-        >>> obj = SetupCircuit()
-        >>> obj.create_report(name="MyObject", expressions=["dB(S(1,1))"])
+        >>> from ansys.aedt.core import Circuit
+        >>> from ansys.aedt.core.generic.constants import Setups
+        >>> circuit_app = Circuit()
+        >>> setup1 = circuit_app.create_setup("circuit", Setups.NexximLNA)
+        >>> setup1.create_report(name="MyObject", expressions=["dB(S(1,1))"])
 
         """
         return self._app.post.create_report(
@@ -2090,8 +2172,9 @@ class Setup3DLayout(CommonSetup):
 
     Examples
     --------
-    >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-    >>> obj = Setup3DLayout()
+    >>> from ansys.aedt.core import Hfss3dLayout
+    >>> app = Hfss3dLayout()
+    >>> setup = app.create_setup()
 
     """
 
@@ -2100,7 +2183,16 @@ class Setup3DLayout(CommonSetup):
 
     @property
     def sweeps(self) -> list["SweepHFSS3DLayout"]:
-        """Retrieve sweeps."""
+        """Retrieve sweeps.
+
+        Examples
+        --------
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.sweeps
+
+        """
         if self._sweeps is not None:
             return self._sweeps
         try:
@@ -2119,7 +2211,16 @@ class Setup3DLayout(CommonSetup):
 
     @property
     def props(self) -> SetupProps:
-        """Retrieve props."""
+        """Retrieve props.
+
+        Examples
+        --------
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.props
+
+        """
         if self._legacy_props:
             return self._legacy_props
         if self._is_new_setup:
@@ -2154,9 +2255,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.is_solved
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.is_solved
 
         """
         if self.properties:
@@ -2196,9 +2298,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.solver_type
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.solver_type
 
         """
         try:
@@ -2226,9 +2329,9 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.create()
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
 
         """
         arg = self._setup_dict_to_arg()
@@ -2256,9 +2359,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.update(properties={"Name": "Value"})
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.update(properties={"Name": "Value"})
 
         """
         if properties:
@@ -2288,9 +2392,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.enable()
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.enable()
 
         """
         self.props["Properties"]["Enable"] = "true"
@@ -2317,9 +2422,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.disable()
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.disable()
 
         """
         self.props["Properties"]["Enable"] = "false"
@@ -2354,9 +2460,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.export_to_hfss(output_file="example.txt")
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.export_to_hfss(output_file="example.aedt")
 
         """
         output_file = output_file
@@ -2626,9 +2733,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.export_to_q3d(output_file="example.txt")
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.export_to_q3d(output_file="example.aedt")
 
         """
         if not os.path.isdir(os.path.dirname(output_file)):
@@ -2647,7 +2755,7 @@ class Setup3DLayout(CommonSetup):
         return succeeded
 
     @pyaedt_function_handler()
-    def add_sweep(self, name: str = None, sweep_type: str = "Interpolating"):
+    def add_sweep(self, name: str = None, sweep_type: str = "Interpolating") -> SweepHFSS3DLayout | bool:
         """Add a frequency sweep.
 
         Parameters
@@ -2671,21 +2779,24 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.add_sweep(name="MyObject", sweep_type=1)
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> app = Hfss3dLayout()
+        >>> setup = app.create_setup()
+        >>> setup.add_sweep()
 
         """
         if not name:
             name = generate_unique_name("Sweep")
         sweep_n = SweepHFSS3DLayout(self, name, sweep_type)
         if sweep_n.create():
-            self.sweeps.append(sweep_n)
+            if self._sweeps is None:
+                self._sweeps = []
+            self._sweeps.append(sweep_n)
             return sweep_n
         return False
 
     @pyaedt_function_handler()
-    def get_sweep(self, name: str = None) -> "SweepHFSS3DLayout" | bool:
+    def get_sweep(self, name: str = None) -> SweepHFSS3DLayout | bool:
         """Return frequency sweep object of a given sweep.
 
         Parameters
@@ -2727,9 +2838,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.import_from_json(file_path="example.json")
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> h3d = Hfss3dLayout()
+        >>> setup = h3d.create_setup()
+        >>> setup.import_from_json(file_path="example.json")
 
         """
         self.props._import_properties_from_json(file_path)
@@ -2757,9 +2869,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.export_to_json(file_path="example.json")
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> h3d = Hfss3dLayout()
+        >>> setup = h3d.create_setup()
+        >>> setup.export_to_json(file_path="example.json"
 
         """
         if os.path.isfile(file_path):  # pragma no cover
@@ -2812,9 +2925,10 @@ class Setup3DLayout(CommonSetup):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import Setup3DLayout
-        >>> obj = Setup3DLayout()
-        >>> obj.use_matrix_convergence(entry_selection=1, ignore_phase_when_mag_is_less_than=1.0)
+        >>> from ansys.aedt.core import Hfss3dLayout
+        >>> h3d = Hfss3dLayout()
+        >>> setup = h3d.create_setup()
+        >>> setup.use_matrix_convergence(entry_selection=1, ignore_phase_when_mag_is_less_than=1.0)
 
         """
         legacy_update = self.auto_update
@@ -2875,8 +2989,9 @@ class SetupHFSS(Setup, PyAedtBase):
 
     Examples
     --------
-    >>> from ansys.aedt.core.modules.solve_setup import SetupHFSS
-    >>> obj = SetupHFSS()
+    >>> from ansys.aedt.core import Hfss
+    >>> h3d = Hfss()
+    >>> setup = h3d.create_setup()
 
     """
 
@@ -2893,9 +3008,10 @@ class SetupHFSS(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSS
-        >>> obj = SetupHFSS()
-        >>> obj.get_derivative_variables()
+        >>> from ansys.aedt.core import Hfss
+        >>> h3d = Hfss()
+        >>> setup = h3d.create_setup()
+        >>> setup.get_derivative_variables()
 
         """
         try:
@@ -2923,9 +3039,11 @@ class SetupHFSS(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSS
-        >>> obj = SetupHFSS()
-        >>> obj.add_derivatives(derivative_list=["Box1"])
+        >>> from ansys.aedt.core import Hfss
+        >>> h3d = Hfss()
+        >>> h3d["a1"] = "1mm"
+        >>> setup = h3d.create_setup()
+        >>> setup.add_derivatives(derivative_list=["a1"])
 
         """
         if not isinstance(derivative_list, list):
@@ -3003,7 +3121,7 @@ class SetupHFSS(Setup, PyAedtBase):
         sweep_type: str = "Discrete",
         interpolation_tol: float = 0.5,
         interpolation_max_solutions: int = 250,
-    ) -> "SweepHFSS" | bool:
+    ) -> SweepHFSS | bool:
         """Create a sweep with the specified number of points.
 
         Parameters
@@ -3051,6 +3169,8 @@ class SetupHFSS(Setup, PyAedtBase):
         Create a setup named ``"LinearCountSetup"`` and use it in a linear count sweep
         named ``"LinearCountSweep"``.
 
+        >>> from ansys.aedt.core import Hfss
+        >>> hfss = Hfss()
         >>> setup = hfss.create_setup("LinearCountSetup")
         >>> linear_count_sweep = setup.create_linear_count_sweep(
         ...     name="LinearStepSweep", unit="MHz", start_frequency=1.1e3, stop_frequency=1200.1, step_size=153.8
@@ -3106,7 +3226,7 @@ class SetupHFSS(Setup, PyAedtBase):
         save_fields: bool = True,
         save_rad_fields: bool = False,
         sweep_type: str = "Discrete",
-    ) -> "SweepHFSS" | bool:
+    ) -> SweepHFSS | bool:
         """Create a Sweep with a specified frequency step.
 
         Parameters
@@ -3144,6 +3264,8 @@ class SetupHFSS(Setup, PyAedtBase):
         Create a setup named ``"LinearStepSetup"`` and use it in a linear step sweep
         named ``"LinearStepSweep"``.
 
+        >>> from ansys.aedt.core import Hfss
+        >>> hfss = Hfss()
         >>> setup = hfss.create_setup("LinearStepSetup")
         >>> linear_step_sweep = setup.create_linear_step_sweep(
         ...     name="LinearStepSweep", unit="MHz", start_frequency=1.1e3, stop_frequency=1200.1, step_size=153.8
@@ -3190,7 +3312,7 @@ class SetupHFSS(Setup, PyAedtBase):
         save_single_field: bool | list = True,
         save_fields: bool = False,
         save_rad_fields: bool = False,
-    ) -> "SweepHFSS" | bool:
+    ) -> SweepHFSS | bool:
         """Create a Sweep with a single frequency point.
 
         Parameters
@@ -3252,7 +3374,10 @@ class SetupHFSS(Setup, PyAedtBase):
         else:
             save0 = save_single_field
             if add_subranges:
-                save_single_field = [save0] * len(freq)
+                if isinstance(freq, list) and isinstance(save_single_field, bool):
+                    save_single_field = [save0] * len(freq)
+                else:
+                    add_subranges = False
 
         if name in [sweep.name for sweep in self.sweeps]:
             oldname = name
@@ -3266,15 +3391,19 @@ class SetupHFSS(Setup, PyAedtBase):
         sweepdata.props["SaveFields"] = save_fields
         sweepdata.props["SaveRadFields"] = save_rad_fields
         sweepdata.props["SMatrixOnlySolveMode"] = "Auto"
-        if add_subranges:
+        if add_subranges and isinstance(freq, list) and isinstance(save_single_field, list):
             for f, s in zip(freq, save_single_field):
                 sweepdata.add_subrange(range_type="SinglePoints", start=f, unit=unit, save_single_fields=s)
         sweepdata.update()
+
+        # Reset children to populate again the new properties
+        self._children = {}
+
         self._app.logger.info(f"Single point sweep {name} has been correctly created")
         return sweepdata
 
     @pyaedt_function_handler()
-    def add_sweep(self, name: str = None, sweep_type: str = "Interpolating", **props) -> "SweepHFSS" | bool:
+    def add_sweep(self, name: str = None, sweep_type: str = "Interpolating", **props) -> SweepHFSS | bool:
         """Add a sweep to the project.
 
         Parameters
@@ -3298,21 +3427,29 @@ class SetupHFSS(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSS
-        >>> obj = SetupHFSS()
-        >>> obj.add_sweep(name="MyObject", sweep_type=1)
+        >>> from ansys.aedt.core import Hfss
+        >>> hfss = Hfss()
+        >>> setup = hfss.create_setup()
+        >>> setup.add_sweep()
 
         """
         if not name:
             name = generate_unique_name("Sweep")
         if self.setuptype <= 4:
             sweep_n = SweepHFSS(self, name=name, sweep_type=sweep_type, props=props)
+
         sweep_n.create()
-        self.sweeps.append(sweep_n)
+
+        # Reset children to populate again the new properties
+        self._children = {}
+
+        if self._sweeps is None:
+            self._sweeps = []
+        self._sweeps.append(sweep_n)
         return sweep_n
 
     @pyaedt_function_handler()
-    def get_sweep(self, name: str = None) -> "SweepHFSS" | bool:
+    def get_sweep(self, name: str = None) -> SweepHFSS | bool:
         """Return frequency sweep object of a given sweep.
 
         Parameters
@@ -3327,9 +3464,10 @@ class SetupHFSS(Setup, PyAedtBase):
 
         Examples
         --------
+        >>> from ansys.aedt.core import Hfss
         >>> hfss = Hfss()
-        >>> setup = hfss.get_setup("Pyaedt_setup")
-        >>> sweep = setup.get_sweep("Sweep1")
+        >>> setup = hfss.create_setup()
+        >>> sweep = setup.add_sweep()
         >>> sweep.add_subrange("LinearCount", 0, 10, 1, "Hz")
         >>> sweep.add_subrange("LogScale", 10, 1e8, 100, "Hz")
 
@@ -3358,9 +3496,9 @@ class SetupHFSS(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> import ansys.aedt.core
-        >>> hfss = ansys.aedt.core.Hfss()
-        >>> setup = hfss.get_setup("Pyaedt_setup")
+        >>> from ansys.aedt.core import Hfss
+        >>> hfss = Hfss()
+        >>> setup = hfss.create_setup(setup_type="HFSSDriven")
         >>> sweeps = setup.get_sweep_names()
 
         """
@@ -3396,8 +3534,16 @@ class SetupHFSS(Setup, PyAedtBase):
 
         """
         if name in self.get_sweep_names():
-            self._sweeps = [sweep for sweep in self._sweeps if sweep.name != name]
+            if self._sweeps is None:
+                self._sweeps = []
+            else:
+                self._sweeps = [sweep for sweep in self._sweeps if sweep.name != name]
+
             self.omodule.DeleteSweep(self.name, name)
+
+            # Reset children to populate again the new properties
+            self._children = {}
+
             return True
         return False
 
@@ -3425,9 +3571,10 @@ class SetupHFSS(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSS
-        >>> obj = SetupHFSS()
-        >>> obj.enable_adaptive_setup_single(freq="1GHz", max_passes=[1, 2, 3])
+        >>> import ansys.aedt.core
+        >>> hfss = ansys.aedt.core.Hfss()
+        >>> setup1 = hfss.create_setup(name="Setup1")
+        >>> setup1.enable_adaptive_setup_single(freq="1GHz", max_passes=2)
 
         """
         if self.setuptype != 1 or self._app.solution_type not in ["Modal", "Terminal"]:
@@ -3475,9 +3622,10 @@ class SetupHFSS(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSS
-        >>> obj = SetupHFSS()
-        >>> obj.enable_adaptive_setup_broadband(low_frequency="1GHz", high_frequency="1GHz")
+        >>> import ansys.aedt.core
+        >>> hfss = ansys.aedt.core.Hfss()
+        >>> setup1 = hfss.create_setup(name="Setup1")
+        >>> setup1.enable_adaptive_setup_broadband(low_frequency="1GHz", high_frequency="1GHz")
 
         """
         if self.setuptype != 1 or self._app.solution_type not in ["Modal", "Terminal"]:
@@ -3517,9 +3665,10 @@ class SetupHFSS(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSS
-        >>> obj = SetupHFSS()
-        >>> obj.enable_adaptive_setup_multifrequency(frequencies=["Box1"])
+        >>> import ansys.aedt.core
+        >>> hfss = ansys.aedt.core.Hfss()
+        >>> setup1 = hfss.create_setup(name="Setup1")
+        >>> setup1.enable_adaptive_setup_multifrequency(frequencies=["Box1"])
 
         """
         if self.setuptype != 1 or self._app.solution_type not in ["Modal", "Terminal"]:
@@ -3594,9 +3743,10 @@ class SetupHFSS(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSS
-        >>> obj = SetupHFSS()
-        >>> obj.use_matrix_convergence(entry_selection=1, ignore_phase_when_mag_is_less_than=1.0)
+        >>> import ansys.aedt.core
+        >>> hfss = ansys.aedt.core.Hfss()
+        >>> setup1 = hfss.create_setup(name="Setup1")
+        >>> setup1.use_matrix_convergence(entry_selection=1, ignore_phase_when_mag_is_less_than=1.0)
 
         """
         legacy_update = self.auto_update
@@ -3647,7 +3797,7 @@ class SetupHFSS(Setup, PyAedtBase):
 
 
 class SetupHFSSAuto(Setup, PyAedtBase):
-    """Initializes, creates, and updates an HFSS SBR+ or  HFSS Auto setup.
+    """Initializes, creates, and updates an HFSS Auto setup.
 
     Parameters
     ----------
@@ -3663,8 +3813,9 @@ class SetupHFSSAuto(Setup, PyAedtBase):
 
     Examples
     --------
-    >>> from ansys.aedt.core.modules.solve_setup import SetupHFSSAuto
-    >>> obj = SetupHFSSAuto()
+    >>> import ansys.aedt.core
+    >>> hfss = ansys.aedt.core.Hfss()
+    >>> setup1 = hfss.create_setup(name="Setup1", setup_type="HFSSDrivenAuto")
 
     """
 
@@ -3681,9 +3832,10 @@ class SetupHFSSAuto(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSSAuto
-        >>> obj = SetupHFSSAuto()
-        >>> obj.get_derivative_variables()
+        >>> import ansys.aedt.core
+        >>> hfss = ansys.aedt.core.Hfss()
+        >>> setup1 = hfss.create_setup(name="Setup1", setup_type="HFSSDrivenAuto")
+        >>> setup1.get_derivative_variables()
 
         """
         try:
@@ -3711,9 +3863,10 @@ class SetupHFSSAuto(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSSAuto
-        >>> obj = SetupHFSSAuto()
-        >>> obj.add_derivatives(derivative_list=["Box1"])
+        >>> import ansys.aedt.core
+        >>> hfss = ansys.aedt.core.Hfss()
+        >>> setup1 = hfss.create_setup(name="Setup1", setup_type="HFSSDrivenAuto")
+        >>> setup1.add_derivatives(derivative_list=["Box1"])
 
         """
         if not isinstance(derivative_list, list):
@@ -3748,7 +3901,7 @@ class SetupHFSSAuto(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aed.core import Hfss
+        >>> from ansys.aedt.core import Hfss
         >>> hfss = Hfss()
         >>> hfss["der_var"] = "1mm"
         >>> setup = hfss.create_setup(setup_type=0)
@@ -3813,9 +3966,10 @@ class SetupHFSSAuto(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSSAuto
-        >>> obj = SetupHFSSAuto()
-        >>> obj.add_subrange(range_type=1, start=[0, 0, 0])
+        >>> from ansys.aedt.core import Hfss
+        >>> hfss = Hfss()
+        >>> setup = hfss.create_setup(setup_type=0)
+        >>> setup.add_subrange(range_type="LinearCount", start=1, end=2)
 
         """
         if clear:
@@ -3874,9 +4028,10 @@ class SetupHFSSAuto(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSSAuto
-        >>> obj = SetupHFSSAuto()
-        >>> obj.enable_adaptive_setup_single(frequency="1GHz", max_passes=[1, 2, 3])
+        >>> from ansys.aedt.core import Hfss
+        >>> hfss = Hfss()
+        >>> setup = hfss.create_setup(setup_type=0)
+        >>> setup.enable_adaptive_setup_single(frequency="1GHz", max_passes=2)
 
         """
         if self.setuptype != 1 or self._app.solution_type not in ["Modal", "Terminal"]:
@@ -3921,9 +4076,10 @@ class SetupHFSSAuto(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSSAuto
-        >>> obj = SetupHFSSAuto()
-        >>> obj.enable_adaptive_setup_broadband(low_frequency="1GHz", high_frequency="1GHz")
+        >>> from ansys.aedt.core import Hfss
+        >>> hfss = Hfss()
+        >>> setup = hfss.create_setup(setup_type=0)
+        >>> setup.enable_adaptive_setup_broadband(low_frequency="1GHz", high_frequency="1GHz")
 
         """
         if self.setuptype != 1 or self._app.solution_type not in ["Modal", "Terminal"]:
@@ -3963,9 +4119,10 @@ class SetupHFSSAuto(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupHFSSAuto
-        >>> obj = SetupHFSSAuto()
-        >>> obj.enable_adaptive_setup_multifrequency(frequencies=["Box1"])
+        >>> from ansys.aedt.core import Hfss
+        >>> hfss = Hfss()
+        >>> setup = hfss.create_setup(setup_type=0)
+        >>> setup.enable_adaptive_setup_multifrequency(frequencies=["Box1"]
 
         """
         if self.setuptype != 1 or self._app.solution_type not in ["Modal", "Terminal"]:
@@ -4010,8 +4167,9 @@ class SetupSBR(Setup, PyAedtBase):
 
     Examples
     --------
-    >>> from ansys.aedt.core.modules.solve_setup import SetupSBR
-    >>> obj = SetupSBR()
+    >>> from ansys.aedt.core import Hfss
+    >>> hfss = Hfss(solution_type="SBR+")
+    >>> setup = hfss.create_setup(setup_type="HFSSSBR")
 
     """
 
@@ -4053,9 +4211,11 @@ class SetupSBR(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupSBR
-        >>> obj = SetupSBR()
-        >>> obj.add_subrange(range_type=1, start=[0, 0, 0])
+        >>> from ansys.aedt.core import Hfss
+        >>> from ansys.aedt.core.modules.setup_templates import SetupKeys
+        >>> hfss = Hfss(solution_type="SBR+")
+        >>> setup = hfss.create_setup(setup_type="HFSSSBR")
+        >>> setup.add_subrange(range_type=1, start=[0, 0, 0])
 
         """
         if clear:
@@ -4126,7 +4286,7 @@ class SetupMaxwell(Setup, PyAedtBase):
         units: str = "Hz",
         clear: bool = True,
         save_all_fields: bool = True,
-    ) -> "SweepMaxwellEC" | bool:
+    ) -> SweepMaxwellEC | bool:
         """Create a Maxwell Eddy Current Sweep.
 
         Parameters
@@ -4203,7 +4363,9 @@ class SetupMaxwell(Setup, PyAedtBase):
             sweep.create()
         self.update()
         self.auto_update = legacy_update
-        self.sweeps.append(sweep)
+        if self._sweeps is None:
+            self._sweeps = []
+        self._sweeps.append(sweep)
         return sweep
 
     @pyaedt_function_handler()
@@ -4217,16 +4379,20 @@ class SetupMaxwell(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupMaxwell
-        >>> obj = SetupMaxwell()
-        >>> obj.delete_all_eddy_current_sweeps()
+        >>> from ansys.aedt.core import Maxwell2d
+        >>> m2d = Maxwell2d()
+        >>> setup = m2d.create_setup()
+        >>> setup.delete_all_eddy_current_sweeps()
 
         """
         if self.setuptype not in [7, 60]:
             self._app.logger.warning("This method only applies to Maxwell Eddy Current Solution.")
             return False
         self.props.pop("SweepRanges")
-        self._sweeps.clear()
+        if self._sweeps:
+            self._sweeps.clear()
+        else:
+            self._sweeps = []
         self.update()
         return True
 
@@ -4269,9 +4435,10 @@ class SetupMaxwell(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupMaxwell
-        >>> obj = SetupMaxwell()
-        >>> obj.enable_control_program(control_program_path=r"C:\\Temp\\example.txt")
+        >>> from ansys.aedt.core import Maxwell2d
+        >>> m2d = Maxwell2d()
+        >>> setup = m2d.create_setup()
+        >>> setup.enable_control_program(control_program_path="example.py")
 
         """
         if self._app.solution_type not in ["Transient", "TransientXY", "TransientZ"]:
@@ -4344,7 +4511,8 @@ class SetupMaxwell(Setup, PyAedtBase):
         --------
         >>> import ansys.aedt.core
         >>> m2d = ansys.aedt.core.Maxwell2d(version="2026.1")
-        >>> m2d.solution_type = SOLUTIONS.Maxwell2d.TransientXY
+        >>> from ansys.aedt.core.generic.constants import SolutionsMaxwell2D
+        >>> m2d.solution_type = SolutionsMaxwell2D.TransientXY
         >>> setup = m2d.create_setup()
         >>> setup.set_save_fields(
         ...     enable=True, range_type="Custom", subrange_type="LinearStep", start=0, stop=8, count=2, units="ms"
@@ -4468,9 +4636,10 @@ class SetupMaxwell(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_setup import SetupMaxwell
-        >>> obj = SetupMaxwell()
-        >>> obj.export_matrix(matrix_type=1, matrix_name=1, output_file=r"C:\\Temp\\example.txt")
+        >>> from ansys.aedt.core import Maxwell2d
+        >>> m2d = Maxwell2d()
+        >>> setup = m2d.create_setup()
+        >>> setup.export_matrix(matrix_type="RL", matrix_name="matrix_name", output_file="example.txt")
 
         """
         if matrix_type == "RL":
@@ -4539,7 +4708,7 @@ class SetupQ3D(Setup, PyAedtBase):
         sweep_type: str = "Discrete",
         interpolation_tol: float = 0.5,
         interpolation_max_solutions: int = 250,
-    ) -> "SweepMatrix" | bool:
+    ) -> SweepMatrix | bool:
         """Create a sweep with the specified number of points.
 
         Parameters
@@ -4777,7 +4946,8 @@ class SetupQ3D(Setup, PyAedtBase):
         else:
             save0 = save_single_field
             if add_subranges:
-                save_single_field = [save0] * len(freq)
+                freq_mult = len(freq) if isinstance(freq, list) else 1
+                save_single_field = [save0] * freq_mult
 
         if name in [sweep.name for sweep in self.sweeps]:
             oldname = name
@@ -4795,6 +4965,10 @@ class SetupQ3D(Setup, PyAedtBase):
             for f, s in zip(freq, save_single_field):
                 sweepdata.add_subrange(range_type="SinglePoints", start=f, unit=unit, save_single_fields=s)
         sweepdata.update()
+
+        # Reset children to populate again the new properties
+        self._children = {}
+
         self._app.logger.info(f"Single point sweep {name} has been correctly created")
         return sweepdata
 
@@ -4831,11 +5005,19 @@ class SetupQ3D(Setup, PyAedtBase):
         if self.setuptype in [14, 30, 31]:
             sweep_n = SweepMatrix(self, name=name, sweep_type=sweep_type)
         sweep_n.create()
-        self.sweeps.append(sweep_n)
+
+        if self._sweeps is None:
+            self._sweeps = []
+        self._sweeps.append(sweep_n)
+
         for setup in self._app.setups:
             if self.name == setup.name:
                 setup.sweeps.append(sweep_n)
                 break
+
+        # Reset children to populate again the new properties
+        self._children = {}
+
         return sweep_n
 
     @pyaedt_function_handler()
@@ -5065,7 +5247,8 @@ class SetupIcepak(Setup, PyAedtBase):
 
         Examples
         --------
-        >>> ipk = ansys.aedt.core.Icepak()
+        >>> from ansys.aedt.core import Icepak
+        >>> ipk = Icepak()
         >>> setup = ipk.get_setup("Setup1")
         >>> setup.start_continue_from_previous_setup(design="IcepakDesign1", solution="Setup1 : SteadyState")
 

--- a/src/ansys/aedt/core/modules/solve_setup.py
+++ b/src/ansys/aedt/core/modules/solve_setup.py
@@ -3396,9 +3396,6 @@ class SetupHFSS(Setup, PyAedtBase):
                 sweepdata.add_subrange(range_type="SinglePoints", start=f, unit=unit, save_single_fields=s)
         sweepdata.update()
 
-        # Reset children to populate again the new properties
-        self._children = {}
-
         self._app.logger.info(f"Single point sweep {name} has been correctly created")
         return sweepdata
 
@@ -4801,7 +4798,7 @@ class SetupQ3D(Setup, PyAedtBase):
         name: str = None,
         save_fields: bool = True,
         sweep_type: str = "Discrete",
-    ) -> "SweepMatrix" | bool:
+    ) -> SweepMatrix | bool:
         """Create a sweep with a specified frequency step.
 
         Parameters
@@ -4883,7 +4880,7 @@ class SetupQ3D(Setup, PyAedtBase):
         name: str = None,
         save_single_field: bool | list = True,
         save_fields: bool = False,
-    ) -> "SweepMatrix" | bool:
+    ) -> SweepMatrix | bool:
         """Create a sweep with a single frequency point.
 
         Parameters
@@ -4966,14 +4963,11 @@ class SetupQ3D(Setup, PyAedtBase):
                 sweepdata.add_subrange(range_type="SinglePoints", start=f, unit=unit, save_single_fields=s)
         sweepdata.update()
 
-        # Reset children to populate again the new properties
-        self._children = {}
-
         self._app.logger.info(f"Single point sweep {name} has been correctly created")
         return sweepdata
 
     @pyaedt_function_handler()
-    def add_sweep(self, name: str = None, sweep_type: str = "Interpolating", **props) -> "SweepMatrix":
+    def add_sweep(self, name: str = None, sweep_type: str = "Interpolating", **props) -> SweepMatrix:
         """Add a sweep to the project.
 
         Parameters
@@ -5021,7 +5015,7 @@ class SetupQ3D(Setup, PyAedtBase):
         return sweep_n
 
     @pyaedt_function_handler()
-    def get_sweep(self, name: str = None) -> "SweepMatrix" | bool:
+    def get_sweep(self, name: str = None) -> SweepMatrix | bool:
         """Get the frequency sweep object of a given sweep.
 
         Parameters

--- a/src/ansys/aedt/core/modules/solve_sweeps.py
+++ b/src/ansys/aedt/core/modules/solve_sweeps.py
@@ -895,6 +895,7 @@ class SweepMatrix(SweepCommon):
         count: float = None,
         unit: str = "GHz",
         clear: bool = False,
+        save_single_fields: bool = False,
     ) -> bool:
         """Add a subrange to the sweep.
 
@@ -914,6 +915,9 @@ class SweepMatrix(SweepCommon):
         clear : bool, optional
             Whether to replace the subrange. The default is ``False``, in which case
             subranges are appended.
+        save_single_fields : bool, optional
+            Whether to save the fields of the single point. The default is ``False``.
+            This parameter is used only for ``range_type="SinglePoints"``.
 
         Returns
         -------
@@ -922,9 +926,10 @@ class SweepMatrix(SweepCommon):
 
         Examples
         --------
-        >>> from ansys.aedt.core.modules.solve_sweeps import SweepMatrix
-        >>> obj = SweepMatrix()
-        >>> obj.add_subrange(range_type=1, start=[0, 0, 0])
+        >>> from ansys.aedt.core import Q3d
+        >>> app = Q3d()
+        >>> setup = app.create_setup()
+        >>> setup.create_single_point_sweep(save_single_field=[True, False, False], freq=[6, 10, 12], unit="GHz")
 
         """
         if clear:
@@ -951,6 +956,10 @@ class SweepMatrix(SweepCommon):
         elif range_type == "LogScale":
             sweep_range["RangeEnd"] = str(end) + unit
             sweep_range["RangeSamples"] = count
+        elif range_type == "SinglePoints":
+            sweep_range["RangeEnd"] = str(start) + unit
+            sweep_range["SaveSingleField"] = save_single_fields
+
         if not self.props.get("SweepRanges") or not self.props["SweepRanges"].get("Subrange"):
             self.props["SweepRanges"] = {"Subrange": []}
         self.props["SweepRanges"]["Subrange"].append(sweep_range)

--- a/tests/system/general/test_hfss.py
+++ b/tests/system/general/test_hfss.py
@@ -415,31 +415,38 @@ def test_create_single_point_sweep(aedt_app) -> None:
         renormalize=False,
         deembed=5,
     )
-    assert setup.update()
-    assert aedt_app.create_single_point_sweep(
+
+    s1 = aedt_app.create_single_point_sweep(
         setup="MySetup",
         unit="MHz",
         freq=1.2e3,
     )
+    assert setup.children[s1.name].properties["Start"] == "1200MHz"
+    assert setup.children[s1.name].properties["Stop"] == "1200MHz"
+    setup._children = {}
+
     setup = aedt_app.get_setup("MySetup")
-    assert setup.create_single_point_sweep(
+    s2 = setup.create_single_point_sweep(
         unit="GHz",
         freq=1.2,
         save_single_field=False,
     )
-    assert aedt_app.create_single_point_sweep(
+    assert setup.children[s2.name].properties["Start"] == "1.2GHz"
+    assert setup.children[s2.name].properties["Stop"] == "1.2GHz"
+
+    s3 = aedt_app.create_single_point_sweep(
         setup="MySetup",
         unit="GHz",
         freq=[1.1, 1.2, 1.3],
     )
-    assert aedt_app.create_single_point_sweep(
+    assert setup.children[s3.name].properties["Start"] == "1.1GHz"
+    assert setup.children[s3.name].properties["Stop"] == "1.3GHz"
+
+    s4 = aedt_app.create_single_point_sweep(
         setup="MySetup", unit="GHz", freq=[1.1e1, 1.2e1, 1.3e1], save_single_field=[True, False, True]
     )
-
-    with pytest.raises(AttributeError):
-        aedt_app.create_single_point_sweep(
-            setup="MySetup", unit="GHz", freq=[1, 2e2, 3.4], save_single_field=[True, False]
-        )
+    assert setup.children[s4.name].properties["Start"] == "11GHz"
+    assert setup.children[s4.name].properties["Stop"] == "13GHz"
 
 
 def test_delete_setup(aedt_app) -> None:

--- a/tests/system/layout/test_3dlayout_modeler.py
+++ b/tests/system/layout/test_3dlayout_modeler.py
@@ -696,33 +696,28 @@ def test_create_linear_step_sweep(aedt_app) -> None:
 
 def test_create_single_point_sweep(aedt_app) -> None:
     setup_name = "RF_create_single_point"
-    aedt_app.create_setup(name=setup_name)
+    setup = aedt_app.create_setup(name=setup_name)
     sweep5 = aedt_app.create_single_point_sweep(
-        setup=setup_name,
+        setup=setup.name,
         unit="MHz",
         freq=1.23,
         name="RFBoardSingle",
         save_fields=True,
     )
     assert sweep5.props["Sweeps"]["Data"] == "1.23MHz"
+    assert setup.children[sweep5.name].properties["Start"] == "1.23MHz"
+    assert setup.children[sweep5.name].properties["Stop"] == "1.23MHz"
+
     sweep6 = aedt_app.create_single_point_sweep(
-        setup=setup_name,
+        setup=setup.name,
         unit="GHz",
         freq=[1, 2, 3, 4],
         name="RFBoardSingle",
         save_fields=False,
     )
     assert sweep6.props["Sweeps"]["Data"] == "1GHz 2GHz 3GHz 4GHz"
-
-    with pytest.raises(AttributeError) as execinfo:
-        aedt_app.create_single_point_sweep(
-            setup=setup_name,
-            unit="GHz",
-            freq=[],
-            name="RFBoardSingle",
-            save_fields=False,
-        )
-        assert execinfo.args[0] == "Frequency list is empty. Specify at least one frequency point."
+    assert setup.children[sweep6.name].properties["Start"] == "1GHz"
+    assert setup.children[sweep6.name].properties["Stop"] == "4GHz"
 
 
 def test_delete_setup(aedt_app) -> None:

--- a/tests/system/solvers/test_q3d.py
+++ b/tests/system/solvers/test_q3d.py
@@ -92,8 +92,8 @@ def test_create_discrete_sweep(aedt_app) -> None:
     sweep = setup.create_frequency_sweep(name="mysweep", start_frequency=1, unit="GHz")
     assert sweep
     assert sweep.props["RangeStart"] == "1GHz"
-
-    assert setup.create_linear_step_sweep(
+    assert setup.children[sweep.name].properties["Start"] == "1GHz"
+    sweep2 = setup.create_linear_step_sweep(
         name="StepFast",
         unit="GHz",
         start_frequency=1,
@@ -101,6 +101,8 @@ def test_create_discrete_sweep(aedt_app) -> None:
         step_size=0.1,
         sweep_type="Interpolating",
     )
+    assert setup.children[sweep2.name].properties["Start"] == "1GHz"
+    assert setup.children[sweep2.name].properties["Stop"] == "20GHz"
 
 
 def test_create_linear_sweep(aedt_app) -> None:
@@ -126,9 +128,14 @@ def test_create_linear_sweep(aedt_app) -> None:
 
 def test_create_single_point_sweep(aedt_app) -> None:
     setup = aedt_app.create_setup()
-    assert setup.create_single_point_sweep(
-        save_fields=True,
-    )
+    setup.props["SaveFields"] = True
+
+    sweep = setup.create_single_point_sweep(save_fields=True, freq=5, unit="GHz")
+    assert setup.children[sweep.name].properties["Start"] == "5GHz"
+
+    sweep2 = setup.create_single_point_sweep(save_single_field=[True, False, False], freq=[6, 10, 12], unit="GHz")
+    assert setup.children[sweep2.name].properties["Start"] == "6GHz"
+    assert setup.children[sweep2.name].properties["Stop"] == "12GHz"
 
 
 def test_create_frequency_sweep(aedt_app) -> None:


### PR DESCRIPTION
## Description
Provided frequency list was missing the first element. This PR fixes this problem and also add more robustness to the tests.

Application: hfss, maxwell, q3d
AEDT-Version: 25.2, 26.1
Platform: windows, linux

## Issue linked
Close #7885 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
