### PR TITLE
TEST: Rework xfail logic to avoid skips in pyedb

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -11,6 +11,7 @@ env:
   ON_CI: True
   PACKAGE_NAME: 'PyAEDT'
   PYTEST_ARGUMENTS: -vvv --color=yes -ra --durations=25 --maxfail=10 --cov=ansys.aedt.core --cov-report=html --cov-report=xml --junitxml=junit/test-results.xml
+  PYAEDT_EDB_XFAIL: "1"
   PYAEDT_LOCAL_SETTINGS_PATH: 'tests/pyaedt_settings.yaml'
   TESTS_VERSION: '3.10'
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -18,6 +18,7 @@ env:
   ON_CI: True
   PYTEST_ARGUMENTS: -vvv --color=yes -ra --durations=25 --maxfail=10 --junitxml=junit/test-results.xml --testmon
   PYTEST_ARGUMENTS_NON_TESTMON: -vvv --color=yes -ra --durations=25 --maxfail=10 --junitxml=junit/test-results.xml
+  PYAEDT_EDB_XFAIL: "1"
   PYAEDT_LOCAL_SETTINGS_PATH: 'tests/pyaedt_settings.yaml'
   TESTMON_DATAFILE: '.testmondata'
   TESTMON_CACHE_KEY_SOLVERS_WIN: 'testmondata-solvers-win'
@@ -1093,7 +1094,7 @@ jobs:
   system-tests-extensions-windows:
     name: Test extensions (windows)
     needs: [integration-tests]
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && needs.analyze-changes.outputs.skip_tests != 'true' && needs.analyze-changes.outputs.extensions_changed == 'true'
     runs-on: [ self-hosted, Windows, pyaedt ]
     steps:
       - name: Install Git and checkout project

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -9,6 +9,7 @@ env:
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
   TESTS_VERSION: '3.10'
   ON_CI: True
+  PYAEDT_EDB_XFAIL: "1"
   PYAEDT_LOCAL_SETTINGS_PATH: 'tests/pyaedt_settings.yaml'
   PYTEST_ARGUMENTS: '-vvv --color=yes -ra --durations=25 --maxfail=10 --cov=ansys.aedt.core --cov-report=html --cov-report=xml --junitxml=junit/test-results.xml'
 

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -17,6 +17,7 @@ env:
   ON_CI: True
   PYAEDT_DOC_BUILD_CHEATSHEET: False
   PYTEST_ARGUMENTS: -vvv --color=yes -ra --durations=25 --maxfail=10 --junitxml=junit/test-results.xml
+  PYAEDT_EDB_XFAIL: "1"
   PYAEDT_LOCAL_SETTINGS_PATH: 'tests/pyaedt_settings.yaml'
 
 concurrency:

--- a/.github/workflows/update-testmondata-cache.yml
+++ b/.github/workflows/update-testmondata-cache.yml
@@ -16,6 +16,7 @@ env:
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
   ON_CI: True
   PYTEST_ARGUMENTS: -vvv --color=yes -ra --durations=25 --maxfail=10 --cov=ansys.aedt.core --cov-report=html --cov-report=xml --junitxml=junit/test-results.xml --testmon
+  PYAEDT_EDB_XFAIL: "1"
   PYAEDT_LOCAL_SETTINGS_PATH: 'tests/pyaedt_settings.yaml'
   TESTMON_DATAFILE: '.testmondata'
   TESTMON_CACHE_KEY_SOLVERS_WIN: 'testmondata-solvers-win'

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -9,6 +9,7 @@ env:
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
   MAIN_PYTHON_VERSION: '3.10'
   ON_CI: True
+  PYAEDT_EDB_XFAIL: "1"
   PYAEDT_LOCAL_SETTINGS_PATH: 'tests/pyaedt_settings.yaml'
   PYTEST_ARGUMENTS: -vvv --color=yes -ra --durations=25 --maxfail=10 --junitxml=junit/test-results.xml --testmon
   PYTEST_ARGUMENTS_NON_TESTMON: -vvv --color=yes -ra --durations=25 --maxfail=10 --junitxml=junit/test-results.xml

--- a/doc/changelog.d/7915.test.md
+++ b/doc/changelog.d/7915.test.md
@@ -1,0 +1,1 @@
+Rework xfail logic to avoid skips in pyedb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,17 @@ USE_PYEDB_GRPC = config.get("use_pyedb_grpc", DEFAULT_CONFIG.get("use_pyedb_grpc
 os.environ["PYAEDT_DESKTOP_VERSION"] = DESKTOP_VERSION
 
 # ================================
+# Shared markers
+# ================================
+
+# Mark tests as xfail when PYAEDT_EDB_XFAIL=1
+# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
+edb_xfail = pytest.mark.xfail(
+    condition=os.environ.get("PYAEDT_EDB_XFAIL") == "1",
+    reason="PyEDB tests are unstable",
+)
+
+# ================================
 # PyAEDT settings
 # ================================
 

--- a/tests/system/extensions/test_configure_layout.py
+++ b/tests/system/extensions/test_configure_layout.py
@@ -33,6 +33,7 @@ from ansys.aedt.core import Hfss3dLayout
 from ansys.aedt.core.extensions.hfss3dlayout.resources.configure_layout.master_ui import ConfigureLayoutExtension
 from ansys.aedt.core.generic.general_methods import is_linux
 from tests import TESTS_EXTENSIONS_PATH
+from tests.conftest import edb_xfail
 
 TEST_SUBFOLDER = "T45"
 SI_VERSE_PROJECT = "ANSYS_SVP_V1_1_SFP"
@@ -40,8 +41,6 @@ EDB_PROJECT = "ANSYS_SVP_V1_1.aedb"
 SI_VERSE_PATH = TESTS_EXTENSIONS_PATH / "example_models" / TEST_SUBFOLDER / EDB_PROJECT
 
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
-# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
-edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
 @edb_xfail

--- a/tests/system/extensions/test_cutout.py
+++ b/tests/system/extensions/test_cutout.py
@@ -33,12 +33,11 @@ from ansys.aedt.core.extensions.hfss3dlayout.cutout import main
 from ansys.aedt.core.hfss3dlayout import Hfss3dLayout
 from tests import TESTS_EXTENSIONS_PATH
 from tests.conftest import DESKTOP_VERSION
+from tests.conftest import edb_xfail
 
 AEDB_FILE_NAME = "ANSYS-HSD_V1"
 TEST_SUBFOLDER = "T45"
 SI_VERSE_PATH = TESTS_EXTENSIONS_PATH / "example_models" / TEST_SUBFOLDER / (AEDB_FILE_NAME + ".aedb")
-# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
-edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
 @edb_xfail

--- a/tests/system/extensions/test_export_layout.py
+++ b/tests/system/extensions/test_export_layout.py
@@ -31,14 +31,13 @@ from ansys.aedt.core.extensions.hfss3dlayout.export_layout import main
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.hfss3dlayout import Hfss3dLayout
 from tests import TESTS_EXTENSIONS_PATH
+from tests.conftest import edb_xfail
 
 AEDB_FILE_NAME = "siverse_sfp"
 TEST_SUBFOLDER = "post_layout_design"
 AEDT_FILE_PATH = TESTS_EXTENSIONS_PATH / "example_models" / TEST_SUBFOLDER / (AEDB_FILE_NAME + ".aedb")
 
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
-# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
-edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
 def cleanup_files(*files) -> None:

--- a/tests/system/extensions/test_parametrize_edb.py
+++ b/tests/system/extensions/test_parametrize_edb.py
@@ -31,13 +31,12 @@ from ansys.aedt.core.extensions.hfss3dlayout.parametrize_edb import main
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from tests import TESTS_EXTENSIONS_PATH
+from tests.conftest import edb_xfail
 
 TEST_SUBFOLDER = "T45"
 EDB_PROJECT = "ANSYS-HSD_V1.aedb"
 SI_VERSE_PATH = TESTS_EXTENSIONS_PATH / "example_models" / TEST_SUBFOLDER / EDB_PROJECT
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
-# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
-edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
 @edb_xfail

--- a/tests/system/extensions/test_post_layout_design.py
+++ b/tests/system/extensions/test_post_layout_design.py
@@ -30,10 +30,9 @@ from ansys.aedt.core.extensions.hfss3dlayout.post_layout_design import PostLayou
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from tests import TESTS_EXTENSIONS_PATH
+from tests.conftest import edb_xfail
 
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
-# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
-edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
 def test_post_layout_design_data_class() -> None:

--- a/tests/system/extensions/test_via_clustering.py
+++ b/tests/system/extensions/test_via_clustering.py
@@ -33,10 +33,9 @@ from ansys.aedt.core.extensions.hfss3dlayout.via_clustering import main
 from ansys.aedt.core.generic.general_methods import is_linux
 from ansys.aedt.core.internal.errors import AEDTRuntimeError
 from tests import TESTS_EXTENSIONS_PATH
+from tests.conftest import edb_xfail
 
 pytestmark = pytest.mark.skipif(is_linux, reason="PyEDB stability issues on Linux")
-# NOTE: Remove marker below if 26R1 SP2 is installed or later version of AEDT is used.
-edb_xfail = pytest.mark.xfail(reason="PyEDB tests are unstable")
 
 
 @edb_xfail


### PR DESCRIPTION
## Description
Following discussion with @Samuelopez-ansys, reworking the xfail logic to avoid skipping tests when releases of pyedb are performed.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
