### PR TITLE
FIX: Improve the method change_stackup_type 

### DIFF
--- a/doc/changelog.d/7944.fixed.md
+++ b/doc/changelog.d/7944.fixed.md
@@ -1,0 +1,1 @@
+Improve the method change_stackup_type

--- a/src/ansys/aedt/core/modules/layer_stackup.py
+++ b/src/ansys/aedt/core/modules/layer_stackup.py
@@ -27,6 +27,8 @@
 The module provides all layer stackup functionalities for the Circuit and HFSS 3D Layout tools.
 """
 
+from copy import deepcopy
+
 from ansys.aedt.core.base import PyAedtBase
 from ansys.aedt.core.generic.constants import unit_converter
 from ansys.aedt.core.generic.data_handlers import str_to_bool
@@ -1809,6 +1811,255 @@ class Layers(PyAedtBase):
 
         return self.layers[newlayer.id]
 
+    @staticmethod
+    def _get_argument_value(args: list, argument: str):
+        if argument in args:
+            return args[args.index(argument) + 1]
+        return None
+
+    @staticmethod
+    def _set_argument_value(args: list, argument: str, value) -> None:
+        if argument in args:
+            args[args.index(argument) + 1] = value
+
+    @staticmethod
+    def _get_stackup_sublayer(layer_args: list) -> list | None:
+        for layer_arg in layer_args:
+            if isinstance(layer_arg, list) and layer_arg and layer_arg[0] == "NAME:Sublayer":
+                return layer_arg
+        return None
+
+    @classmethod
+    def _is_generated_dielectric_layer(cls, layer_args: list) -> bool:
+        name = cls._get_argument_value(layer_args, "Name:=")
+        return isinstance(name, str) and name.startswith("pyaedt_diel")
+
+    @staticmethod
+    def _get_layer_quantity(value, default_unit=None) -> Quantity:
+        quantity = Quantity(value)
+        if default_unit and not quantity.unit:
+            quantity = Quantity(value, default_unit)
+        return quantity
+
+    @classmethod
+    def _get_layer_value(cls, value, default_unit=None):
+        quantity = cls._get_layer_quantity(value, default_unit)
+        if default_unit and quantity.unit:
+            quantity = quantity.to(default_unit)
+        return float(quantity)
+
+    @staticmethod
+    def _format_layer_quantity(value, default_unit=None) -> str:
+        value = round(value, 12)
+        return str(Quantity(value, default_unit)) if default_unit else str(value)
+
+    @classmethod
+    def _add_layer_thickness(cls, first_thickness, second_thickness, default_unit=None) -> str:
+        try:
+            return str(
+                cls._get_layer_quantity(first_thickness, default_unit)
+                + cls._get_layer_quantity(second_thickness, default_unit)
+            )
+        except (TypeError, ValueError):
+            return f"({first_thickness})+({second_thickness})"
+
+    @classmethod
+    def _are_adjacent_stackup_sublayers(
+        cls, first_sublayer: list, second_sublayer: list, default_unit=None
+    ) -> tuple[bool, str | None]:
+        first_lower_elevation = cls._get_argument_value(first_sublayer, "LowerElevation:=")
+        first_thickness = cls._get_argument_value(first_sublayer, "Thickness:=")
+        second_lower_elevation = cls._get_argument_value(second_sublayer, "LowerElevation:=")
+        second_thickness = cls._get_argument_value(second_sublayer, "Thickness:=")
+        if None in [first_lower_elevation, first_thickness, second_lower_elevation, second_thickness]:
+            return False, None
+
+        try:
+            first_lower_elevation = cls._get_layer_quantity(first_lower_elevation, default_unit)
+            first_upper_elevation = first_lower_elevation + cls._get_layer_quantity(first_thickness, default_unit)
+            second_lower_elevation = cls._get_layer_quantity(second_lower_elevation, default_unit)
+            second_upper_elevation = second_lower_elevation + cls._get_layer_quantity(second_thickness, default_unit)
+        except (TypeError, ValueError):
+            return False, None
+
+        if abs(float(first_upper_elevation - second_lower_elevation)) <= 1e-12:
+            return True, str(first_lower_elevation)
+        if abs(float(second_upper_elevation - first_lower_elevation)) <= 1e-12:
+            return True, str(second_lower_elevation)
+        return False, None
+
+    @classmethod
+    def _ensure_unique_layer_ids(cls, args: list) -> list:
+        used_ids = set()
+        layer_ids = []
+        for layer_args in args:
+            if isinstance(layer_args, list):
+                layer_id = cls._get_argument_value(layer_args, "ID:=")
+                if layer_id is not None:
+                    layer_ids.append(int(layer_id))
+
+        next_id = max(layer_ids, default=0) + 1
+        for layer_args in args:
+            if not isinstance(layer_args, list):
+                continue
+            layer_id = cls._get_argument_value(layer_args, "ID:=")
+            if layer_id is None:
+                continue
+            layer_id = int(layer_id)
+            if layer_id in used_ids:
+                while next_id in used_ids:
+                    next_id += 1
+                cls._set_argument_value(layer_args, "ID:=", next_id)
+                used_ids.add(next_id)
+                next_id += 1
+            else:
+                used_ids.add(layer_id)
+        return args
+
+    @classmethod
+    def _get_stackup_sublayer_interval(cls, sublayer: list, default_unit=None) -> tuple[float, float] | None:
+        lower_elevation = cls._get_argument_value(sublayer, "LowerElevation:=")
+        thickness = cls._get_argument_value(sublayer, "Thickness:=")
+        if None in [lower_elevation, thickness]:
+            return None
+        try:
+            lower_elevation = cls._get_layer_value(lower_elevation, default_unit)
+            thickness = cls._get_layer_value(thickness, default_unit)
+        except (TypeError, ValueError):
+            return None
+        return lower_elevation, lower_elevation + thickness
+
+    @classmethod
+    def _split_dielectric_layers_on_signals(cls, args: list, default_unit=None) -> list:
+        """Split dielectric layer arguments around signal layers and update signal fill materials."""
+        signal_layers = []
+        for layer_args in args:
+            if (
+                isinstance(layer_args, list)
+                and layer_args
+                and layer_args[0] == "NAME:stackup layer"
+                and cls._get_argument_value(layer_args, "Type:=") == "signal"
+            ):
+                sublayer = cls._get_stackup_sublayer(layer_args)
+                interval = cls._get_stackup_sublayer_interval(sublayer, default_unit) if sublayer else None
+                if interval:
+                    signal_layers.append((layer_args, sublayer, interval))
+
+        split_args = []
+        split_index = 1
+        tolerance = 1e-12
+        for layer_args in args:
+            if not (
+                isinstance(layer_args, list)
+                and layer_args
+                and layer_args[0] == "NAME:stackup layer"
+                and cls._get_argument_value(layer_args, "Type:=") == "dielectric"
+            ):
+                split_args.append(layer_args)
+                continue
+
+            sublayer = cls._get_stackup_sublayer(layer_args)
+            interval = cls._get_stackup_sublayer_interval(sublayer, default_unit) if sublayer else None
+            material = cls._get_argument_value(sublayer, "Material:=") if sublayer else None
+            if not interval or not material:
+                split_args.append(layer_args)
+                continue
+
+            segments = [interval]
+            for _, signal_sublayer, signal_interval in signal_layers:
+                signal_lower, signal_upper = signal_interval
+                if signal_upper <= interval[0] + tolerance or signal_lower >= interval[1] - tolerance:
+                    continue
+
+                cls._set_argument_value(signal_sublayer, "FillMaterial:=", material)
+                new_segments = []
+                for segment_lower, segment_upper in segments:
+                    if signal_upper <= segment_lower + tolerance or signal_lower >= segment_upper - tolerance:
+                        new_segments.append((segment_lower, segment_upper))
+                        continue
+                    if segment_lower < signal_lower - tolerance:
+                        new_segments.append((segment_lower, signal_lower))
+                    if signal_upper < segment_upper - tolerance:
+                        new_segments.append((signal_upper, segment_upper))
+                segments = new_segments
+
+            segments.sort(key=lambda segment: segment[0], reverse=True)
+            for segment_index, (segment_lower, segment_upper) in enumerate(segments):
+                split_layer_args = layer_args if segment_index == 0 else deepcopy(layer_args)
+                split_sublayer = cls._get_stackup_sublayer(split_layer_args)
+                cls._set_argument_value(
+                    split_sublayer, "LowerElevation:=", cls._format_layer_quantity(segment_lower, default_unit)
+                )
+                cls._set_argument_value(
+                    split_sublayer,
+                    "Thickness:=",
+                    cls._format_layer_quantity(segment_upper - segment_lower, default_unit),
+                )
+                if segment_index > 0:
+                    name = cls._get_argument_value(split_layer_args, "Name:=")
+                    cls._set_argument_value(split_layer_args, "Name:=", f"{name}_split_{split_index}")
+                    split_index += 1
+                split_args.append(split_layer_args)
+        return cls._ensure_unique_layer_ids(split_args)
+
+    @classmethod
+    def _merge_adjacent_dielectric_layers(cls, args: list, default_unit=None) -> list:
+        """Merge adjacent dielectric layer arguments that use the same material."""
+        merged_args = []
+        previous_dielectric_layer_args = None
+        previous_dielectric_sublayer = None
+        previous_dielectric_material = None
+        previous_dielectric_index = None
+        for layer_args in args:
+            if not (
+                isinstance(layer_args, list)
+                and layer_args
+                and layer_args[0] == "NAME:stackup layer"
+                and cls._get_argument_value(layer_args, "Type:=") == "dielectric"
+            ):
+                merged_args.append(layer_args)
+                continue
+
+            sublayer = cls._get_stackup_sublayer(layer_args)
+            material = cls._get_argument_value(sublayer, "Material:=") if sublayer else None
+
+            if (
+                material
+                and previous_dielectric_material
+                and material.casefold() == previous_dielectric_material.casefold()
+            ):
+                layers_are_adjacent, lower_elevation = cls._are_adjacent_stackup_sublayers(
+                    previous_dielectric_sublayer, sublayer, default_unit
+                )
+                if layers_are_adjacent:
+                    merge_into_current = cls._is_generated_dielectric_layer(
+                        previous_dielectric_layer_args
+                    ) and not cls._is_generated_dielectric_layer(layer_args)
+                    target_sublayer = sublayer if merge_into_current else previous_dielectric_sublayer
+                    thickness = cls._add_layer_thickness(
+                        cls._get_argument_value(previous_dielectric_sublayer, "Thickness:="),
+                        cls._get_argument_value(sublayer, "Thickness:="),
+                        default_unit,
+                    )
+                    cls._set_argument_value(target_sublayer, "Thickness:=", thickness)
+                    if lower_elevation:
+                        cls._set_argument_value(target_sublayer, "LowerElevation:=", lower_elevation)
+                    if merge_into_current:
+                        merged_args.pop(previous_dielectric_index)
+                        merged_args.append(layer_args)
+                        previous_dielectric_layer_args = layer_args
+                        previous_dielectric_sublayer = sublayer
+                        previous_dielectric_material = material
+                        previous_dielectric_index = len(merged_args) - 1
+                    continue
+
+            merged_args.append(layer_args)
+            previous_dielectric_layer_args = layer_args
+            previous_dielectric_sublayer = sublayer
+            previous_dielectric_material = material
+            previous_dielectric_index = len(merged_args) - 1
+        return cls._ensure_unique_layer_ids(merged_args)
+
     @pyaedt_function_handler()
     def change_stackup_type(self, mode: str = "MultiZone", number_zones: int = 3) -> bool:
         """Change the stackup type between Multizone, Overlap and Laminate.
@@ -1844,12 +2095,28 @@ class Layers(PyAedtBase):
         else:
             self.logger.error("Stackup mode has to be Multizone, Overlap or Laminate.")
             return False
-        for v in list(self.layers.values()):
+        len_ll = len(list(self.layers.values())) + 1
+        for idx, v in enumerate(list(self.layers.values())):
             if v.type in ["signal", "dielectric"]:
                 if mode.lower() == "multizone":
                     v._zones = [i for i in range(number_zones)]
                 else:
                     v._zones = []
+            if mode.lower() == "overlap" and v.type == "signal":
+                if v.fill_material != "":
+                    new_v = Layer(self, layertype="dielectric")
+                    new_v.name = f"pyaedt_diel_{idx}"
+                    new_v._thickness = v.thickness
+                    new_v._thickness_units = v.thickness_units
+                    new_v._lower_elevation = v.lower_elevation
+                    new_v._material = self._app.materials[v.fill_material].name
+                    new_v.id = len_ll
+                    len_ll += 1
+                    args.append(new_v._get_layer_arg)
             args.append(v._get_layer_arg)
+        if mode.lower() == "overlap":
+            args = self._merge_adjacent_dielectric_layers(args, self.LengthUnit)
+        else:
+            args = self._split_dielectric_layers_on_signals(args, self.LengthUnit)
         self.oeditor.ChangeLayers(args)
         return True

--- a/src/ansys/aedt/core/modules/layer_stackup.py
+++ b/src/ansys/aedt/core/modules/layer_stackup.py
@@ -2095,7 +2095,7 @@ class Layers(PyAedtBase):
         else:
             self.logger.error("Stackup mode has to be Multizone, Overlap or Laminate.")
             return False
-        len_ll = len(list(self.layers.values())) + 1
+        len_layers_list = len(list(self.layers.values())) + 1
         for idx, v in enumerate(list(self.layers.values())):
             if v.type in ["signal", "dielectric"]:
                 if mode.lower() == "multizone":
@@ -2110,8 +2110,8 @@ class Layers(PyAedtBase):
                     new_v._thickness_units = v.thickness_units
                     new_v._lower_elevation = v.lower_elevation
                     new_v._material = self._app.materials[v.fill_material].name
-                    new_v.id = len_ll
-                    len_ll += 1
+                    new_v.id = len_layers_list
+                    len_layers_list += 1
                     args.append(new_v._get_layer_arg)
             args.append(v._get_layer_arg)
         if mode.lower() == "overlap":

--- a/tests/unit/test_layer_stackup.py
+++ b/tests/unit/test_layer_stackup.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+from ansys.aedt.core.modules.layer_stackup import Layers
+
+
+@pytest.fixture(scope="module", autouse=True)
+def desktop() -> None:
+    """Override the desktop fixture to DO NOT open the Desktop when running this test class."""
+    return
+
+
+def _dielectric_layer(name, thickness, lower_elevation, material="FR4_epoxy", layer_id=None):
+    layer_args = [
+        "NAME:stackup layer",
+        "Name:=",
+        name,
+        "Type:=",
+        "dielectric",
+        [
+            "NAME:Sublayer",
+            "Thickness:=",
+            thickness,
+            "LowerElevation:=",
+            lower_elevation,
+            "Material:=",
+            material,
+        ],
+    ]
+    if layer_id is not None:
+        layer_args[3:3] = ["ID:=", layer_id]
+    return layer_args
+
+
+def _signal_layer(name, thickness, lower_elevation, layer_id=None, fill_material="FR4_epoxy"):
+    layer_args = [
+        "NAME:stackup layer",
+        "Name:=",
+        name,
+        "Type:=",
+        "signal",
+        [
+            "NAME:Sublayer",
+            "Thickness:=",
+            thickness,
+            "LowerElevation:=",
+            lower_elevation,
+            "Material:=",
+            "copper",
+            "FillMaterial:=",
+            fill_material,
+        ],
+    ]
+    if layer_id is not None:
+        layer_args[3:3] = ["ID:=", layer_id]
+    return layer_args
+
+
+def test_merge_adjacent_dielectric_layers() -> None:
+    args = [
+        "NAME:layers",
+        "Mode:=",
+        "Overlap",
+        ["NAME:pps"],
+        _dielectric_layer("pyaedt_diel_0", "0.2", "1200mm", layer_id=12),
+        _signal_layer("top2", "0.2meter", "1200mm", layer_id=10),
+        _dielectric_layer("die_1", "0.3meter", "900mm", "fr4_epoxy", layer_id=9),
+        _dielectric_layer("pyaedt_diel_2", "0.2", "700mm", layer_id=13),
+        _dielectric_layer("diel3", "1mm", "10mm", layer_id=10),
+    ]
+
+    merged_args = Layers._merge_adjacent_dielectric_layers(args, default_unit="meter")
+
+    assert len(merged_args) == len(args) - 2
+    layer_names = [
+        layer_arg[2]
+        for layer_arg in merged_args
+        if isinstance(layer_arg, list) and layer_arg[0] == "NAME:stackup layer"
+    ]
+    assert "pyaedt_diel_0" not in layer_names
+    assert "pyaedt_diel_2" not in layer_names
+    assert merged_args[4][2] == "top2"
+    assert merged_args[5][2] == "die_1"
+    sublayer = Layers._get_stackup_sublayer(merged_args[5])
+    assert Layers._get_argument_value(sublayer, "Thickness:=") == "0.7meter"
+    assert Layers._get_argument_value(sublayer, "LowerElevation:=") == "700mm"
+    assert merged_args[-1][2] == "diel3"
+    layer_ids = [
+        Layers._get_argument_value(layer_arg, "ID:=")
+        for layer_arg in merged_args
+        if isinstance(layer_arg, list) and Layers._get_argument_value(layer_arg, "ID:=") is not None
+    ]
+    assert len(layer_ids) == len(set(layer_ids))
+
+
+def test_split_dielectric_layers_on_signals() -> None:
+    args = [
+        "NAME:layers",
+        "Mode:=",
+        "Laminate",
+        ["NAME:pps"],
+        _dielectric_layer("die", "1.4meter", "0mm", "FR4_epoxy", layer_id=7),
+        _signal_layer("bot", "0.2meter", "0mm", layer_id=8, fill_material="air"),
+        _signal_layer("top", "0.2meter", "700mm", layer_id=6, fill_material="air"),
+        _signal_layer("top2", "0.2meter", "1200mm", layer_id=10, fill_material="air"),
+    ]
+
+    split_args = Layers._split_dielectric_layers_on_signals(args, default_unit="meter")
+    dielectrics = [
+        layer_arg
+        for layer_arg in split_args
+        if isinstance(layer_arg, list) and Layers._get_argument_value(layer_arg, "Type:=") == "dielectric"
+    ]
+
+    assert len(dielectrics) == 2
+    first_sublayer = Layers._get_stackup_sublayer(dielectrics[0])
+    second_sublayer = Layers._get_stackup_sublayer(dielectrics[1])
+    assert Layers._get_argument_value(first_sublayer, "LowerElevation:=") == "0.9meter"
+    assert Layers._get_argument_value(first_sublayer, "Thickness:=") == "0.3meter"
+    assert Layers._get_argument_value(second_sublayer, "LowerElevation:=") == "0.2meter"
+    assert Layers._get_argument_value(second_sublayer, "Thickness:=") == "0.5meter"
+    for layer_arg in split_args:
+        if isinstance(layer_arg, list) and Layers._get_argument_value(layer_arg, "Type:=") == "signal":
+            sublayer = Layers._get_stackup_sublayer(layer_arg)
+            assert Layers._get_argument_value(sublayer, "FillMaterial:=") == "FR4_epoxy"


### PR DESCRIPTION
## Description
Improve the method change_stackup_type to automatically merge dielectric layers as expected in case of switch from laminate to overlap or viceversa.
When switching from laminate to overlapping there is a dielectric simplification carried out in the UI which was not performed into the pyaedt method. the new alghoritm mimic the same behaviour trying to merge the dielectrics during the stackup type change.

  Application:  hfss3dlayout
  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1

## Issue linked
#7943 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
