### PR TITLE
FIX: fix a bug in IbisReader 

### DIFF
--- a/doc/changelog.d/7945.fixed.md
+++ b/doc/changelog.d/7945.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug in IbisReader

--- a/src/ansys/aedt/core/generic/ibis_reader.py
+++ b/src/ansys/aedt/core/generic/ibis_reader.py
@@ -1827,10 +1827,12 @@ class IbisReader(PyAedtBase):
         current_string = current_string[len(l_value) + 1 :].strip()
 
         c_value = self.get_first_parameter(current_string)
-
+        pin_name = pin_name.replace("/", "")
+        component_name = component_name.replace("/", "")
+        ibis_name = ibis.name.replace("/", "")
         pin = Pin(
-            pin_name + "_" + component_name + "_" + ibis.name,
-            signal + "_" + component_name + "_" + ibis.name,
+            pin_name + "_" + component_name + "_" + ibis_name,
+            signal + "_" + component_name + "_" + ibis_name,
             ibis,
         )
         pin.short_name = pin_name
@@ -1956,12 +1958,15 @@ class AMIReader(IbisReader, PyAedtBase):
         self.read_model(ibis, model)
 
         buffers = {}
+        ami_name = ami_name.replace("/", "")
         for model_selector in ibis.model_selectors:
-            buffer = Buffer(ami_name, model_selector.name, self)
+            model_selector_name = model_selector.name.replace("/", "")
+            buffer = Buffer(ami_name, model_selector_name, self)
             buffers[buffer.short_name] = buffer
 
         for model in ibis.models:
-            buffer = Buffer(ami_name, model.name, self)
+            model_selector_name = model.name.replace("/", "")
+            buffer = Buffer(ami_name, model_selector_name, self)
             buffers[buffer.short_name] = buffer
 
         ibis.buffers = buffers


### PR DESCRIPTION
## Description
Fix a bug in IbisReader  which was preventing placing ibis when special symbol "/" is present


  Application:  circuit
  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
  Platform: windows, linux, rocky

## Issue linked
Fix a bug in IbisReader  which was preventing placing ibis when special symbol "/" is present

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
