### PR TITLE
FIX: Spisim ICN calculation 

### DIFF
--- a/doc/changelog.d/7946.fixed.md
+++ b/doc/changelog.d/7946.fixed.md
@@ -1,0 +1,1 @@
+Spisim ICN calculation

--- a/src/ansys/aedt/core/visualization/post/spisim.py
+++ b/src/ansys/aedt/core/visualization/post/spisim.py
@@ -432,6 +432,21 @@ class SpiSim(PyAedtBase):
             except IndexError:
                 self.logger.error(f"Failed to compute {parameter_name}. Check input parameters and retry")
                 return False
+        elif parameter_name == "ccICN":
+            try:
+                with open_file(out_file, "r") as infile:
+                    txt = infile.read()
+                    m = re.search(r"\[ParmDat\]\s*:\s*ccICNNext\s*=\s*([\d.]+)\s*,\s*ccICNFext\s*=\s*([\d.]+)", txt)
+                    if m:
+                        return [float(m.group(1)) * 0.001, float(m.group(2)) * 0.001]
+
+                self.logger.error(
+                    f"Failed to compute {parameter_name}. Check input parameters and retry"
+                )  # pragma: no cover
+                return False  # pragma: no cover
+            except IndexError:
+                self.logger.error(f"Failed to compute {parameter_name}. Check input parameters and retry")
+                return False
         return False
 
     @pyaedt_function_handler()
@@ -599,7 +614,7 @@ class SpiSim(PyAedtBase):
         bandwidth: float | None = None,
         use_pcie_icn: bool = False,
         compute_retries: int = 3,
-    ) -> bool | float:
+    ) -> bool | float | list:
         """Compute the integrated crosstalk noise (ICN) in volts using Ansys SPISIM from S-parameter file.
 
         .. warning::
@@ -630,7 +645,7 @@ class SpiSim(PyAedtBase):
 
         Returns
         -------
-        bool or float
+        bool or float or list
             ICN in volts from the SPISIM executable command, ``False`` when failed.
 
         Examples
@@ -688,7 +703,7 @@ class SpiSim(PyAedtBase):
         nb_retry = 0
         while nb_retry < compute_retries:
             out_processing = self.__compute_spisim("CalcICN", config_file)
-            results = self.__get_output_parameter_from_result(out_processing, "ICN")
+            results = self.__get_output_parameter_from_result(out_processing, "ICN" if not use_pcie_icn else "ccICN")
             if results:
                 return results
             self.logger.warning("Failing to compute ICN, retrying...")

--- a/tests/system/solvers/test_analyze.py
+++ b/tests/system/solvers/test_analyze.py
@@ -700,6 +700,15 @@ def test_compute_icn(test_tmp_dir) -> None:
         compute_retries=10,
     )
     assert abs(icn - 0.000770524135501) < SMALL_NUMBER
+    icn = spisim.compute_icn(
+        port_order="EvenOdd",
+        fext_s4p=str(fext_s4p),
+        next_s4p=str(next_s4p),
+        bandwidth=10e9,
+        compute_retries=10,
+        use_pcie_icn=True,
+    )
+    assert isinstance(icn, list)
 
 
 def test_compute_com(test_tmp_dir) -> None:


### PR DESCRIPTION
## Description
When computing ICN spisim returns two parameters in case of ICN computed using PCIE criteria.

  Application:  circuit
  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
  Platform: windows, linux, rocky

## Issue linked
When computing ICN spisim returns two parameters in case of ICN computed using PCIE criteria.

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
