### PR TITLE
CI: Fix job needs to avoid running without approval

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -309,6 +309,7 @@ jobs:
       attestations: write   # Required to create and publish build attestations (SLSA provenance)
       contents: read        # Required to read repository content for building
       id-token: write       # Required for OIDC token generation (for provenance signing)
+    needs: [analyze-changes]
     uses: ./.github/workflows/reusable-smoke-tests-rocky.yml
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'

--- a/doc/changelog.d/7964.maintenance.md
+++ b/doc/changelog.d/7964.maintenance.md
@@ -1,0 +1,1 @@
+Fix job needs to avoid running without approval


### PR DESCRIPTION
## Description
The rocky wheelhouse job was running on dependabot PR without requiring approval. The changes ensure that this doesn't happen anymore and that this job is aligned with the logic for others.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
