### PR TITLE
FIX: import circuit netlist

### DIFF
--- a/doc/changelog.d/7973.fixed.md
+++ b/doc/changelog.d/7973.fixed.md
@@ -1,0 +1,1 @@
+Import circuit netlist

--- a/src/ansys/aedt/core/circuit.py
+++ b/src/ansys/aedt/core/circuit.py
@@ -173,9 +173,10 @@ class Circuit(FieldAnalysisCircuit, ScatteringMethods, PyAedtBase):
         aedt_process_id: int | None = None,
         remove_lock: bool | None = False,
     ) -> None:
+        application = "CIRCUITNETLIST" if str(project).endswith(".cir") else "CIRCUIT"
         FieldAnalysisCircuit.__init__(
             self,
-            "CIRCUIT",
+            application,
             project,
             design,
             solution_type,


### PR DESCRIPTION
## Description


Circuit.__init__ is hardcoded to design type CIRCUIT. This is a problem when importing a .cir file. The fix is to change type to CIRCUITNETLIST when the import file suffix is .cir. 

```
from pathlib import Path
import uuid

from ansys.aedt.core import Circuit

WDIR = Path(__file__).parent

app = Circuit(
    project=str(WDIR / "test.cir"),
    version="2026.1",
    non_graphical=False,
)
app.save_project(file_name=WDIR / f"test_{uuid.uuid4()[:4]}.aedt")
app.release_desktop(False, False)
```
## Issue linked
#7971 #7972 

## Checklist