### PR TITLE
DOCS: Use `force-orphan: false` in ansys/actions/doc-deploy-dev and stable actions

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1301,4 +1301,5 @@ jobs:
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          force-orphan: false
           use-python-cache: false

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -52,3 +52,4 @@ jobs:
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          force-orphan: false

--- a/doc/changelog.d/8003.documentation.md
+++ b/doc/changelog.d/8003.documentation.md
@@ -1,0 +1,1 @@
+Use \`force-orphan: false\` in ansys/actions/doc-deploy-dev and stable actions


### PR DESCRIPTION
## Description
This PR is setting the `force-orphan` option to `false` in `ansys/actions/doc-deploy-stable` and `ansys/actions/doc-deploy-dev`, aiming to fix the `pages build and deployment` workflow failing on the `deploy` job for a few days now.

The logs provided on the `pages build and deployment` workflow (as well as observations on other projects) suggest that keeping the `gh-pages` branch orphan results in a too large single commit for the project docs, generating a very large artifact that cannot be processed by the `deploy-pages` action of the workflow.
It is assumed that the size of the docs contained in the `gh-branch` (with many older versions - currently up to 0.14) is not in itself responsible for the deployment failure, as the `deploy-pages` action is supposed to handle artifacts of up to 10 GB. This extensive documentation should therefore be deployed properly if updates were introduced gradually on the `gh-pages` branch.

If these changes were to provide a solution to the current problem, they would offer the advantage of not having to discard the documentation for older versions of pyaedt from the `gh-pages` branch.

## Issue linked
N/A

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
