### PR TITLE
FIX: double click lockfile

### DIFF
--- a/doc/changelog.d/8006.fixed.md
+++ b/doc/changelog.d/8006.fixed.md
@@ -1,0 +1,1 @@
+Double click lockfile

--- a/src/ansys/aedt/core/extensions/hfss/fresnel.py
+++ b/src/ansys/aedt/core/extensions/hfss/fresnel.py
@@ -827,8 +827,6 @@ class FresnelExtension(ExtensionHFSSCommon):
         self.active_setup_sweep = self.active_setup.name + " : " + self.sweep.name
         app.create_fresnel_variables(self.active_setup_sweep)
 
-        app.save_project()
-
         self._button("start_button").grid()
 
         cast(Any, self._widgets["tabs"]).hide(self._widgets["extraction_tab"])

--- a/src/ansys/aedt/core/extensions/hfss/fresnel.py
+++ b/src/ansys/aedt/core/extensions/hfss/fresnel.py
@@ -1002,8 +1002,6 @@ class FresnelExtension(ExtensionHFSSCommon):
         # Solve
         app.analyze_setup(cores=cores, num_variations_to_distribute=tasks, name=active_parametric)
 
-        app.save_project()
-
         is_valid = self._validate(self.active_setup_sweep)
 
         if is_valid:
@@ -1037,6 +1035,10 @@ class FresnelExtension(ExtensionHFSSCommon):
         )
 
         settings.enable_desktop_logs = enable_log
+
+        # Project can only be saved when the extension is going to be released
+        app.save_project()
+
         self.release_desktop()
 
         self.root.destroy()

--- a/src/ansys/aedt/core/extensions/hfss/fresnel.py
+++ b/src/ansys/aedt/core/extensions/hfss/fresnel.py
@@ -1036,9 +1036,6 @@ class FresnelExtension(ExtensionHFSSCommon):
 
         settings.enable_desktop_logs = enable_log
 
-        # Project can only be saved when the extension is going to be released
-        app.save_project()
-
         self.release_desktop()
 
         self.root.destroy()


### PR DESCRIPTION
## Description
Avoid lockfile when double clicking "Apply and validate" button

<!--
Trailers must be placed at the end of the description, separated from the
rest of the text by a blank line. Available trailers for automatic labeling:

  Application: hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical, twin-builder, hfss3dlayout
               (comma-separated values allowed)
  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
                (comma-separated values allowed)
  Platform: windows, linux, rocky
            (comma-separated values allowed)
  Deprecation: <scope>
  Breaking-Change: <scope>

Examples:
  Application: hfss, maxwell
  AEDT-Version: 25.2, 26.1
  Platform: windows, linux
  Breaking-Change: removed MyClass
-->

## Issue linked
No issue

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
