### PR TITLE
FEAT: Create export_image method

### DIFF
--- a/doc/changelog.d/8007.added.md
+++ b/doc/changelog.d/8007.added.md
@@ -1,0 +1,1 @@
+Create export_image method

--- a/src/ansys/aedt/core/modeler/modeler_3d.py
+++ b/src/ansys/aedt/core/modeler/modeler_3d.py
@@ -74,6 +74,128 @@ class Modeler3D(Primitives3D, PyAedtBase):
         return self
 
     @pyaedt_function_handler()
+    def export_image(
+        self,
+        output_file: str | Path,
+        width: int = 0,
+        height: int = 0,
+        show_axis: bool = True,
+        show_grid: bool = True,
+        show_ruler: bool = True,
+        show_region: str = "Default",
+        selections: str | list[str] | None = None,
+        auto_fit: bool = True,
+        orientation: str = "",
+        show_orientation_gadget: bool = False,
+        background_type: str = "Default",
+    ) -> str:
+        """Export a 3D model image with detailed display settings.
+
+        Parameters
+        ----------
+        output_file : str or :class:`pathlib.Path`
+            Full path and name for the exported image file.
+        width : int, optional
+            Image width in pixels. The default is ``0``, which uses the
+            desktop width.
+        height : int, optional
+            Image height in pixels. The default is ``0``, which uses the
+            desktop height.
+        show_axis : bool, optional
+            Whether to display the axis triad. The default is ``True``.
+        show_grid : bool, optional
+            Whether to display the grid. The default is ``True``.
+        show_ruler : bool, optional
+            Whether to display the ruler. The default is ``True``.
+        show_region : str, optional
+            Region visibility setting. The default is ``"Default"``.
+        selections : str or list of str, optional
+            Model objects to include in the image. The default is
+            ``None``.
+        auto_fit : bool, optional
+            Whether to automatically fit the model in the image. The
+            default is ``True``.
+        orientation : str, optional
+            View orientation or a custom orientation name. The default is
+            an empty string.
+        show_orientation_gadget : bool, optional
+            Whether to display the orientation gadget. The default is
+            ``False``.
+        background_type : str, optional
+            Background type. Options are ``"Default"``, ``"Plain"``,
+            ``"LinearGradient"``, and ``"RadialGradient"``. The default is
+            ``"Default"``.
+
+        Returns
+        -------
+        str
+            Full path to the exported image file.
+
+        References
+        ----------
+        >>> oEditor.ExportModelImageToFile
+
+        Examples
+        --------
+        >>> from ansys.aedt.core import Hfss
+        >>> app = Hfss(non_graphical=False)
+        >>> image = app.modeler.export_image("C:/temp/model.png", width=1920, height=1080)
+
+        """
+        if selections:
+            selections = self.convert_to_selections(selections, False)
+        else:
+            selections = ""
+
+        arg = [
+            "NAME:SaveImageParams",
+            "ShowAxis:=",
+            str(show_axis),
+            "ShowGrid:=",
+            str(show_grid),
+            "ShowRuler:=",
+            str(show_ruler),
+            "ShowRegion:=",
+            show_region,
+            "Selections:=",
+            selections,
+            "AutoFit:=",
+            str(auto_fit),
+            "Orientation:=",
+            orientation,
+            "ShowOrientationGadget:=",
+            str(show_orientation_gadget),
+            "BackgroundType:=",
+            background_type,
+            [
+                "NAME:BackgroundColor",
+                "R:=",
+                -1,
+                "G:=",
+                -1,
+                "B:=",
+                -1,
+            ],
+            [
+                "NAME:BackgroundContrastColor",
+                "R:=",
+                -1,
+                "G:=",
+                -1,
+                "B:=",
+                -1,
+            ],
+        ]
+        output_file = str(output_file)
+        self.oeditor.ExportModelImageToFile(
+            output_file,
+            width,
+            height,
+            arg,
+        )
+        return output_file
+
+    @pyaedt_function_handler()
     def create_3dcomponent(
         self,
         input_file: str,

--- a/tests/system/general/test_3d_modeler.py
+++ b/tests/system/general/test_3d_modeler.py
@@ -1203,6 +1203,25 @@ def test_copy_solid_bodies_udm(hfss_app, add_app) -> None:
     dest.copy_solid_bodies_from(hfss_app)
 
 
+def test_export_image(aedt_app, test_tmp_dir) -> None:
+    """Test exporting a 3D model image."""
+    aedt_app.modeler.create_box([0, 0, 0], [10, 10, 10], name="image_export_box")
+    output_file = test_tmp_dir / "model.png"
+
+    image_path = aedt_app.modeler.export_image(
+        output_file,
+        width=1920,
+        height=1080,
+        show_grid=False,
+        orientation="top",
+        show_orientation_gadget=True,
+        background_type="Plain",
+    )
+
+    assert image_path == str(output_file)
+    assert output_file.is_file()
+
+
 def test_create_conical_rings(aedt_app) -> None:
     position = aedt_app.modeler.Position(0, 0, 0)
     rings1 = aedt_app.modeler.create_conical_rings("Z", position, 20, 10, 20, 1)


### PR DESCRIPTION
## Description
Implemented method to export the modeler view as an image with more quality than `export_design_preview_to_jpg` method. This is something required to improve PyAEDT MCP capabilities to analyze images with vision LLMs

<!--
Trailers must be placed at the end of the description, separated from the
rest of the text by a blank line. Available trailers for automatic labeling:

  Application: hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical, twin-builder, hfss3dlayout
               (comma-separated values allowed)
  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
                (comma-separated values allowed)
  Platform: windows, linux, rocky
            (comma-separated values allowed)
  Deprecation: <scope>
  Breaking-Change: <scope>

Examples:
  Application: hfss, maxwell
  AEDT-Version: 25.2, 26.1
  Platform: windows, linux
  Breaking-Change: removed MyClass
-->

## Issue linked
No issue

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
