### PR TITLE
FIX: emit threading issues

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -142,3 +142,10 @@
 - name: release-maintenance
   description: Related to maintenance of the release branch
   color: f78c37
+
+# Used by CI workflows to skip the "Wait for master cache update" step.
+# Add this label to a pull request when you want to avoid waiting for the
+# testmon cache update during CI runs.
+- name: skip-testmon
+  description: Skip the testmon cache wait step in CI
+  color: 9e9e9e

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -439,6 +439,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -510,6 +511,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -577,6 +579,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -651,6 +654,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -718,6 +722,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -793,6 +798,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -855,6 +861,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -926,6 +933,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -990,6 +998,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -1059,6 +1068,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache
@@ -1345,6 +1355,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
 #      - name: Restore testmondata cache
@@ -1413,6 +1424,7 @@ jobs:
           uv sync --frozen --group tests --extra all
 
       - name: Wait for master cache update
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-testmon') }}
         uses: ./.github/actions/check-cache
 
       - name: Restore testmondata cache

--- a/doc/changelog.d/8033.fixed.md
+++ b/doc/changelog.d/8033.fixed.md
@@ -1,0 +1,1 @@
+Emit threading issues

--- a/src/ansys/aedt/core/emit.py
+++ b/src/ansys/aedt/core/emit.py
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import time
 import warnings
 
 from ansys.aedt.core import emit_core
@@ -181,6 +182,10 @@ class Emit(Design, PyAedtBase):
             """''Result'' object for the selected design."""
 
             self.__emit_api_enabled = True
+
+        # Throttle delay (ms) between consecutive engine.run() calls.
+        # Non-zero for AEDT <= 26.1 to avoid overwhelming the iemit gRPC server.
+        self._engine_throttle_ms = 50 if self._aedt_version <= "2026.1" else 0
 
     def _init_from_design(self, *args, **kwargs) -> None:
         self.__init__(*args, **kwargs)
@@ -394,4 +399,28 @@ class Emit(Design, PyAedtBase):
 
         result = Design.save_project(self, file_name, overwrite, refresh_ids)
 
+        return result
+
+    def close_project(self, name: str = None, save: bool = True) -> bool:
+        """Close an AEDT project with a quiesce barrier for EMIT.
+
+        On AEDT <= 26.1, adds a brief delay after closing to allow the iemit
+        subprocess event pipeline to fully drain before a subsequent InsertDesign.
+        This prevents the DesignInstanceBase assertion crash that causes hangs.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the project. The default is ``None``.
+        save : bool, optional
+            Whether to save the project before closing. The default is ``True``.
+
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+        """
+        result = Design.close_project(self, name, save)
+        if self._aedt_version <= "2026.1":
+            time.sleep(1.0)
         return result

--- a/src/ansys/aedt/core/emit_core/results/revision.py
+++ b/src/ansys/aedt/core/emit_core/results/revision.py
@@ -24,6 +24,7 @@
 
 from __future__ import annotations
 
+import time
 import warnings
 
 from ansys.aedt.core.emit_core.emit_constants import EmiCategoryFilter
@@ -248,10 +249,72 @@ class Revision:
                     "and will not be included in the EMIT analysis: " + ", ".join(disconnected_radios)
                 )
                 warnings.warn(err_msg)
-        interaction = engine.run(domain)
+
+        max_retries = 3
+        backoff_ms = 200
+        for attempt in range(max_retries):
+            try:
+                interaction = engine.run(domain)
+                break
+            except Exception as e:
+                err_str = str(e).lower()
+                is_transient = "unavailable" in err_str or "deadline" in err_str or "timeout" in err_str
+                if is_transient and attempt < max_retries - 1:
+                    time.sleep(backoff_ms / 1000.0)
+                    backoff_ms *= 2
+                else:
+                    raise
         # save the project and revision
         self.emit_project.save_project()
         return interaction
+
+    def _run_no_save(self, domain: object) -> object:
+        """Run the engine without saving afterward (for use in batch loops).
+
+        This avoids the save_project() call that triggers change notifications
+        back to AEDT, preventing concurrent gRPC access during tight iteration
+        loops in protection_level_classification / interference_type_classification.
+        """
+        if domain.receiver_channel_frequency > 0:
+            raise ValueError("The domain must not have channels specified.")
+        if len(domain.interferer_channel_frequencies) != 0:
+            for freq in domain.interferer_channel_frequencies:
+                if freq > 0:
+                    raise ValueError("The domain must not have channels specified.")
+        self._load_revision()
+        engine = self.emit_project._emit_api.get_engine()
+        if self.emit_project._aedt_version < "2024.1":
+            if len(domain.interferer_names) == 1:
+                engine.max_simultaneous_interferers = 1
+            if len(domain.interferer_names) > 1:
+                raise ValueError("Multiple interferers cannot be specified prior to AEDT version 2024 R1.")
+        if self.emit_project._aedt_version > "2025.1":
+            disconnected_radios = self._get_disconnected_radios()
+            if len(disconnected_radios) > 0:
+                err_msg = (
+                    "Some radios are part of a system with unconnected ports or errors "
+                    "and will not be included in the EMIT analysis: " + ", ".join(disconnected_radios)
+                )
+                warnings.warn(err_msg)
+
+        throttle_ms = getattr(self.emit_project, "_engine_throttle_ms", 0)
+        if throttle_ms > 0:
+            time.sleep(throttle_ms / 1000.0)
+
+        max_retries = 3
+        backoff_ms = 200
+        for attempt in range(max_retries):
+            try:
+                interaction = engine.run(domain)
+                return interaction
+            except Exception as e:
+                err_str = str(e).lower()
+                is_transient = "unavailable" in err_str or "deadline" in err_str or "timeout" in err_str
+                if is_transient and attempt < max_retries - 1:
+                    time.sleep(backoff_ms / 1000.0)
+                    backoff_ms *= 2
+                else:
+                    raise
 
     @pyaedt_function_handler()
     def is_domain_valid(self, domain: object) -> bool:
@@ -712,7 +775,7 @@ class Revision:
                         tx_band: Band
                         domain.set_receiver(rx_radio.name, rx_band.name)
                         domain.set_interferer(tx_radio.name, tx_band.name)
-                        interaction = self.run(domain)
+                        interaction = self._run_no_save(domain)
                         # check for valid interaction, this would catch any disabled radio pairs
                         if not interaction.is_valid():
                             continue
@@ -776,6 +839,7 @@ class Revision:
             all_colors.append(rx_colors)
             power_matrix.append(rx_powers)
 
+        self.emit_project.save_project()
         return all_colors, power_matrix
 
     @pyaedt_function_handler()
@@ -881,7 +945,7 @@ class Revision:
                     rx_freq = self.get_active_frequencies(rx_radio.name, rx_band_name, mode_rx)[0]
                     domain.set_receiver(rx_radio.name, rx_band_name)
                     domain.set_interferer(tx_radio.name, tx_band_name)
-                    interaction = self.run(domain)
+                    interaction = self._run_no_save(domain)
                     # check for valid interaction, this would catch any disabled radio pairs
                     if not interaction.is_valid():
                         continue
@@ -944,6 +1008,7 @@ class Revision:
             all_colors.append(rx_colors)
             power_matrix.append(rx_powers)
 
+        self.emit_project.save_project()
         return all_colors, power_matrix
 
     def get_emi_category_filter_enabled(self, category: EmiCategoryFilter) -> bool:


### PR DESCRIPTION

## Description
Add a run_no_save method to use for batch runs, add a delay when closing emit projects to allow for iemit process to be closed before inserting new designs.

emit, 26.1

## Issue linked
Hopefully helps with some threading issues that are plaguing the tests.

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
