### PR TITLE
DOCS: Add pyaedt-dev Copilot plugin and branch naming rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,64 @@ Skills are organized as plugins under `.github/plugin/`. Always **read the skill
 | Skill | Skill file | Purpose |
 |---|---|---|
 | `pyaedt-cli` | `.github/plugin/pyaedt-cli/skills/SKILL.md` | Interact with AEDT via the `pyaedt` CLI |
+| `pyaedt-code-placement` | `.github/plugin/pyaedt-dev/skills/pyaedt-code-placement/SKILL.md` | Decide where new PyAEDT code belongs and reuse existing code |
+| `pyaedt-docstrings` | `.github/plugin/pyaedt-dev/skills/pyaedt-docstrings/SKILL.md` | Write PyAnsys-style numpydoc docstrings and PEP 8 compliant code |
+| `pyaedt-testing` | `.github/plugin/pyaedt-dev/skills/pyaedt-testing/SKILL.md` | Add or update tests for PyAEDT code |
+| `pyaedt-refactor` | `.github/plugin/pyaedt-dev/skills/pyaedt-refactor/SKILL.md` | Modify, clean up, or deprecate existing PyAEDT code |
+| `pyaedt-branch-naming` | `.github/plugin/pyaedt-dev/skills/pyaedt-branch-naming/SKILL.md` | Name and create Git branches per the PyAnsys ruleset |
+| `pyaedt-contribution` | `.github/plugin/pyaedt-dev/skills/pyaedt-contribution/SKILL.md` | Run quality checks, write changelog fragments, and open pull requests |
+
+---
+
+## Branch naming (MANDATORY, always applies)
+
+**Whenever you are asked to create, rename, or check out a new branch, the branch name MUST match
+the PyAnsys [branch naming ruleset](https://dev.docs.pyansys.com/_downloads/7510e6c963aea4a6bc7ca8a9798cb721/branch_naming.json),
+which is enforced as an active repository rule with no bypass actors.**
+
+```text
+^(feat|fix|chore|docs|style|refactor|test|testing|perf|ci|no-ci|build|dependabot|release|maint|junk)/.+
+```
+
+Allowed prefixes: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `test`, `testing`, `perf`,
+`ci`, `no-ci`, `build`, `dependabot`, `release`, `maint`, `junk`.
+
+Rules:
+
+- Always prefix the branch, then a single `/`, then a lowercase hyphen-separated description,
+  prefixed by the issue number when one exists, for example `feat/8034-twisted-pair-cable`.
+- Never create an unprefixed branch such as `8034-my-fix`, and never use `feature/`, `FEAT/`, or
+  `feat-`.
+- If the user does not give a conforming name, derive the prefix from the nature of the change,
+  state the name you chose, and use it. Do not silently invent a non-conforming name.
+- Never create, force-push, or delete `main`, `gh-pages`, or `pre-commit-ci-update-config`. The
+  ruleset also blocks deletions and non-fast-forward pushes on all other branches.
+
+Read `.github/plugin/pyaedt-dev/skills/pyaedt-branch-naming/SKILL.md` for prefix selection guidance,
+validation commands, and examples.
+
+---
+
+## pyaedt-dev (MANDATORY)
+
+**Read the relevant skill files whenever you write or modify PyAEDT Python code:**
+
+- Adding a new class, method, function, or static asset → `pyaedt-code-placement`
+- Writing or fixing docstrings, type hints, imports, or formatting → `pyaedt-docstrings`
+- Adding or updating tests → `pyaedt-testing`
+- Changing, cleaning up, or deprecating existing code → `pyaedt-refactor`
+- Creating, renaming, or checking out a branch → `pyaedt-branch-naming`
+- Committing, opening a pull request, or running quality checks → `pyaedt-contribution`
+
+Core rules enforced by these skills:
+
+- Prefer reusing existing code over writing new code.
+- Place code in the package matching its function; never restructure the repository unless the user
+  explicitly asks.
+- Document everything following the
+  [PyAnsys documentation style reference](https://dev.docs.pyansys.com/doc-style/index.html).
+- Cover new functionality with a test, preferring updates to existing tests.
+- Improving poorly written or poorly documented code requires explicit user approval first.
 
 ---
 

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -37,6 +37,45 @@
             "skills": [
                 "./skills/pyaedt-cli"
             ]
+        },
+        {
+            "name": "pyaedt-dev",
+            "source": ".github/plugin/pyaedt-dev",
+            "description": "PyAEDT development skills for writing, documenting, testing, and maintaining PyAEDT Python code.",
+            "version": "1.0.dev0",
+            "author": {
+                "name": "PyAnsys"
+            },
+            "homepage": "https://github.com/ansys/pyaedt",
+            "repository": "https://github.com/ansys/pyaedt",
+            "keywords": [
+                "AEDT",
+                "PyAnsys",
+                "claude",
+                "copilot",
+                "PyAEDT",
+                "development",
+                "numpydoc",
+                "testing"
+            ],
+            "category": "development",
+            "tags": [
+                "AEDT",
+                "claude-code",
+                "copilot",
+                "contributing",
+                "documentation",
+                "PyAEDT",
+                "testing"
+            ],
+            "skills": [
+                "./skills/pyaedt-code-placement",
+                "./skills/pyaedt-docstrings",
+                "./skills/pyaedt-testing",
+                "./skills/pyaedt-refactor",
+                "./skills/pyaedt-branch-naming",
+                "./skills/pyaedt-contribution"
+            ]
         }
     ]
 }

--- a/.github/plugin/pyaedt-dev/README.md
+++ b/.github/plugin/pyaedt-dev/README.md
@@ -1,0 +1,46 @@
+# PyAEDT Dev
+
+Plugin that helps AI coding agents develop and maintain the PyAEDT Python codebase.
+
+Use `pyaedt-cli` when you want to *drive* Ansys Electronics Desktop (AEDT). Use `pyaedt-dev` when
+you want to *change the PyAEDT source code itself*.
+
+## What it does
+
+- **Code placement**: decides which package a new class, method, or asset belongs in, and enforces
+  code reuse before new code is written
+- **Documentation and style**: numpydoc docstrings following the
+  [PyAnsys documentation style reference](https://dev.docs.pyansys.com/doc-style/index.html), plus
+  the PEP 8 and ruff rules configured in `pyproject.toml`
+- **Testing**: requires coverage for every new behavior and prefers extending existing tests
+- **Refactoring**: improves poorly written or poorly documented code, but only with explicit user
+  approval, and keeps the public API backward compatible
+- **Branch naming**: enforces the PyAnsys branch naming ruleset on every new branch
+- **Contribution workflow**: towncrier changelog fragments, conventional-commit pull request titles,
+  and the pre-commit quality gate
+
+## Skills
+
+| Skill | Use when |
+|---|---|
+| `pyaedt-code-placement` | Deciding where new code, data, or assets belong in `src/ansys/aedt/core` |
+| `pyaedt-docstrings` | Writing or reviewing docstrings, type hints, imports, or formatting |
+| `pyaedt-testing` | Adding or updating tests for new or changed behavior |
+| `pyaedt-refactor` | Modifying, cleaning up, or deprecating existing PyAEDT code |
+| `pyaedt-branch-naming` | Creating, renaming, or checking out a Git branch |
+| `pyaedt-contribution` | Committing, opening a pull request, or running quality checks |
+
+## Requirements
+
+Install the development dependency groups from the repository root:
+
+```bash
+uv sync --group dev
+```
+
+## Links
+
+- [PyAEDT documentation](https://aedt.docs.pyansys.com/)
+- [PyAnsys developer's guide](https://dev.docs.pyansys.com/)
+- [PyAnsys documentation style reference](https://dev.docs.pyansys.com/doc-style/index.html)
+- [GitHub repository](https://github.com/ansys/pyaedt)

--- a/.github/plugin/pyaedt-dev/skills/pyaedt-branch-naming/SKILL.md
+++ b/.github/plugin/pyaedt-dev/skills/pyaedt-branch-naming/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: pyaedt-branch-naming
+description: Use whenever a Git branch is about to be created, renamed, or pushed in the PyAEDT repository. Triggers on requests to create a new branch, start work on an issue or feature, check out a new branch, rename a branch, or choose a branch name. Enforces the PyAnsys branch naming ruleset.
+---
+
+# PyAEDT branch naming skill
+
+The PyAEDT repository enforces the PyAnsys
+[branch naming ruleset](https://dev.docs.pyansys.com/_downloads/7510e6c963aea4a6bc7ca8a9798cb721/branch_naming.json)
+as an **active** GitHub repository rule with no bypass actors. A push to a non-conforming branch is
+rejected by the server, so the name must be correct at creation time.
+
+A copy of the ruleset is stored next to this skill in `branch_naming.json` for reference.
+
+## Hard rule
+
+**Never create a branch without a valid prefix.** Before running `git branch`, `git checkout -b`,
+`git switch -c`, or `gh pr create` on a new branch, the name must match:
+
+```text
+^(feat|fix|chore|docs|style|refactor|test|testing|perf|ci|no-ci|build|dependabot|release|maint|junk)/.*
+```
+
+That is: an allowed prefix, a single forward slash, then a non-empty descriptive name.
+
+If the user asks for a branch and does not supply a conforming name, do **not** invent an arbitrary
+name and do not fall back to the plain issue number. Derive the prefix from the nature of the work
+using the table below, propose the full name, and use it.
+
+## Allowed prefixes
+
+| Prefix | Use for |
+|---|---|
+| `feat` | New user-facing functionality. |
+| `fix` | Bug fixes. |
+| `chore` | Routine repository upkeep that is not a feature or a fix. |
+| `docs` | Documentation only, including docstrings and `doc/`. |
+| `style` | Formatting and cosmetic changes with no behavior change. |
+| `refactor` | Restructuring existing code without changing behavior. |
+| `test` / `testing` | Adding or updating tests. |
+| `perf` | Performance improvements. |
+| `ci` | Continuous integration and workflow changes. |
+| `no-ci` | Changes that must not trigger continuous integration. |
+| `build` | Build system, packaging, or `pyproject.toml` changes. |
+| `dependabot` | Automated dependency updates. |
+| `release` | Release preparation branches. |
+| `maint` | Maintenance work. |
+| `junk` | Throwaway experiments that will never be merged. |
+
+Pick the prefix that matches the dominant purpose of the change, and keep it consistent with the
+conventional-commit type used for the pull request title (see the `pyaedt-contribution` skill):
+a `feat/...` branch carries `FEAT:` commits, a `fix/...` branch carries `FIX:` commits.
+
+## Naming the rest of the branch
+
+After the slash, use a short, lowercase, hyphen-separated description. Include the issue number
+first when one exists.
+
+```text
+feat/8034-twisted-pair-cable-creation
+fix/7988-box-unit-handling
+docs/8034-pyaedt-dev-plugin
+test/7991-extend-general-methods-coverage
+ci/pin-ruff-version
+```
+
+Guidance:
+
+- Keep it under roughly 60 characters.
+- Use hyphens, not underscores or spaces.
+- Use lowercase; do not uppercase the prefix (`FEAT/...` does not match the pattern).
+- Describe the change, not the author or the date.
+
+## Excluded and protected branches
+
+These refs are exempt from the pattern and must never be created, force-pushed, or deleted by you:
+
+- `main`
+- `gh-pages`
+- `pre-commit-ci-update-config`
+
+The ruleset also blocks branch **deletion** and **non-fast-forward** pushes. Never run
+`git push --force`, `git push --force-with-lease`, or `git push --delete` against the remote unless
+the user explicitly asks and understands the rule will reject it.
+
+## Procedure
+
+1. Determine the purpose of the work and map it to a prefix from the table.
+2. Look up the related issue or pull request number, if any.
+3. Compose `"<prefix>/<number>-<short-description>"`.
+4. Validate it before using it:
+
+   ```bash
+   python -c "import re, sys; pattern = r'^(feat|fix|chore|docs|style|refactor|test|testing|perf|ci|no-ci|build|dependabot|release|maint|junk)/.+$'; print('OK' if re.match(pattern, sys.argv[1]) else 'INVALID')" feat/8034-my-change
+   ```
+
+5. Create the branch from an up-to-date `main`:
+
+   ```bash
+   git switch main
+   git pull --ff-only
+   git switch -c feat/8034-twisted-pair-cable-creation
+   ```
+
+6. If a branch with a non-conforming name already exists locally and has not been pushed, rename it
+   rather than pushing it:
+
+   ```bash
+   git branch -m feat/8034-twisted-pair-cable-creation
+   ```
+
+## Anti-patterns
+
+- `8034-twisted-pair-cable` — no prefix; rejected.
+- `feature/twisted-pair` — `feature` is not an allowed prefix; use `feat`.
+- `FEAT/twisted-pair` — the pattern is case sensitive.
+- `feat-twisted-pair` — the separator must be a forward slash.
+- `feat/` — the description after the slash must not be empty.
+- `/my-change` — the ruleset regex contains an empty alternative that technically permits a leading
+  slash. Never use it; it defeats the purpose of the convention.

--- a/.github/plugin/pyaedt-dev/skills/pyaedt-branch-naming/branch_naming.json
+++ b/.github/plugin/pyaedt-dev/skills/pyaedt-branch-naming/branch_naming.json
@@ -1,0 +1,37 @@
+{
+  "id": 2680634,
+  "name": "Branch naming",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [
+        "refs/heads/pre-commit-ci-update-config",
+        "refs/heads/main",
+        "refs/heads/gh-pages"
+      ],
+      "include": [
+        "~ALL"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "branch_name_pattern",
+      "parameters": {
+        "operator": "regex",
+        "pattern": "^(feat|fix|chore|docs|style|refactor|test|testing|perf|ci|no-ci|build|dependabot|release|maint|junk|)\\/.*",
+        "negate": false,
+        "name": ""
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/plugin/pyaedt-dev/skills/pyaedt-code-placement/SKILL.md
+++ b/.github/plugin/pyaedt-dev/skills/pyaedt-code-placement/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: pyaedt-code-placement
+description: Use when adding new classes, methods, functions, or static assets to the PyAEDT source tree, or when deciding which module or package a change belongs in. Triggers on requests to implement a new PyAEDT feature, add a utility, add a geometry operation, add a configuration schema, or wrap a native AEDT API call.
+---
+
+# PyAEDT code placement skill
+
+New code must land in the package that matches its function and must match the existing structure of
+`src/ansys/aedt/core`. Never reorganize the repository layout unless the user explicitly asks for it.
+
+## Rule 0: reuse before you create
+
+Creating new code is the last resort. Before writing anything:
+
+1. Search for an existing implementation. Prefer symbol and code search over guessing.
+
+   ```bash
+   grep -rn "def <candidate_name>" src/ansys/aedt/core
+   grep -rn "<domain keyword>" src/ansys/aedt/core --include=*.py
+   ```
+
+2. If a function does most of what is needed, extend it (new optional keyword argument with a
+   backward-compatible default) instead of writing a near-duplicate.
+3. If two candidate helpers already exist, use the one in the most general package and do not add a
+   third.
+4. Only if nothing suitable exists, add new code, in the smallest possible unit, in the package
+   chosen with the map below.
+
+If reuse requires changing existing code, follow the `pyaedt-refactor` skill: propose the change and
+get user approval first.
+
+## Placement map
+
+| Location | What belongs there |
+|---|---|
+| `src/ansys/aedt/core/application` | Application setup, settings, design and solution workflow. Anything that configures an AEDT application object or drives the solve process. |
+| `src/ansys/aedt/core/generic` | General-purpose utilities with no AEDT-specific behavior: file system helpers, math and number utilities, data handlers, settings and logging infrastructure. |
+| `src/ansys/aedt/core/misc` | Static data only: JSON schemas, general configuration files, and other static settings consumed by PyAEDT. No business logic. |
+| `src/ansys/aedt/core/internal` | Low-level functions that simplify the interface to the native AEDT API, plus internal checks and guards. Thin wrappers, not user-facing workflows. |
+| `src/ansys/aedt/core/modeler` | Geometric operations and any command that modifies or manipulates the geometry of an AEDT model. |
+| `src/ansys/aedt/core/modeler/cad` | Classes and methods for geometric operations: primitives, objects, components, coordinate systems. |
+| `src/ansys/aedt/core/modeler/advanced_cad` | Advanced, application-specific geometry creation, such as twisted-pair cables or other geometrically complex model builders. |
+
+Other existing packages, listed so that you use them instead of inventing new locations:
+
+| Location | What belongs there |
+|---|---|
+| `src/ansys/aedt/core/cli` | The `pyaedt` command-line interface. |
+| `src/ansys/aedt/core/modules` | Solution setups, boundaries, materials, mesh, and post-processing modules. |
+| `src/ansys/aedt/core/visualization` | Plotting, reports, and post-processing visualization. |
+| `src/ansys/aedt/core/extensions` | AEDT toolkit extensions and their installers. |
+| `src/ansys/aedt/core/emit_core` | EMIT-specific logic. |
+| `src/ansys/aedt/core/filtersolutions_core` | Filter Solutions logic. |
+| `src/ansys/aedt/core/rpc` | Remote procedure call server and client. |
+| `src/ansys/aedt/core/examples` | Example downloaders and sample data helpers. |
+| `src/ansys/aedt/core/syslib` | Shipped binary/system libraries. Do not add Python logic here. |
+
+## Decision procedure
+
+Ask these questions in order and stop at the first match:
+
+1. Is it static data (schema, JSON, configuration file)? → `misc`
+2. Is it a thin wrapper over a native AEDT API call? → `internal`
+3. Does it create or modify model geometry?
+   - Complex, application-specific builder → `modeler/advanced_cad`
+   - General geometric operation or CAD entity → `modeler/cad`
+   - Other modeler-level operation → `modeler`
+4. Does it configure the application, its settings, or the solution process? → `application`
+5. Is it solution setup, boundary, material, mesh, or post-processing data? → `modules`
+6. Is it plotting or reporting? → `visualization`
+7. Is it AEDT-agnostic? → `generic`
+
+If none of these fit, ask the user rather than creating a new top-level package.
+
+## Pre-write checklist
+
+Before adding code, confirm all of the following:
+
+- [ ] An equivalent helper does not already exist (Rule 0 search was run).
+- [ ] The owning package was selected with the decision procedure above.
+- [ ] The target module already groups related behavior; a new module is created only when no
+      existing module is a reasonable home.
+- [ ] Public API surface is intentional: if the symbol is meant to be public, it is exported from
+      the appropriate `__init__.py` and documented under `doc/source/API`.
+- [ ] Imports follow the repository isort configuration (see the `pyaedt-docstrings` skill).
+- [ ] The new behavior is documented and tested (see `pyaedt-docstrings` and `pyaedt-testing`).
+
+## Anti-patterns
+
+- Adding a `utils.py`, `helpers.py`, or `common.py` module next to the caller instead of using
+  `generic`.
+- Putting AEDT-specific logic in `generic`, or AEDT-agnostic math in `application`.
+- Putting Python logic in `misc`, which is reserved for static data.
+- Duplicating a modeler operation in an application class because the modeler API was not searched.
+- Moving or renaming existing modules to "clean things up" without an explicit user request.

--- a/.github/plugin/pyaedt-dev/skills/pyaedt-contribution/SKILL.md
+++ b/.github/plugin/pyaedt-dev/skills/pyaedt-contribution/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: pyaedt-contribution
+description: Use when preparing a PyAEDT change for review. Triggers on requests to commit, open or update a pull request, write a changelog fragment, name a branch or pull request, or run the PyAEDT quality checks and pre-commit hooks.
+---
+
+# PyAEDT contribution workflow skill
+
+Follow the [PyAnsys contributing guide](https://dev.docs.pyansys.com/how-to/contributing.html) plus
+the PyAEDT specifics below.
+
+## 1. Quality gate
+
+Run the full hook set before committing. The repository pins `prek` in the `quality` dependency
+group; `pre-commit` works as a drop-in alternative.
+
+```bash
+prek run --all-files
+```
+
+Hooks that must pass:
+
+| Hook | Purpose |
+|---|---|
+| `ruff-check` | Lint (`D`, `E`, `F`, `I`, `N`, `PTH`, `TD`, `W`, `UP006`, `UP007`, `UP045`). |
+| `ruff-format` | Formatting, 120 columns, double quotes. |
+| `codespell` | Spelling, using `doc/styles/config/vocabularies/ANSYS/accept.txt`. |
+| `debug-statements` | No leftover debugger or debug statements. |
+| `trailing-whitespace` | No trailing whitespace. |
+| `check-github-workflows` | Workflow files validate against the schema. |
+| `blacken-docs` | Code blocks in documentation are formatted. |
+| `add-license-headers` | MIT header on `src`, `tests`, `doc`, `examples` Python files. |
+| `ty` | Static type checking. |
+
+Then run the targeted tests for the change (see the `pyaedt-testing` skill).
+
+## 2. Changelog fragment
+
+Every user-visible change needs a towncrier fragment in `doc/changelog.d`, named
+`<pull-request-number>.<type>.md`, for example `7983.added.md`.
+
+Valid types, from `[tool.towncrier]` in `pyproject.toml`:
+
+`breaking`, `added`, `fixed`, `documentation`, `dependencies`, `maintenance`, `miscellaneous`, `test`
+
+The file contains a single short sentence describing the change from the user's point of view:
+
+```text
+Add support for creating twisted-pair cables in the advanced CAD modeler.
+```
+
+If the pull request number is not known yet, tell the user to rename the fragment once the pull
+request is opened.
+
+## 3. Branch and commit
+
+- Work on a feature branch; never commit to `main`.
+- The branch name must satisfy the PyAnsys branch naming ruleset, which is enforced as an active
+  repository rule: `<prefix>/<description>` where `<prefix>` is one of `feat`, `fix`, `chore`,
+  `docs`, `style`, `refactor`, `test`, `testing`, `perf`, `ci`, `no-ci`, `build`, `dependabot`,
+  `release`, `maint`, or `junk`. See the `pyaedt-branch-naming` skill for details.
+
+  ```bash
+  git switch main
+  git pull --ff-only
+  git switch -c feat/8034-twisted-pair-cable-creation
+  ```
+
+- Commit messages follow conventional commits with an **upper-case** type, matching the pull request
+  title requirement and the branch prefix, for example:
+
+  ```text
+  FEAT: Add twisted-pair cable creation to advanced CAD
+  FIX: Correct unit handling in Modeler.create_box
+  DOCS: Clarify Hfss setup docstrings
+  MAINT: Update ruff configuration
+  TEST: Extend unit coverage for general methods
+  ```
+
+- Never commit secrets, AEDT project binaries, or generated artifacts.
+
+## 4. Pull request
+
+- Title uses the same conventional-commit format with an upper-case type. This is checked in CI.
+- Fill in `.github/pull_request_template.md`.
+- Describe what changed, why, and how it was verified.
+- Confirm in the description that documentation and tests were added or updated.
+
+## Pre-submit checklist
+
+- [ ] Code is placed per the `pyaedt-code-placement` skill and reuses existing helpers.
+- [ ] Docstrings follow the PyAnsys style and pass numpydoc validation.
+- [ ] New or changed behavior is covered by tests, preferring updates to existing tests.
+- [ ] `prek run --all-files` passes.
+- [ ] Targeted `pytest` selector passes.
+- [ ] A `doc/changelog.d/<pr>.<type>.md` fragment exists.
+- [ ] The branch name matches the PyAnsys branch naming ruleset (`<prefix>/<description>`).
+- [ ] Commit messages and the pull request title use the upper-case conventional-commit format.

--- a/.github/plugin/pyaedt-dev/skills/pyaedt-docstrings/SKILL.md
+++ b/.github/plugin/pyaedt-dev/skills/pyaedt-docstrings/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: pyaedt-docstrings
+description: Use when writing, reviewing, or fixing docstrings, type hints, imports, or formatting in the PyAEDT source tree. Triggers on requests to document a PyAEDT function or class, follow the PyAnsys documentation style, satisfy numpydoc validation, fix ruff or pydocstyle findings, or add a new public API entry to the documentation.
+---
+
+# PyAEDT documentation and style skill
+
+All PyAEDT code must be documented with numpydoc docstrings that follow the
+[PyAnsys documentation style reference](https://dev.docs.pyansys.com/doc-style/index.html), and must
+satisfy PEP 8 as enforced by ruff. The style is consistent with NumPy, SciPy, and pandas.
+
+Everything below reflects the configuration that already exists in `pyproject.toml` and
+`.pre-commit-config.yaml`. Do not invent additional style rules.
+
+## Docstring rules
+
+Write a docstring for every public module, class, method, function, and property you add or change.
+
+Required shape:
+
+- One-line summary, starting with a capital letter, ending with a period, written in the
+  **infinitive** ("Return the...", not "Returns the...").
+- Blank line, then an optional extended summary.
+- `Parameters`, `Returns`, `Raises`, `References`, `Examples` sections, in that order, only when
+  they apply.
+- Every parameter documented with `name : type` (space before the colon) and, for optional
+  arguments, `, optional` plus the default stated in the description as ``` ``value`` ```.
+- Return descriptions start with a capital letter and end with a period.
+- Cross-reference AEDT API calls in a `References` section when the method wraps one.
+
+Template:
+
+```python
+@pyaedt_function_handler()
+def create_box(self, origin, sizes, name=None, material="vacuum"):
+    """Create a box.
+
+    Parameters
+    ----------
+    origin : list of float
+        Anchor point of the box in ``[x, y, z]`` coordinates.
+    sizes : list of float
+        Length of the box edges in ``[dx, dy, dz]``.
+    name : str, optional
+        Name of the box. The default is ``None``, in which case a
+        name is automatically assigned.
+    material : str, optional
+        Material to assign to the box. The default is ``"vacuum"``.
+
+    Returns
+    -------
+    :class:`ansys.aedt.core.modeler.cad.object_3d.Object3d`
+        3D object.
+
+    Raises
+    ------
+    AEDTRuntimeError
+        If the box cannot be created.
+
+    References
+    ----------
+    >>> oEditor.CreateBox
+
+    Examples
+    --------
+    >>> from ansys.aedt.core import Hfss
+    >>> hfss = Hfss()
+    >>> box = hfss.modeler.create_box([0, 0, 0], [10, 10, 5], name="my_box")
+    """
+```
+
+## numpydoc validation checks that are enforced
+
+`[tool.numpydoc_validation]` in `pyproject.toml` enables these checks. Satisfy all of them:
+
+| Check | Requirement |
+|---|---|
+| `GL06` | No unknown sections. |
+| `GL07` | Sections in the canonical order. |
+| `GL08` | The object has a docstring. |
+| `GL09` | Deprecation warning precedes the extended summary. |
+| `GL10` | reST directives are followed by two colons. |
+| `RT04` | Return description starts with a capital letter. |
+| `RT05` | Return description ends with a period. |
+| `SS01` | A summary is present. |
+| `SS02` | Summary starts with a capital letter. |
+| `SS03` | Summary ends with a period. |
+| `SS04` | Summary has no leading whitespace. |
+| `SS05` | Summary starts with an infinitive verb, not third person. |
+| `PR10` | A space precedes the colon between parameter name and type. |
+
+## Coding style
+
+Enforced by ruff (`ruff check`, `ruff format`):
+
+- Line length: **120**.
+- Quote style: **double**. Indentation: spaces. Docstring code is formatted.
+- Selected rule sets: `D` (pydocstyle, numpy convention), `E`/`W` (pycodestyle), `F` (pyflakes),
+  `I` (isort), `N` (pep8-naming), `PTH` (use `pathlib`), `TD` (todos), and `UP006`, `UP007`, `UP045`.
+- Prefer `pathlib.Path` over the `os.path` functions that are not in the ignore list; new code
+  should use `pathlib` throughout.
+- Use modern typing: `list[str]` instead of `List[str]`, `str | None` instead of `Optional[str]`.
+  Add `from __future__ import annotations` at the top of new modules that use these forms on
+  Python 3.10.
+- Naming: `snake_case` for functions and variables, `PascalCase` for classes, leading underscore for
+  private helpers.
+- Do not leave `print` or debug statements; the `debug-statements` pre-commit hook fails on them.
+- `TODO` comments must include an author and a link, otherwise `TD002`/`TD003` fail.
+
+## Import ordering
+
+isort is configured with `force-sort-within-sections = true` and `force-single-line = true`, with
+first-party packages `doc`, `src/ansys/aedt/core`, and `tests`. One import per line, alphabetically
+sorted within each section:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+import warnings
+
+import numpy as np
+
+from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
+from ansys.aedt.core.internal.errors import AEDTRuntimeError
+```
+
+Never write `from module import a, b`. Never reorder imports by hand; run `ruff format` and
+`ruff check --fix`.
+
+## License header
+
+Every new `.py` file under `src`, `tests`, `doc`, or `examples` needs the MIT header applied by the
+`add-license-headers` pre-commit hook (start year 2021). Run the hook rather than typing the header
+manually:
+
+```bash
+prek run add-license-headers --all-files
+```
+
+## Documenting the public API
+
+If you add a public class, method, or function, also update the reStructuredText files under
+`doc/source/API` so the symbol appears in the rendered documentation. If you add user-facing
+behavior, check whether `doc/source/User_guide` needs an update too.
+
+## Verification
+
+Run before declaring the work done:
+
+```bash
+ruff format .
+ruff check .
+ty check
+```

--- a/.github/plugin/pyaedt-dev/skills/pyaedt-refactor/SKILL.md
+++ b/.github/plugin/pyaedt-dev/skills/pyaedt-refactor/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: pyaedt-refactor
+description: Use when modifying, cleaning up, deprecating, or removing existing PyAEDT code. Triggers on requests to refactor a PyAEDT module, improve poorly written or undocumented code, rename or change a public API, fix a bug in existing code, or review a change for backward compatibility.
+---
+
+# PyAEDT refactoring skill
+
+PyAEDT is a widely used public API. Changes to existing code must be surgical, backward compatible,
+and approved when they go beyond the user's request.
+
+## Approval gate for opportunistic cleanup
+
+Poorly written or poorly documented code **should** be improved, but you must get explicit user
+approval before making the change. When you spot such code:
+
+1. Stop before editing.
+2. Report: the file and symbol, what is wrong (missing docstring, dead code, duplicated logic,
+   unsafe error handling, and so on), the proposed fix, and the blast radius (callers, public API,
+   tests affected).
+3. Ask the user whether to proceed, and wait for the answer.
+4. Only then apply the change.
+
+Never bundle unapproved cleanup into a functional change. Fixes that are *directly caused by* or
+*tightly coupled to* the requested change do not need a separate approval, but say so in the summary.
+
+## Surgical diff rules
+
+- Change only what the task requires. No drive-by reformatting of untouched lines.
+- Do not reorder imports, rewrap strings, or restyle code that you are not otherwise editing;
+  `ruff format` handles formatting on the lines you touch.
+- Do not move modules, rename files, or restructure packages without an explicit user request.
+- Keep the diff readable: prefer extending an existing function over replacing it wholesale.
+- Preserve existing behavior for every currently documented input.
+
+## Public API compatibility
+
+Anything importable from `ansys.aedt.core` is public. When changing it:
+
+- **Do not** rename or remove a public function, method, property, or keyword argument outright.
+- Add new behavior through new optional keyword arguments with defaults that preserve today's
+  results.
+- Use the existing deprecation helpers instead of hand-rolled warnings:
+
+  ```python
+  from ansys.aedt.core.generic.general_methods import deprecate_argument
+  from ansys.aedt.core.generic.general_methods import pyaedt_function_handler
+
+
+  # pyaedt_function_handler maps a deprecated keyword to its replacement
+  @pyaedt_function_handler(old_name="new_name")
+  @deprecate_argument("legacy_arg", version="1.0")
+  def do_something(self, new_name=None, legacy_arg=None): ...
+  ```
+
+- Guard version-dependent behavior with `min_aedt_version` from
+  `ansys.aedt.core.internal.checks`.
+- Document deprecations in the docstring, with the deprecation note placed before the extended
+  summary (numpydoc check `GL09`).
+- Raise the PyAEDT error types from `ansys.aedt.core.internal.errors` (for example
+  `AEDTRuntimeError`) rather than bare `Exception`.
+
+## Reuse while refactoring
+
+If the refactor reveals duplicated logic, consolidate into the correct package per the
+`pyaedt-code-placement` skill (usually `generic` for AEDT-agnostic helpers, `internal` for native API
+wrappers). Consolidation that changes call sites needs the approval gate above.
+
+## Verification loop
+
+After every set of edits:
+
+```bash
+ruff format .
+ruff check .
+ty check
+pytest <the smallest selector covering the change> -q
+```
+
+Also confirm:
+
+- [ ] Existing tests that cover the changed code still pass, and were **updated rather than
+      duplicated** when behavior legitimately changed.
+- [ ] Docstrings for the changed symbols still describe reality, including `Parameters`, `Returns`,
+      and `Raises`.
+- [ ] No public symbol was removed or renamed without a deprecation path.
+- [ ] `doc/source/API` still matches the public surface.
+- [ ] A changelog fragment was added (see the `pyaedt-contribution` skill).

--- a/.github/plugin/pyaedt-dev/skills/pyaedt-testing/SKILL.md
+++ b/.github/plugin/pyaedt-dev/skills/pyaedt-testing/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: pyaedt-testing
+description: Use when adding or updating tests for PyAEDT code. Triggers on requests to test new PyAEDT functionality, choose between a unit, integration, or system test, pick a pytest marker, mock an AEDT session, or run a targeted subset of the PyAEDT test suite.
+---
+
+# PyAEDT testing skill
+
+Every new or changed behavior must be covered by a test. **Prefer modifying an applicable existing
+test over creating a new one.** A new test module is justified only when no existing module covers
+the area.
+
+## Where tests live
+
+| Path | Scope |
+|---|---|
+| `tests/unit` | Pure Python tests. No AEDT installation, no live desktop session. |
+| `tests/unit/extensions` | Unit tests for AEDT toolkit extensions. |
+| `tests/integration` | Tests that cross component boundaries but still avoid a full solve. |
+| `tests/system/general` | System tests against a live AEDT session, general features. |
+| `tests/system/layout` | Layout and 3D Layout / EDB-oriented system tests. |
+| `tests/system/solvers` | Solver-driven system tests, including `tests/system/solvers/sequential`. |
+| `tests/system/icepak` | Icepak system tests. |
+| `tests/system/visualization` | Plotting, reports, and post-processing system tests. |
+| `tests/system/extensions` | Extension system tests. |
+| `tests/system/emit` | EMIT system tests. |
+| `tests/system/filter_solutions` | Filter Solutions system tests. |
+
+Test data files belong in the `example_models` (or `resources`) folder of the owning test package.
+Do not add binary models to `tests/unit`.
+
+## Choosing the right level
+
+1. Can the behavior be exercised with plain Python objects or mocks? → **unit test**. This is the
+   default and the fastest feedback loop.
+2. Does it need several PyAEDT components wired together but no AEDT process? → **integration test**.
+3. Does it genuinely require a running AEDT session or a solve? → **system test**, in the
+   subdirectory matching the product area.
+
+Unit tests must never launch AEDT. Use `unittest.mock` / the `mock` package (already a test
+dependency) to patch the desktop, the modeler, or the native API objects.
+
+```python
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ansys.aedt.core.internal.errors import AEDTRuntimeError
+
+TARGET = "ansys.aedt.core.modeler.cad.primitives_3d.Primitives3D.oeditor"
+
+
+@patch(TARGET, new_callable=MagicMock)
+def test_create_box_invalid_sizes_raises(mock_editor, modeler):
+    with pytest.raises(AEDTRuntimeError):
+        modeler.create_box([0, 0, 0], [0, 0, 0])
+```
+
+## Markers
+
+Only these markers are registered in `pyproject.toml`. Using an unregistered marker fails the
+configuration:
+
+`unit`, `integration`, `system`, `solvers`, `general`, `visualization`, `extensions`,
+`filter_solutions`, `emit`, `avoid_ansys_load`
+
+Apply the level marker plus, where relevant, the area marker:
+
+```python
+pytestmark = [pytest.mark.unit, pytest.mark.general]
+```
+
+## What to cover
+
+For each new public function, class, or method:
+
+- The nominal path, asserting the returned value or the resulting state.
+- Each documented `Raises` entry.
+- Each meaningful branch introduced by a new optional argument.
+- Boundary conditions for numeric or geometric inputs.
+
+For a bug fix, add or extend a test that fails before the fix and passes after it.
+
+## Running tests
+
+Run the smallest command that covers the change:
+
+```bash
+# One file
+pytest tests/unit/test_general_methods.py -q
+
+# One test
+pytest tests/unit/test_general_methods.py::test_deprecate_argument -q
+
+# All unit tests
+pytest tests/unit -m unit -q
+```
+
+Do not run the system test suites unless a live AEDT installation is available and the user asked
+for it; they are slow and require licensing.
+
+## Checklist
+
+- [ ] An existing test module was checked first and extended if applicable.
+- [ ] The test level (unit / integration / system) matches the dependency on AEDT.
+- [ ] Only registered markers are used.
+- [ ] Unit tests pass without AEDT installed.
+- [ ] The targeted pytest command was actually run and passes.

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -12,11 +12,17 @@ Add the marketplace:
 copilot plugin marketplace add ansys/pyaedt
 ```
 
-Install the current plugin:
+Install the available plugins:
 
 ```bash
 copilot plugin install pyaedt-cli@pyaedt-skills
+copilot plugin install pyaedt-dev@pyaedt-skills
 ```
+
+| Plugin | Purpose |
+|---|---|
+| `pyaedt-cli` | Drive Ansys Electronics Desktop through the `pyaedt` command-line interface. |
+| `pyaedt-dev` | Develop and maintain the PyAEDT Python code base. |
 
 **Claude Code**
 
@@ -24,4 +30,8 @@ Claude uses `.claude-plugin/marketplace.json`, whose content points to `../.gith
 
 ## Maintenance
 
-When you add or update a skill, place it under `.github/plugin/<plugin-name>/skills/`. Update `.github/plugin/marketplace.json` accordingly. The referenced `.claude-plugin/marketplace.json` picks up changes automatically.
+When you add or update a skill, place it under `.github/plugin/<plugin-name>/skills/`. A plugin with a
+single skill may keep it at `skills/SKILL.md`; a plugin with several skills uses one subdirectory per
+skill, `skills/<skill-name>/SKILL.md`, and lists each path in the manifest. Update
+`.github/plugin/marketplace.json` accordingly. The referenced `.claude-plugin/marketplace.json` picks
+up changes automatically.

--- a/doc/changelog.d/8034.documentation.md
+++ b/doc/changelog.d/8034.documentation.md
@@ -1,0 +1,1 @@
+Add the `pyaedt-dev` Copilot plugin with skills covering code placement, documentation style, testing, refactoring, branch naming, and the contribution workflow, and enforce the PyAnsys branch naming ruleset in the Copilot instructions.

--- a/doc/changelog.d/8040.documentation.md
+++ b/doc/changelog.d/8040.documentation.md
@@ -1,0 +1,1 @@
+Add pyaedt-dev Copilot plugin and branch naming rules


### PR DESCRIPTION
Add a second Copilot/Claude plugin, `pyaedt-dev`, that assists with the development and maintenance of the PyAEDT Python code base. It complements the existing `pyaedt-cli` plugin, which drives AEDT rather than the source code.

The plugin provides six skills:

- `pyaedt-code-placement`: maps new code to the correct package under `src/ansys/aedt/core` and requires reuse of existing code before new code is written.
- `pyaedt-docstrings`: numpydoc docstrings following the PyAnsys documentation style reference, plus the ruff, isort, typing, and license header rules already configured in `pyproject.toml`.
- `pyaedt-testing`: requires test coverage for new behavior, prefers updating existing tests, and documents the test tree and registered pytest markers.
- `pyaedt-refactor`: requires explicit user approval before opportunistic cleanup and enforces backward compatible public API changes.
- `pyaedt-branch-naming`: enforces the PyAnsys branch naming ruleset.
- `pyaedt-contribution`: pre-commit quality gate, towncrier changelog fragments, and conventional commit titles.

Also add an always-on branch naming rule to `.github/copilot-instructions.md` so that any branch created by an AI assistant matches the PyAnsys ruleset, and register the plugin in `.github/plugin/marketplace.json`.



## Issue linked
Resolve Issue #8039
