### PR TITLE
CI: Add single job as gate keeper

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1491,3 +1491,37 @@ jobs:
           library-name: ${{ env.PACKAGE_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           use-python-cache: false
+
+  # Gate keeper aggregates critical CI jobs and fails only on failure/cancelled,
+  # so intentionally skipped jobs do not block merge while real regressions do.
+  # Whenever an important job needs to be ensured to run, it should be added to
+  # the needs list of this job.
+  gate-keeper:
+    name: Gate keeper
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [smoke-tests,
+            smoke-tests-rocky,
+            unit-tests,
+            integration-tests,
+            system-tests-solvers-windows,
+            system-tests-solvers-linux,
+            system-tests-general-windows,
+            system-tests-general-linux,
+            system-tests-visualization-windows,
+            system-tests-visualization-linux,
+            system-tests-icepak-windows,
+            system-tests-icepak-linux,
+            system-tests-layout-windows,
+            system-tests-layout-linux,
+            system-tests-extensions-windows,
+            system-tests-extensions-linux,
+            system-tests-filter-windows,
+            doc-build,
+            package]
+    steps:
+      - name: Check for failed or cancelled jobs
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A job in the CI failed or was cancelled."
+          exit 1

--- a/doc/changelog.d/8046.maintenance.md
+++ b/doc/changelog.d/8046.maintenance.md
@@ -1,0 +1,1 @@
+Add single job as gate keeper


### PR DESCRIPTION
## Description
This PR consists in adding a job acting as gate keeper in our CI to simplify maintenance and in particular to simplify our way of managing `main` branch rules. Currently we have many status checks that are required but from time to time our CI changes and we can forget to add this job as a required check. This happened recently in https://github.com/ansys/pyaedt/pull/7918 when the rocky jobs were not listed in the status check. While it wasn't an issue in that case, it could become in the future. 

If we ever need something more custom, we could have a look into https://github.com/re-actors/alls-green where we could list jobs as flaky and so on :)

>[!NOTE]
Before merging this PR, the CI's configuration must be updated to only contain a single check pass in the main branch rules.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
