### PR TITLE
CI: Prepare 27R1 by extending labels management

### DIFF
--- a/.github/actions/label-from-trailers/action.yml
+++ b/.github/actions/label-from-trailers/action.yml
@@ -7,7 +7,7 @@ description: |
   Supported trailers:
     Application:   hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical,
                    twin-builder, hfss3dlayout  (comma-separated values allowed)
-    AEDT-Version:  24.1, 24.2, 25.1, 25.2, 26.1  (comma-separated values allowed)
+    AEDT-Version:  24.1, 24.2, 25.1, 25.2, 26.1, 27.1  (comma-separated values allowed)
     Platform:      windows, linux, rocky  (comma-separated values allowed)
     Deprecation:   <scope>   -> adds label "deprecation"
     Breaking-Change: <scope> -> adds label "breaking-change"
@@ -134,7 +134,7 @@ runs:
           while IFS= read -r VER; do
             [ -z "$VER" ] && continue
             case "$VER" in
-              24.1|24.2|25.1|25.2|26.1) add_label "AEDT $VER" ;;
+              24.1|24.2|25.1|25.2|26.1,27.1) add_label "AEDT $VER" ;;
               *) echo "::warning::Unknown AEDT-Version value: '${VER}'" ;;
             esac
           done <<< "$(split_and_normalize "$LINE")"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -110,6 +110,10 @@
   description: Affects or requires AEDT 2026 R1
   color: 6d28d9
 
+- name: AEDT 27.1
+  description: Affects or requires AEDT 2027 R1
+  color: 6d28d9
+
 # Platform / OS
 
 - name: windows

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ rest of the text by a blank line. Available trailers for automatic labeling:
 
   Application: hfss, circuit, maxwell, icepak, q3d, q2d, emit, mechanical, twin-builder, hfss3dlayout
                (comma-separated values allowed)
-  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1
+  AEDT-Version: 24.1, 24.2, 25.1, 25.2, 26.1, 27.1
                 (comma-separated values allowed)
   Platform: windows, linux, rocky
             (comma-separated values allowed)
@@ -16,7 +16,7 @@ rest of the text by a blank line. Available trailers for automatic labeling:
 
 Examples:
   Application: hfss, maxwell
-  AEDT-Version: 25.2, 26.1
+  AEDT-Version: 25.2, 26.1, 27.1
   Platform: windows, linux
   Breaking-Change: removed MyClass
 -->

--- a/doc/changelog.d/8051.maintenance.md
+++ b/doc/changelog.d/8051.maintenance.md
@@ -1,0 +1,1 @@
+Prepare 27R1 by extending labels management


### PR DESCRIPTION
## Description
Update CI's label management to be work with 27R1 related changes. I just saw that neither #8047 nor #7997 did have an AEDT label associated to them. Once this PR is merged, we can manually go there and update the labels.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
