### PR TITLE
DOCS: Add MCP server banner to the documentation to promote PyAEDT MCP

### DIFF
--- a/doc/changelog.d/8061.documentation.md
+++ b/doc/changelog.d/8061.documentation.md
@@ -1,0 +1,1 @@
+Add MCP server banner to the documentation to promote PyAEDT MCP

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -323,6 +323,10 @@ html_theme_options = {
         "limit": 10,
         "ignoreLocation": True,
     },
+    "mcp_server": {
+        "url": "https://github.com/ansys/pyaedt-mcp",
+        "project_name": "PyAEDT-MCP",
+    },
 }
 
 


### PR DESCRIPTION
## Description
Leveraging a new feature provided by version v1.11.0 of the `ansys-sphinx-theme`, this PR is adding an MCP server banner to the landing page of the documentation to promote usage of the PyAEDT MCP.

To achieve this, the `mcp_server` dict is added to the `html_theme_options` in `conf.py` (as described in the documentation of the theme here: https://sphinxdocs.ansys.com/version/stable/user-guide/options.html#mcp-server).

## Issue linked
N/A

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
