### PR TITLE
CI: Revert changes from 8003

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1301,5 +1301,4 @@ jobs:
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          force-orphan: false
           use-python-cache: false

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -52,4 +52,3 @@ jobs:
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          force-orphan: false

--- a/doc/changelog.d/8063.maintenance.md
+++ b/doc/changelog.d/8063.maintenance.md
@@ -1,0 +1,1 @@
+Revert changes from 8003


### PR DESCRIPTION
## Description
Partially taking code from https://github.com/ansys/pyaedt/pull/8022 but given that the PR discussion about older version is in progress. I'm opening this PR.

Also, we really need to cleanup the PR directory as keeping orphan led us to directories not being effectively removed in `gh-pages`. See  #8062.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue(s) that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
