### PR TITLE
FIX: Add missing IBIS keyword [C Comp Model] to ibis_v7 template

### DIFF
--- a/doc/changelog.d/8083.fixed.md
+++ b/doc/changelog.d/8083.fixed.md
@@ -1,0 +1,1 @@
+Add missing IBIS keyword [C Comp Model] to ibis_v7 template

--- a/src/ansys/aedt/core/misc/ibis_v7.json
+++ b/src/ansys/aedt/core/misc/ibis_v7.json
@@ -44,6 +44,7 @@
 		"GND Clamp Reference": "",
 		"External Reference": "",
 		"C Comp Corner": "",
+		"C Comp Model": "",
 		"TTgnd": "",
 		"TTpower": "",
 		"Pulldown": "",

--- a/tests/unit/test_ibis_reader.py
+++ b/tests/unit/test_ibis_reader.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+from ansys.aedt.core.generic.ibis_reader import ibis_parsing
+
+
+@pytest.fixture(scope="module", autouse=True)
+def desktop() -> None:
+    """Override the desktop fixture to DO NOT open the Desktop when running this test class"""
+    return
+
+
+MINIMAL_IBIS = """\
+IBIS Ver : 7.0
+File Name : c_comp_model.ibs
+Component : Driver
+
+[Model]
+Comp Pin : PIN_1
+Pin Model : typ
+[Model Spec]
+| dummy
+[End Model Spec]
+
+[C Comp Model]
+C_comp_model_mode All
+File_TS ./dummy_typ.s2p ./dummy_fast.s2p
+Number_of_terminals = 1
+1 Buffer_I/O
+[End C Comp Model]
+
+[C Comp Corner]
+C_comp_pullup 0.1982pF 0.1860pF 0.2132pF
+[End C Comp Corner]
+
+[End Component]
+"""
+
+
+def test_ibis_parsing_c_comp_model(tmp_path):
+    """``[C Comp Model]`` is a valid IBIS 7.1+ child of ``[Model]`` and must not abort parsing."""
+    ibs = tmp_path / "c_comp_model.ibs"
+    ibs.write_text(MINIMAL_IBIS, encoding="utf-8")
+
+    parsed = ibis_parsing(str(ibs))
+
+    assert parsed is not False
+    models = [k for k, v in parsed.items() if isinstance(v, dict) and "model" in v]
+    assert models, "no [Model] section was parsed"
+    c_comp_model = parsed[models[0]]["c comp model"]
+    assert "C_comp_model_mode All" in c_comp_model["c comp model"]
+    # a sibling keyword of [C Comp Model] must still be collected under the same model
+    assert "c comp corner" in parsed[models[0]]


### PR DESCRIPTION
## Description

`ibis_parsing()` aborts with `Invalid IBIS Keyword : C Comp Model` (and returns `False`) on any IBIS file that uses a `[C Comp Model]` section inside `[Model]`.

`[C Comp Model]` is a valid IBIS 7.1+ keyword and a direct child of `[Model]`, sibling of `[C Comp Corner]` (see the official IBIS 7.2 keyword tree at `https://www.ibis.org/ver7.2/tree_ver7_2.txt`). It was simply missing from the `Model` branch of the keyword template `src/ansys/aedt/core/misc/ibis_v7.json`.

The fix adds the missing keyword to the template, plus a small AEDT-free unit test that parses a minimal IBIS snippet containing `[C Comp Model]`. Because the parser returns `False` instead of raising, downstream callers typically surfaced this as an unrelated `TypeError: 'bool' object is not iterable`, which is why the failure was hard to trace.

Application: circuit
AEDT-Version: 25.2, 26.1, 27.1
Platform: windows, linux

## Issue linked

Closes #8082

## Checklist

- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation. (N/A - no public API change)
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue(s) that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [ ] I have added the minimum version decorator to any new backend method implemented. (N/A - no new backend method)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
